### PR TITLE
[KED-824][KED-788] Use new JSON API in app, and calculate transitive links on the fly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,10 @@
 # CSS
 /src/**/*.css
 
-# JSON viz data (generated from logs)
+# JSON viz data
 /public/data
 /public/logs
+/public/api
 
 # dependencies
 /node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,36 +33,42 @@ Typically, small contributions to Kedro-Viz are more preferable due to an easier
 ## Your first contribution
 
 Working on your first pull request? You can learn how from these resources:
-* [First timers only](https://www.firsttimersonly.com/)
-* [How to contribute to an open source project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
+
+- [First timers only](https://www.firsttimersonly.com/)
+- [How to contribute to an open source project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
 
 ### Guidelines
-> *Note:* We only accept contributions under the [Apache 2.0](https://opensource.org/licenses/Apache-2.0) license and you should have permission to share the submitted code.
 
-*  Aim for cross-platform compatibility on Windows, macOS and Linux, and support recent versions of major browsers
-* We use [SemVer](https://semver.org/) for versioning
-* Our code is designed to be compatible with Python 3.5 onwards
-* We use [Anaconda](https://www.anaconda.com/distribution/) as a preferred virtual environment
-* We use [PEP 8 conventions](https://www.python.org/dev/peps/pep-0008/) for all Python code
-* We use [Google docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) for code comments
-* We use [PEP 484 type hints](https://www.python.org/dev/peps/pep-0484/) for all user-facing functions / class methods e.g.
+> _Note:_ We only accept contributions under the [Apache 2.0](https://opensource.org/licenses/Apache-2.0) license and you should have permission to share the submitted code.
+
+- Aim for cross-platform compatibility on Windows, macOS and Linux, and support recent versions of major browsers
+- We use [SemVer](https://semver.org/) for versioning
+- Our code is designed to be compatible with Python 3.5 onwards
+- We use [Anaconda](https://www.anaconda.com/distribution/) as a preferred virtual environment
+- We use [PEP 8 conventions](https://www.python.org/dev/peps/pep-0008/) for all Python code
+- We use [Google docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) for code comments
+- We use [PEP 484 type hints](https://www.python.org/dev/peps/pep-0484/) for all user-facing functions / class methods e.g.
+
 ```
 def count_truthy(elements: List[Any]) -> int:
     return sum(1 for elem in elements if elem)
 ```
-*  Keep UI elements fully keyboard accessible, and aim to support screen-readers where possible
-*  Maintain a high level of animation performance, and minimise page-load time
+
+- Keep UI elements fully keyboard accessible, and aim to support screen-readers where possible
+- Maintain a high level of animation performance, and minimise page-load time
 
 ### JavaScript Development
+
 First, clone this repo. Then install dependencies (`npm i`). Now you're ready to begin development.
 
 If you want to use a particular dataset, you'll first need to place it in `/public/logs/nodes.json`. Otherwise, you can serve randomly-generated data.
 
-Kedro-Viz uses an environment variable to configure the data source. You can set it when starting up the dev server, e.g. `DATA=random npm start` will serve random procedurally-generated data (refreshed on each page-load). When random data is enabled, certain other features like snapshot history are also enabled by default to help with browser testing. This is usually the most useful setting for local development.
+Kedro-Viz uses an environment variable to configure the data source. You can set it when starting up the dev server, e.g. `DATA=random npm start` will serve random procedurally-generated data (refreshed on each page-load). When random or mock data is enabled, certain other features like snapshot history are also enabled by default to help with browser testing. This is usually the most useful setting for local development.
 
 In other words, to run the app in development mode on a local server, use one of the following:
 
 - `DATA=random npm start` --> Serve randomly-generated data
+- `DATA=mock npm start` --> Serve example test data, from `/src/utils/data.mock.js`
 - `npm start` --> Serve data loaded from `/public/logs/nodes.json`
 
 This will serve the app at [localhost:4141](http://localhost:4141/), and watch files in `/src` for changes. It will also update the `/lib` directory, which contains a Babel-compiled copy of the source. This directory is exported to `npm`, and is used when importing as a React component into another application. It is updated automatically on save in case you need to test/debug it locally (e.g. with `npm link`). You can also update it manually, by running
@@ -84,10 +90,10 @@ We use a branching model that helps us keep track of branches in a logical, cons
 
 ## Plugin contribution process
 
- 1. Fork the project
- 2. Develop your contribution in a new branch and open a PR against the `develop` branch
- 3. Make sure the CI builds are green (have a look at the section [Running checks locally](#running-checks-locally) below)
- 4. Update the PR according to the reviewer's comments
+1.  Fork the project
+2.  Develop your contribution in a new branch and open a PR against the `develop` branch
+3.  Make sure the CI builds are green (have a look at the section [Running checks locally](#running-checks-locally) below)
+4.  Update the PR according to the reviewer's comments
 
 ### JavaScript application tests
 
@@ -112,6 +118,7 @@ npm run test:coverage
 See the [Create-React-App docs](https://github.com/facebook/create-react-app) for further information on JS testing.
 
 ## Python web server tests
+
 To run E2E tests you need to install the test requirements which includes `behave`, do this using the following command:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ As a JavaScript React component, the project is designed to be used in two diffe
 
 1. **Standalone application**
 
-   Run `npm run build` to generate a production build as a full-page app. The built app will be placed in the `/build` directory. Data for the chart should be placed in `/public/logs/nodes.json` because this directory is marked `gitignore`.
+   Run `npm run build` to generate a production build as a full-page app. The built app will be placed in the `/build` directory. Data for the chart should be placed in `/public/api/nodes.json` because this directory is marked `gitignore`.
 
 2. **React component**
 

--- a/src/actions/actions.test.js
+++ b/src/actions/actions.test.js
@@ -1,4 +1,4 @@
-import { mockData } from '../utils/data.mock';
+import mockData from '../utils/data.mock';
 import {
   CHANGE_ACTIVE_SNAPSHOT,
   CHANGE_VIEW,

--- a/src/components/app/app.test.js
+++ b/src/components/app/app.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import App from './index';
-import { mockData } from '../../utils/data.mock';
+import mockData from '../../utils/data.mock';
 
 describe('App', () => {
   describe('renders without crashing', () => {
@@ -30,14 +30,18 @@ describe('App', () => {
 
     it('when data prop is set on first load', () => {
       const wrapper = shallow(<App data={mockData} />);
-      expect(getSnapshotIDs(wrapper)).toHaveLength(mockData.length);
+      expect(getSnapshotIDs(wrapper)).toHaveLength(mockData.snapshots.length);
     });
 
     it('when data prop is updated', () => {
       const wrapper = shallow(<App data={mockData} />);
-      const newMockData = Object.assign([], mockData.concat(mockData[0]));
+      const newMockData = Object.assign({}, mockData, {
+        snapshots: [...mockData.snapshots, mockData.snapshots[0]]
+      });
       wrapper.setProps({ data: newMockData });
-      expect(getSnapshotIDs(wrapper)).toHaveLength(newMockData.length);
+      expect(getSnapshotIDs(wrapper)).toHaveLength(
+        newMockData.snapshots.length
+      );
     });
   });
 

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -33,7 +33,7 @@ class App extends React.Component {
    */
   dataWasUpdated(prevData, newData) {
     // Check just the schema IDs of incoming data updates
-    const dataID = snapshots =>
+    const dataID = ({ snapshots }) =>
       Array.isArray(snapshots) && snapshots.map(d => d.schema_id).join('');
 
     return dataID(prevData) !== dataID(newData);
@@ -60,14 +60,17 @@ App.propTypes = {
   allowHistoryDeletion: PropTypes.bool,
   data: PropTypes.oneOfType([
     PropTypes.string,
-    PropTypes.arrayOf(
-      PropTypes.shape({
-        created_ts: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        json_schema: PropTypes.array.isRequired,
-        schema_id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        message: PropTypes.string
-      })
-    )
+    PropTypes.shape({
+      snapshots: PropTypes.arrayOf(
+        PropTypes.shape({
+          created_ts: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+          edges: PropTypes.array.isRequired,
+          message: PropTypes.string,
+          nodes: PropTypes.array.isRequired,
+          tags: PropTypes.array
+        })
+      )
+    })
   ]),
   onDeleteSnapshot: PropTypes.func,
   showHistory: PropTypes.bool

--- a/src/components/app/load-data.js
+++ b/src/components/app/load-data.js
@@ -2,6 +2,7 @@ import { json } from 'd3-fetch';
 import config from '../../config';
 import getRandomHistory from '../../utils/random-data';
 import formatSnapshots from '../../utils/format-data';
+import mockData from '../../utils/data.mock';
 import { loadState } from '../../utils';
 
 /**
@@ -48,6 +49,8 @@ export const loadData = (data, onLoadData) => {
   switch (data) {
     case 'random':
       return formatSnapshots(getRandomHistory());
+    case 'mock':
+      return formatSnapshots(mockData);
     case 'json':
       loadJsonData().then(onLoadData);
       return formatSnapshots({ snapshots: [] });

--- a/src/components/app/load-data.js
+++ b/src/components/app/load-data.js
@@ -2,7 +2,6 @@ import { json } from 'd3-fetch';
 import config from '../../config';
 import getRandomHistory from '../../utils/random-data';
 import formatSnapshots from '../../utils/format-data';
-import mockData from '../../utils/data.mock';
 import { loadState } from '../../utils';
 
 /**

--- a/src/components/app/load-data.js
+++ b/src/components/app/load-data.js
@@ -50,7 +50,7 @@ export const loadData = (data, onLoadData) => {
       return formatSnapshots(getRandomHistory());
     case 'json':
       loadJsonData().then(onLoadData);
-      return formatSnapshots([]);
+      return formatSnapshots({ snapshots: [] });
     case null:
       throw new Error('No data was provided to App component via props');
     default:
@@ -64,10 +64,10 @@ export const loadData = (data, onLoadData) => {
 export const loadJsonData = () => {
   const { dataPath } = config();
   return json(dataPath)
-    .then(json_schema => formatSnapshots([{ json_schema }]))
     .catch(() => {
       throw new Error(
         `Unable to load pipeline data. Please check that you have placed a file at ${dataPath}`
       );
-    });
+    })
+    .then(formatSnapshots);
 };

--- a/src/components/app/load-data.js
+++ b/src/components/app/load-data.js
@@ -2,6 +2,7 @@ import { json } from 'd3-fetch';
 import config from '../../config';
 import getRandomHistory from '../../utils/random-data';
 import formatSnapshots from '../../utils/format-data';
+import mockData from '../../utils/data.mock';
 import { loadState } from '../../utils';
 
 /**

--- a/src/components/chart-ui/chart-ui.test.js
+++ b/src/components/chart-ui/chart-ui.test.js
@@ -4,7 +4,7 @@ import ChartUI, {
   mapStateToProps,
   mapDispatchToProps
 } from './index';
-import { mockState, setup } from '../../utils/data.mock';
+import { mockState, setup } from '../../utils/state.mock';
 
 describe('ChartUI', () => {
   it('renders without crashing', () => {

--- a/src/components/description/description.test.js
+++ b/src/components/description/description.test.js
@@ -1,5 +1,5 @@
 import { Description, mapStateToProps } from './index';
-import { mockState, setup } from '../../utils/data.mock';
+import { mockState, setup } from '../../utils/state.mock';
 import {
   getActiveSnapshotMessage,
   getActiveSnapshotTimestamp

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import $ from 'cheerio';
 import FlowChart, { mapStateToProps, mapDispatchToProps } from './index';
-import { mockState, setup } from '../../utils/data.mock';
+import { mockState, setup } from '../../utils/state.mock';
 import { getActiveSnapshotNodes } from '../../selectors/nodes';
 
 describe('FlowChart', () => {

--- a/src/components/flowchart/linked-nodes.js
+++ b/src/components/flowchart/linked-nodes.js
@@ -7,21 +7,21 @@ export const getLinkedNodes = (edges, nodeID) => {
   const linkedNodes = [];
 
   (function getParents(id) {
-    edges
-      .filter(d => d.target === id)
-      .forEach(d => {
+    edges.forEach(d => {
+      if (d.target === id) {
         linkedNodes.push(d.source);
         getParents(d.source);
-      });
+      }
+    });
   })(nodeID);
 
   (function getChildren(id) {
-    edges
-      .filter(d => d.source === id)
-      .forEach(d => {
+    edges.forEach(d => {
+      if (d.source === id) {
         linkedNodes.push(d.target);
         getChildren(d.target);
-      });
+      }
+    });
   })(nodeID);
 
   return linkedNodes;

--- a/src/components/flowchart/linked-nodes.test.js
+++ b/src/components/flowchart/linked-nodes.test.js
@@ -1,6 +1,6 @@
 import { getLinkedNodes } from './linked-nodes';
 import { getLayout } from '../../selectors/layout';
-import { mockState } from '../../utils/data.mock';
+import { mockState } from '../../utils/state.mock';
 
 describe('getLinkedNodes function', () => {
   it('should search through edges for ancestor and descendant nodes', () => {

--- a/src/components/history/history.test.js
+++ b/src/components/history/history.test.js
@@ -5,7 +5,7 @@ import History, {
   mapStateToProps,
   mapDispatchToProps
 } from './index';
-import { mockState, setup } from '../../utils/data.mock';
+import { mockState, setup } from '../../utils/state.mock';
 import { getSnapshotHistory } from '../../selectors';
 
 const props = {

--- a/src/components/node-list/node-list.scss
+++ b/src/components/node-list/node-list.scss
@@ -19,7 +19,7 @@
 }
 
 .pipeline-node-list-scrollbars {
-  min-height: 150px;
+  min-height: 400px;
 
   .kui-theme--light & {
     background: $color-bg-light-alt;

--- a/src/components/node-list/node-list.test.js
+++ b/src/components/node-list/node-list.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import NodeList, { mapStateToProps, mapDispatchToProps } from './index';
-import { mockState, setup } from '../../utils/data.mock';
+import { mockState, setup } from '../../utils/state.mock';
 import { getNodes } from '../../selectors/nodes';
 
 describe('NodeList', () => {

--- a/src/components/sidebar-tabs/sidebar-tabs.test.js
+++ b/src/components/sidebar-tabs/sidebar-tabs.test.js
@@ -3,7 +3,7 @@ import SidebarTabs, {
   SidebarTabs as UnconnectedSidebarTabs,
   mapStateToProps
 } from './index';
-import { mockState, setup } from '../../utils/data.mock';
+import { mockState, setup } from '../../utils/state.mock';
 
 describe('SidebarTabs', () => {
   it('renders without crashing', () => {

--- a/src/components/tag-list/tag-list.test.js
+++ b/src/components/tag-list/tag-list.test.js
@@ -4,7 +4,7 @@ import TagList, {
   mapStateToProps,
   mapDispatchToProps
 } from './index';
-import { mockState, setup } from '../../utils/data.mock';
+import { mockState, setup } from '../../utils/state.mock';
 
 describe('TagList', () => {
   it('renders without crashing', () => {

--- a/src/components/wrapper/wrapper.test.js
+++ b/src/components/wrapper/wrapper.test.js
@@ -1,5 +1,5 @@
 import { Wrapper, mapStateToProps } from './index';
-import { mockState, setup } from '../../utils/data.mock';
+import { mockState, setup } from '../../utils/state.mock';
 
 const { showHistory, theme } = mockState;
 const mockProps = { showHistory, theme };

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,7 @@
  * Generate a configuration object for use across the application
  */
 const config = () => ({
-  dataPath: './logs/nodes.json',
+  dataPath: './api/nodes.json',
   dataSource: process.env.REACT_APP_DATA_SOURCE || 'json',
   localStorageName: 'KedroViz'
 });

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,13 @@ import config from './config';
 import './styles/index.css';
 
 const { dataSource } = config();
-const useRandomData = dataSource === 'random';
+const showHistory = dataSource === 'random' || dataSource === 'mock';
 
 ReactDOM.render(
   <App
-    allowHistoryDeletion={useRandomData}
+    allowHistoryDeletion={showHistory}
     data={dataSource}
-    showHistory={useRandomData}
+    showHistory={showHistory}
   />,
   document.getElementById('root')
 );

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -80,8 +80,8 @@ function reducer(state = {}, action) {
     }
 
     case TOGGLE_PARAMETERS: {
-      const paramIDs = state.snapshotNodes[state.activeSnapshot].filter(id =>
-        state.nodeName[id].includes('param')
+      const paramIDs = state.snapshotNodes[state.activeSnapshot].filter(
+        id => state.nodeIsParam[id]
       );
       return Object.assign({}, state, {
         nodeDisabled: paramIDs.reduce(

--- a/src/reducers/reducers.test.js
+++ b/src/reducers/reducers.test.js
@@ -2,6 +2,7 @@ import mockData from '../utils/data.mock';
 import { mockState } from '../utils/state.mock';
 import reducer from './index';
 import * as action from '../actions';
+import { getActiveSnapshotNodes } from '../selectors/nodes';
 import formatData from '../utils/format-data';
 
 describe('Reducer', () => {
@@ -148,15 +149,23 @@ describe('Reducer', () => {
   });
 
   describe('TOGGLE_PARAMETERS', () => {
-    it("should disable any nodes with 'param' in their titles", () => {
-      const newState = reducer(mockState, {
-        type: action.TOGGLE_PARAMETERS,
-        parameters: false
-      });
-      expect(newState.nodeDisabled).toEqual({
-        '123456789012345/data/parameters': true,
-        '123456789012345/data/parameters_rabbit': true
-      });
+    const newState = reducer(mockState, {
+      type: action.TOGGLE_PARAMETERS,
+      parameters: false
+    });
+    const { nodeDisabled, nodeIsParam } = newState;
+    const activeSnapshotNodes = getActiveSnapshotNodes(newState);
+
+    it('should disable any nodes where is_parameters is true', () => {
+      const paramNodes = activeSnapshotNodes.filter(node => nodeIsParam[node]);
+      expect(paramNodes.every(key => nodeDisabled[key])).toBe(true);
+    });
+
+    it('should not disable any nodes where is_parameters is false', () => {
+      const nonParamNodes = activeSnapshotNodes.filter(
+        node => !nodeIsParam[node]
+      );
+      expect(nonParamNodes.every(key => !nodeDisabled[key])).toBe(true);
     });
   });
 

--- a/src/reducers/reducers.test.js
+++ b/src/reducers/reducers.test.js
@@ -1,5 +1,5 @@
-// import { toggleTagFilter } from '../actions';
-import { mockData, mockState } from '../utils/data.mock';
+import mockData from '../utils/data.mock';
+import { mockState } from '../utils/state.mock';
 import reducer from './index';
 import * as action from '../actions';
 import formatData from '../utils/format-data';
@@ -104,12 +104,12 @@ describe('Reducer', () => {
     it('should reset the snapshots', () => {
       const newState = reducer(mockState, {
         type: action.RESET_SNAPSHOT_DATA,
-        snapshots: formatData([mockData[0]])
+        snapshots: formatData({ snapshots: [mockData.snapshots[0]] })
       });
       expect(newState.snapshotIDs).toEqual([mockState.snapshotIDs[1]]);
-      expect(newState.activeSnapshot).toBe(mockData[0].schema_id);
+      expect(newState.activeSnapshot).toBe(mockData.snapshots[0].schema_id);
       expect(Object.keys(newState.snapshotNodes)).toEqual([
-        mockData[0].schema_id
+        mockData.snapshots[0].schema_id
       ]);
     });
   });
@@ -154,8 +154,8 @@ describe('Reducer', () => {
         parameters: false
       });
       expect(newState.nodeDisabled).toEqual({
-        '123456789012345/parameters-data': true,
-        '123456789012345/parameters_rabbit-data': true
+        '123456789012345/data/parameters': true,
+        '123456789012345/data/parameters_rabbit': true
       });
     });
   });

--- a/src/selectors/edges.js
+++ b/src/selectors/edges.js
@@ -88,10 +88,8 @@ export const addNewEdge = (source, target, { edgeIDs, sources, targets }) => {
  */
 export const findTransitiveEdges = (
   activeSnapshotEdges,
-  edgeSources,
-  edgeTargets,
-  nodeDisabled,
-  transitiveEdges
+  transitiveEdges,
+  { edgeSources, edgeTargets, nodeDisabled }
 ) => {
   /**
    * Recursively walk through the graph, stepping over disabled nodes,
@@ -149,13 +147,11 @@ export const getTransitiveEdges = createSelector(
     // that end in a terminus can never be transitive.
     activeSnapshotNodes.forEach(nodeID => {
       if (!nodeDisabled[nodeID]) {
-        findTransitiveEdges(
-          activeSnapshotEdges,
+        findTransitiveEdges(activeSnapshotEdges, transitiveEdges, {
           edgeSources,
           edgeTargets,
-          nodeDisabled,
-          transitiveEdges
-        )([nodeID]);
+          nodeDisabled
+        })([nodeID]);
       }
     });
     return transitiveEdges;

--- a/src/selectors/edges.js
+++ b/src/selectors/edges.js
@@ -66,7 +66,7 @@ export const getEdgeDisabled = createSelector(
 );
 
 /**
- * Create a new transitive edge fromn the first and last edge in the path
+ * Create a new transitive edge from the first and last edge in the path
  * @param {string} target Node ID for the new edge
  * @param {string} source Node ID for the new edge
  * @param {object} transitiveEdges Store of existing edges

--- a/src/selectors/edges.js
+++ b/src/selectors/edges.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { arrayToObject } from '../utils';
-import { getNodeDisabled } from './nodes';
+import { getActiveSnapshotNodes, getNodeDisabled } from './nodes';
 
 const getView = state => state.view;
 const getActiveSnapshot = state => state.activeSnapshot;
@@ -66,23 +66,127 @@ export const getEdgeDisabled = createSelector(
 );
 
 /**
- * Format edges and return them as an array
+ * Create a new transitive edge fromn the first and last edge in the path
+ * @param {string} target Node ID for the new edge
+ * @param {string} source Node ID for the new edge
+ * @param {object} transitiveEdges Store of existing edges
  */
-export const getEdges = createSelector(
-  [getActiveSnapshotEdges, getEdgeDisabled, getEdgeSources, getEdgeTargets],
-  (activeSnapshotEdges, edgeDisabled, edgeSources, edgeTargets) =>
-    activeSnapshotEdges.map(edgeID => ({
-      id: edgeID,
-      disabled: edgeDisabled[edgeID],
-      source: edgeSources[edgeID],
-      target: edgeTargets[edgeID]
-    }))
+export const addNewEdge = (source, target, { edgeIDs, sources, targets }) => {
+  const id = [source, target].join('|');
+  if (!edgeIDs.includes(id)) {
+    edgeIDs.push(id);
+    sources[id] = source;
+    targets[id] = target;
+  }
+};
+
+/**
+ * Recursively walk through the graph, stepping over disabled nodes,
+ * generating a list of nodes visited so far, and create transitive edges
+ * for each path that visits disabled nodes between enabled nodes.
+ * @param {Array} path The route that has been explored so far
+ */
+export const findTransitiveEdges = (
+  activeSnapshotEdges,
+  edgeSources,
+  edgeTargets,
+  nodeDisabled,
+  transitiveEdges
+) => {
+  /**
+   * Recursively walk through the graph, stepping over disabled nodes,
+   * generating a list of nodes visited so far, and create transitive edges
+   * for each path that visits disabled nodes between enabled nodes.
+   * @param {Array} path The route that has been explored so far
+   */
+  const edgeGraphWalker = path => {
+    activeSnapshotEdges.forEach(edgeID => {
+      const source = path[path.length - 1];
+      // Filter to only edges where the source node is the previous target
+      if (edgeSources[edgeID] !== source) {
+        return;
+      }
+      const target = edgeTargets[edgeID];
+      if (nodeDisabled[target]) {
+        // If target node is disabled then keep walking the graph
+        edgeGraphWalker(path.concat(target));
+      } else if (path.length > 1) {
+        // Else only create a new edge if there would be 3 or more nodes in the path
+        addNewEdge(path[0], target, transitiveEdges);
+      }
+    });
+  };
+
+  return edgeGraphWalker;
+};
+
+/**
+ * Create new edges to connect nodes which have a disabled node (or nodes)
+ * in between them
+ */
+export const getTransitiveEdges = createSelector(
+  [
+    getActiveSnapshotNodes,
+    getActiveSnapshotEdges,
+    getNodeDisabled,
+    getEdgeSources,
+    getEdgeTargets
+  ],
+  (
+    activeSnapshotNodes,
+    activeSnapshotEdges,
+    nodeDisabled,
+    edgeSources,
+    edgeTargets
+  ) => {
+    const transitiveEdges = {
+      edgeIDs: [],
+      sources: {},
+      targets: {}
+    };
+    // Examine the children of every enabled node. The walk only needs
+    // to be run in a single direction (i.e. top down), because links
+    // that end in a terminus can never be transitive.
+    activeSnapshotNodes.forEach(nodeID => {
+      if (!nodeDisabled[nodeID]) {
+        findTransitiveEdges(
+          activeSnapshotEdges,
+          edgeSources,
+          edgeTargets,
+          nodeDisabled,
+          transitiveEdges
+        )([nodeID]);
+      }
+    });
+    return transitiveEdges;
+  }
 );
 
 /**
- * Get only the visible edges
+ * Get only the visible edges (plus transitive edges),
+ * and return them formatted as an array of objects
  */
 export const getVisibleEdges = createSelector(
-  [getEdges],
-  edges => edges.filter(edge => !edge.disabled)
+  [
+    getActiveSnapshotEdges,
+    getEdgeDisabled,
+    getEdgeSources,
+    getEdgeTargets,
+    getTransitiveEdges
+  ],
+  (
+    activeSnapshotEdges,
+    edgeDisabled,
+    edgeSources,
+    edgeTargets,
+    transitiveEdges
+  ) =>
+    activeSnapshotEdges
+      .filter(id => !edgeDisabled[id])
+      .concat(transitiveEdges.edgeIDs)
+      .map(id => ({
+        id,
+        source: edgeSources[id] || transitiveEdges.sources[id],
+        target: edgeTargets[id] || transitiveEdges.targets[id]
+      }))
 );

--- a/src/selectors/edges.test.js
+++ b/src/selectors/edges.test.js
@@ -1,10 +1,9 @@
-import { mockState } from '../utils/data.mock';
+import { mockState } from '../utils/state.mock';
 import {
   getActiveSnapshotEdges,
   getEdgeDisabledNode,
   getEdgeDisabledView,
   getEdgeDisabled,
-  getEdges,
   getVisibleEdges
 } from './edges';
 import { getActiveSnapshotNodes } from './nodes';
@@ -188,24 +187,10 @@ describe('Selectors', () => {
     });
   });
 
-  describe('getEdges', () => {
-    it('returns formatted edges as an array', () => {
-      expect(getEdges(mockState)).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: expect.any(String),
-            source: expect.any(String),
-            target: expect.any(String),
-            disabled: expect.any(Boolean)
-          })
-        ])
-      );
-    });
-  });
-
   describe('getVisibleEdges', () => {
     it('gets only the visible edges', () => {
-      expect(getVisibleEdges(mockState).map(d => d.disabled)).toEqual(
+      const edgeDisabled = getEdgeDisabled(mockState);
+      expect(getVisibleEdges(mockState).map(d => edgeDisabled[d.id])).toEqual(
         expect.arrayContaining([false])
       );
     });

--- a/src/selectors/edges.test.js
+++ b/src/selectors/edges.test.js
@@ -198,23 +198,29 @@ describe('Selectors', () => {
       transitiveEdges.targets = {};
     });
 
-    it('Adds a new edge to the list of edge IDs', () => {
+    it('adds a new edge to the list of edge IDs', () => {
       addNewEdge('foo', 'bar', transitiveEdges);
       expect(transitiveEdges.edgeIDs).toEqual(['foo|bar']);
     });
 
-    it('Adds a new source to the sources dictionary', () => {
+    it('adds a new source to the sources dictionary', () => {
       addNewEdge('source_name', 'target', transitiveEdges);
       expect(transitiveEdges.sources).toEqual({
         'source_name|target': 'source_name'
       });
     });
 
-    it('Adds a new target to the targets dictionary', () => {
+    it('adds a new target to the targets dictionary', () => {
       addNewEdge('source', 'target name', transitiveEdges);
       expect(transitiveEdges.targets).toEqual({
         'source|target name': 'target name'
       });
+    });
+
+    it('does not add a new edge if it already exists', () => {
+      addNewEdge('foo', 'bar', transitiveEdges);
+      addNewEdge('foo', 'bar', transitiveEdges);
+      expect(transitiveEdges.edgeIDs).toEqual(['foo|bar']);
     });
   });
 

--- a/src/selectors/index.test.js
+++ b/src/selectors/index.test.js
@@ -1,4 +1,4 @@
-import { mockState } from '../utils/data.mock';
+import { mockState } from '../utils/state.mock';
 import {
   getSnapshotHistory,
   getActiveSnapshotMessage,

--- a/src/selectors/layout.test.js
+++ b/src/selectors/layout.test.js
@@ -1,4 +1,4 @@
-import { mockState } from '../utils/data.mock';
+import { mockState } from '../utils/state.mock';
 import {
   prepareTextContainer,
   getNodeWidth,
@@ -86,7 +86,6 @@ describe('Selectors', () => {
         expect.arrayContaining([
           expect.objectContaining({
             id: expect.any(String),
-            disabled: expect.any(Boolean),
             source: expect.any(String),
             target: expect.any(String),
             points: expect.arrayContaining([

--- a/src/selectors/nodes.js
+++ b/src/selectors/nodes.js
@@ -107,16 +107,22 @@ export const getNodes = createSelector(
     nodeDisabledTag,
     nodeDisabledView
   ) =>
-    activeSnapshotNodes.sort().map(id => ({
-      id,
-      name: nodeName[id],
-      type: nodeType[id],
-      active: nodeActive[id],
-      disabled: nodeDisabled[id],
-      disabled_node: Boolean(nodeDisabledNode[id]),
-      disabled_tag: nodeDisabledTag[id],
-      disabled_view: nodeDisabledView[id]
-    }))
+    activeSnapshotNodes
+      .sort((a, b) => {
+        if (nodeName[a] < nodeName[b]) return -1;
+        if (nodeName[a] > nodeName[b]) return 1;
+        return 0;
+      })
+      .map(id => ({
+        id,
+        name: nodeName[id],
+        type: nodeType[id],
+        active: nodeActive[id],
+        disabled: nodeDisabled[id],
+        disabled_node: Boolean(nodeDisabledNode[id]),
+        disabled_tag: nodeDisabledTag[id],
+        disabled_view: nodeDisabledView[id]
+      }))
 );
 
 /**

--- a/src/selectors/nodes.test.js
+++ b/src/selectors/nodes.test.js
@@ -1,4 +1,4 @@
-import { mockState } from '../utils/data.mock';
+import { mockState } from '../utils/state.mock';
 import {
   getActiveSnapshotNodes,
   getNodeDisabledTag,

--- a/src/selectors/nodes.test.js
+++ b/src/selectors/nodes.test.js
@@ -212,9 +212,14 @@ describe('Selectors', () => {
       );
     });
 
-    it('returns nodes sorted by ID', () => {
+    it('returns nodes sorted by name', () => {
+      const { nodeName } = mockState;
       const nodeIDs = getNodes(mockState).map(d => d.id);
-      const activeNodeIDs = getActiveSnapshotNodes(mockState).sort();
+      const activeNodeIDs = getActiveSnapshotNodes(mockState).sort((a, b) => {
+        if (nodeName[a] < nodeName[b]) return -1;
+        if (nodeName[a] > nodeName[b]) return 1;
+        return 0;
+      });
       expect(nodeIDs).toEqual(activeNodeIDs);
     });
   });

--- a/src/selectors/tags.test.js
+++ b/src/selectors/tags.test.js
@@ -1,4 +1,4 @@
-import { mockState } from '../utils/data.mock';
+import { mockState } from '../utils/state.mock';
 import { getActiveSnapshotTags, getTags, getTagCount } from './tags';
 import { toggleTagFilter } from '../actions';
 import reducer from '../reducers';

--- a/src/utils/data.mock.js
+++ b/src/utils/data.mock.js
@@ -68,6 +68,7 @@ export default {
         {
           tags: ['Nulla', 'pulvinar', 'enim', 'consectetur', 'volutpat'],
           id: 'task/consectetur',
+          is_parameters: false,
           type: 'task',
           full_name: 'consectetur',
           name: 'consectetur'
@@ -75,6 +76,7 @@ export default {
         {
           tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
           id: 'data/mauris',
+          is_parameters: false,
           type: 'data',
           full_name: 'mauris',
           name: 'mauris'
@@ -82,6 +84,7 @@ export default {
         {
           tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
           id: 'data/Lorem',
+          is_parameters: false,
           type: 'data',
           full_name: 'Lorem',
           name: 'Lorem'
@@ -89,6 +92,7 @@ export default {
         {
           tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
           id: 'data/dolor',
+          is_parameters: false,
           type: 'data',
           full_name: 'dolor',
           name: 'dolor'
@@ -96,6 +100,7 @@ export default {
         {
           tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
           id: 'data/eu',
+          is_parameters: false,
           type: 'data',
           full_name: 'eu',
           name: 'eu'
@@ -103,6 +108,7 @@ export default {
         {
           tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
           id: 'data/accumsan',
+          is_parameters: false,
           type: 'data',
           full_name: 'accumsan',
           name: 'accumsan'
@@ -110,6 +116,7 @@ export default {
         {
           tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
           id: 'data/ipsum',
+          is_parameters: false,
           type: 'data',
           full_name: 'ipsum',
           name: 'ipsum'
@@ -117,6 +124,7 @@ export default {
         {
           tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
           id: 'data/sit',
+          is_parameters: false,
           type: 'data',
           full_name: 'sit',
           name: 'sit'
@@ -124,6 +132,7 @@ export default {
         {
           tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
           id: 'data/Aliquam',
+          is_parameters: false,
           type: 'data',
           full_name: 'Aliquam',
           name: 'Aliquam'
@@ -131,6 +140,7 @@ export default {
         {
           tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
           id: 'data/amet',
+          is_parameters: false,
           type: 'data',
           full_name: 'amet',
           name: 'amet'
@@ -157,6 +167,7 @@ export default {
           name: 'salmon',
           full_name: 'salmon',
           tags: ['huge', 'small'],
+          is_parameters: false,
           type: 'task'
         },
         {
@@ -164,6 +175,7 @@ export default {
           name: 'shark',
           full_name: 'shark',
           tags: [],
+          is_parameters: false,
           type: 'task'
         },
         {
@@ -171,6 +183,7 @@ export default {
           name: 'trout',
           full_name: 'trout',
           tags: [],
+          is_parameters: false,
           type: 'task'
         },
         {
@@ -178,6 +191,7 @@ export default {
           name: 'whale',
           full_name: 'whale',
           tags: [],
+          is_parameters: false,
           type: 'data'
         },
         {
@@ -185,6 +199,7 @@ export default {
           name: 'dog',
           full_name: 'dog',
           tags: ['small', 'huge'],
+          is_parameters: false,
           type: 'data'
         },
         {
@@ -192,6 +207,7 @@ export default {
           name: 'cat',
           full_name: 'cat',
           tags: ['small', 'huge'],
+          is_parameters: false,
           type: 'data'
         },
         {
@@ -199,6 +215,7 @@ export default {
           name: 'parameters_rabbit',
           full_name: 'parameters_rabbit',
           tags: ['small', 'huge'],
+          is_parameters: true,
           type: 'data'
         },
         {
@@ -206,6 +223,7 @@ export default {
           name: 'parameters',
           full_name: 'parameters',
           tags: ['small', 'huge'],
+          is_parameters: true,
           type: 'data'
         },
         {
@@ -213,6 +231,7 @@ export default {
           name: 'sheep',
           full_name: 'sheep',
           tags: ['small', 'huge'],
+          is_parameters: false,
           type: 'data'
         },
         {
@@ -220,6 +239,7 @@ export default {
           name: 'horse',
           full_name: 'horse',
           tags: ['small', 'huge'],
+          is_parameters: false,
           type: 'data'
         },
         {
@@ -227,6 +247,7 @@ export default {
           name: 'weasel',
           full_name: 'weasel',
           tags: [],
+          is_parameters: false,
           type: 'data'
         },
         {
@@ -234,6 +255,7 @@ export default {
           name: 'elephant',
           full_name: 'elephant',
           tags: [],
+          is_parameters: false,
           type: 'data'
         },
         {
@@ -241,6 +263,7 @@ export default {
           name: 'bear',
           full_name: 'bear',
           tags: [],
+          is_parameters: false,
           type: 'data'
         },
         {
@@ -248,6 +271,7 @@ export default {
           name: 'giraffe',
           full_name: 'giraffe',
           tags: [],
+          is_parameters: false,
           type: 'data'
         },
         {
@@ -255,6 +279,7 @@ export default {
           name: 'pig',
           full_name: 'pig',
           tags: ['small', 'huge'],
+          is_parameters: false,
           type: 'data'
         }
       ],

--- a/src/utils/data.mock.js
+++ b/src/utils/data.mock.js
@@ -1,87 +1,329 @@
-import React from 'react';
-import { Provider } from 'react-redux';
-import { mount, shallow } from 'enzyme';
-import store from '../store';
-import { getInitialState } from '../components/app/load-data';
-import formatSnapshots from './format-data';
-
-/**
- * Example data for use in tests
- */
-export const mockData = [
-  {
-    created_ts: '1551452832000',
-    schema_id: '310750827599783',
-    message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-    json_schema: [
-      {
-        inputs: ['Lorem', 'ipsum', 'dolor', 'sit', 'amet'],
-        name: 'consectetur',
-        outputs: ['Aliquam', 'eu', 'accumsan', 'mauris'],
-        tags: ['Nulla', 'pulvinar', 'enim', 'consectetur', 'volutpat']
-      }
-    ]
-  },
-  {
-    created_ts: '9999999999999',
-    schema_id: '123456789012345',
-    message: 'List of animal names',
-    json_schema: [
-      {
-        inputs: ['cat', 'dog', 'parameters', 'parameters_rabbit'],
-        name: 'salmon',
-        outputs: ['pig', 'horse', 'sheep'],
-        tags: ['huge', 'small']
-      },
-      {
-        inputs: ['cat', 'weasel', 'elephant', 'bear'],
-        name: 'shark',
-        outputs: ['sheep', 'pig', 'giraffe']
-      },
-      {
-        inputs: ['pig'],
-        name: 'trout',
-        outputs: ['whale']
-      }
-    ]
-  }
-];
-
-/**
- * Example state object for use in tests of redux-enabled components
- */
-export const mockState = getInitialState(formatSnapshots(mockData), {
-  allowHistoryDeletion: true,
-  showHistory: true
-});
-
-// Redux store based on mock data
-export const mockStore = store(mockState);
-
-/**
- * React-Redux Provider wrapper for testing connected components
- * @param {Object} children A React component
- * @param {Object} state Redux state object for creating the store
- */
-export const MockProvider = ({ children, state = mockState }) => (
-  <Provider store={store(state)}>{children}</Provider>
-);
-
-/**
- * Set up mounted/shallow Enzyme wrappers
- */
-export const setup = {
-  /**
-   * Mount a React-Redux Provider wrapper for testing connected components
-   * @param {Object} children React component(s)
-   * @param {Object} state Redux state object for creating the store
-   */
-  mount: (children, state) =>
-    mount(<MockProvider state={state}>{children}</MockProvider>),
-  /**
-   * Render a pure React component in a shallow wrapper
-   * @param {Object} Component A React component
-   * @param {Object} props React component props
-   */
-  shallow: (Component, props = {}) => shallow(<Component {...props} />)
+export default {
+  snapshots: [
+    {
+      created_ts: '1551452832000',
+      schema_id: '310750827599783',
+      message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      tags: [
+        {
+          id: 'Nulla',
+          name: 'Nulla'
+        },
+        {
+          id: 'pulvinar',
+          name: 'pulvinar'
+        },
+        {
+          id: 'volutpat',
+          name: 'volutpat'
+        },
+        {
+          id: 'enim',
+          name: 'enim'
+        },
+        {
+          id: 'consectetur',
+          name: 'consectetur'
+        }
+      ],
+      edges: [
+        {
+          target: 'task/consectetur',
+          source: 'data/Lorem'
+        },
+        {
+          target: 'task/consectetur',
+          source: 'data/ipsum'
+        },
+        {
+          target: 'task/consectetur',
+          source: 'data/dolor'
+        },
+        {
+          target: 'task/consectetur',
+          source: 'data/sit'
+        },
+        {
+          target: 'task/consectetur',
+          source: 'data/amet'
+        },
+        {
+          target: 'data/Aliquam',
+          source: 'task/consectetur'
+        },
+        {
+          target: 'data/eu',
+          source: 'task/consectetur'
+        },
+        {
+          target: 'data/accumsan',
+          source: 'task/consectetur'
+        },
+        {
+          target: 'data/mauris',
+          source: 'task/consectetur'
+        }
+      ],
+      nodes: [
+        {
+          tags: ['Nulla', 'pulvinar', 'enim', 'consectetur', 'volutpat'],
+          id: 'task/consectetur',
+          type: 'task',
+          full_name: 'consectetur',
+          name: 'consectetur'
+        },
+        {
+          tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
+          id: 'data/mauris',
+          type: 'data',
+          full_name: 'mauris',
+          name: 'mauris'
+        },
+        {
+          tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
+          id: 'data/Lorem',
+          type: 'data',
+          full_name: 'Lorem',
+          name: 'Lorem'
+        },
+        {
+          tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
+          id: 'data/dolor',
+          type: 'data',
+          full_name: 'dolor',
+          name: 'dolor'
+        },
+        {
+          tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
+          id: 'data/eu',
+          type: 'data',
+          full_name: 'eu',
+          name: 'eu'
+        },
+        {
+          tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
+          id: 'data/accumsan',
+          type: 'data',
+          full_name: 'accumsan',
+          name: 'accumsan'
+        },
+        {
+          tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
+          id: 'data/ipsum',
+          type: 'data',
+          full_name: 'ipsum',
+          name: 'ipsum'
+        },
+        {
+          tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
+          id: 'data/sit',
+          type: 'data',
+          full_name: 'sit',
+          name: 'sit'
+        },
+        {
+          tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
+          id: 'data/Aliquam',
+          type: 'data',
+          full_name: 'Aliquam',
+          name: 'Aliquam'
+        },
+        {
+          tags: ['Nulla', 'pulvinar', 'volutpat', 'enim', 'consectetur'],
+          id: 'data/amet',
+          type: 'data',
+          full_name: 'amet',
+          name: 'amet'
+        }
+      ]
+    },
+    {
+      created_ts: '9999999999999',
+      schema_id: '123456789012345',
+      message: 'List of animal names',
+      tags: [
+        {
+          id: 'small',
+          name: 'small'
+        },
+        {
+          id: 'huge',
+          name: 'huge'
+        }
+      ],
+      nodes: [
+        {
+          id: 'task/salmon',
+          name: 'salmon',
+          full_name: 'salmon',
+          tags: ['huge', 'small'],
+          type: 'task'
+        },
+        {
+          id: 'task/shark',
+          name: 'shark',
+          full_name: 'shark',
+          tags: [],
+          type: 'task'
+        },
+        {
+          id: 'task/trout',
+          name: 'trout',
+          full_name: 'trout',
+          tags: [],
+          type: 'task'
+        },
+        {
+          id: 'data/whale',
+          name: 'whale',
+          full_name: 'whale',
+          tags: [],
+          type: 'data'
+        },
+        {
+          id: 'data/dog',
+          name: 'dog',
+          full_name: 'dog',
+          tags: ['small', 'huge'],
+          type: 'data'
+        },
+        {
+          id: 'data/cat',
+          name: 'cat',
+          full_name: 'cat',
+          tags: ['small', 'huge'],
+          type: 'data'
+        },
+        {
+          id: 'data/parameters_rabbit',
+          name: 'parameters_rabbit',
+          full_name: 'parameters_rabbit',
+          tags: ['small', 'huge'],
+          type: 'data'
+        },
+        {
+          id: 'data/parameters',
+          name: 'parameters',
+          full_name: 'parameters',
+          tags: ['small', 'huge'],
+          type: 'data'
+        },
+        {
+          id: 'data/sheep',
+          name: 'sheep',
+          full_name: 'sheep',
+          tags: ['small', 'huge'],
+          type: 'data'
+        },
+        {
+          id: 'data/horse',
+          name: 'horse',
+          full_name: 'horse',
+          tags: ['small', 'huge'],
+          type: 'data'
+        },
+        {
+          id: 'data/weasel',
+          name: 'weasel',
+          full_name: 'weasel',
+          tags: [],
+          type: 'data'
+        },
+        {
+          id: 'data/elephant',
+          name: 'elephant',
+          full_name: 'elephant',
+          tags: [],
+          type: 'data'
+        },
+        {
+          id: 'data/bear',
+          name: 'bear',
+          full_name: 'bear',
+          tags: [],
+          type: 'data'
+        },
+        {
+          id: 'data/giraffe',
+          name: 'giraffe',
+          full_name: 'giraffe',
+          tags: [],
+          type: 'data'
+        },
+        {
+          id: 'data/pig',
+          name: 'pig',
+          full_name: 'pig',
+          tags: ['small', 'huge'],
+          type: 'data'
+        }
+      ],
+      edges: [
+        {
+          target: 'task/salmon',
+          source: 'data/cat'
+        },
+        {
+          target: 'task/salmon',
+          source: 'data/dog'
+        },
+        {
+          target: 'task/salmon',
+          source: 'data/parameters'
+        },
+        {
+          target: 'task/salmon',
+          source: 'data/parameters_rabbit'
+        },
+        {
+          target: 'data/pig',
+          source: 'task/salmon'
+        },
+        {
+          target: 'data/horse',
+          source: 'task/salmon'
+        },
+        {
+          target: 'data/sheep',
+          source: 'task/salmon'
+        },
+        {
+          target: 'task/shark',
+          source: 'data/cat'
+        },
+        {
+          target: 'task/shark',
+          source: 'data/weasel'
+        },
+        {
+          target: 'task/shark',
+          source: 'data/elephant'
+        },
+        {
+          target: 'task/shark',
+          source: 'data/bear'
+        },
+        {
+          target: 'data/sheep',
+          source: 'task/shark'
+        },
+        {
+          target: 'data/pig',
+          source: 'task/shark'
+        },
+        {
+          target: 'data/giraffe',
+          source: 'task/shark'
+        },
+        {
+          target: 'task/trout',
+          source: 'data/pig'
+        },
+        {
+          target: 'data/whale',
+          source: 'task/trout'
+        }
+      ]
+    }
+  ]
 };

--- a/src/utils/format-data.js
+++ b/src/utils/format-data.js
@@ -55,6 +55,7 @@ const formatSnapshots = data => {
   const nodeName = {};
   const nodeFullName = {};
   const nodeType = {};
+  const nodeIsParam = {};
   const nodeTags = {};
   // Edges
   const edgeSources = {};
@@ -83,17 +84,20 @@ const formatSnapshots = data => {
      * @param {string} type - 'data' or 'task'
      * @param {Array} tags - List of associated tags
      */
-    const addNode = ({ name, type, tags = [], full_name, ...node }) => {
+    const addNode = node => {
       const id = getNodeID(snapshotID, node.id);
       if (nodeName[id]) {
         return;
       }
       snapshotNodes[snapshotID].push(id);
       nodeID[id] = id;
-      nodeName[id] = name;
-      nodeFullName[id] = full_name;
-      nodeType[id] = type;
-      nodeTags[id] = tags.map(tagID => getTagID(snapshotID, tagID));
+      nodeName[id] = node.name;
+      nodeFullName[id] = node.full_name;
+      nodeType[id] = node.type;
+      nodeIsParam[id] = Boolean(node.is_parameters);
+      nodeTags[id] = (node.tags || []).map(tagID =>
+        getTagID(snapshotID, tagID)
+      );
     };
 
     /**
@@ -151,6 +155,7 @@ const formatSnapshots = data => {
     nodeActive: {},
     nodeDisabled: {},
     nodeType,
+    nodeIsParam,
     nodeTags,
     edgeActive: {},
     edgeSources,

--- a/src/utils/format-data.js
+++ b/src/utils/format-data.js
@@ -69,6 +69,10 @@ const formatSnapshots = data => {
    * @return {Object} The node, edge and raw data for the chart
    */
   const formatSnapshotData = (snapshotID, rawSnapshot) => {
+    if (!validateInput(rawSnapshot)) {
+      return;
+    }
+
     snapshotNodes[snapshotID] = [];
     snapshotEdges[snapshotID] = [];
     snapshotTags[snapshotID] = [];
@@ -118,11 +122,9 @@ const formatSnapshots = data => {
     };
 
     // Begin formatting
-    if (validateInput(rawSnapshot)) {
-      rawSnapshot.nodes.forEach(addNode);
-      rawSnapshot.edges.forEach(addEdge);
-      rawSnapshot.tags.forEach(addTag);
-    }
+    rawSnapshot.nodes.forEach(addNode);
+    rawSnapshot.edges.forEach(addEdge);
+    rawSnapshot.tags.forEach(addTag);
   };
 
   data.snapshots.forEach(snapshot => {

--- a/src/utils/format-data.js
+++ b/src/utils/format-data.js
@@ -5,12 +5,7 @@
  */
 const validateInput = data => {
   const { isArray } = Array;
-  return (
-    isArray(data) &&
-    data.every(
-      d => isArray(d.inputs) && isArray(d.outputs) && typeof d.name === 'string'
-    )
-  );
+  return isArray(data.edges) && isArray(data.nodes);
 };
 
 /**
@@ -19,8 +14,7 @@ const validateInput = data => {
  * @param {string} nodeName - The original name for the node
  * @param {string} nodeType - The node's type
  */
-export const getNodeID = (snapshotID, nodeName, nodeType) =>
-  `${snapshotID}/${nodeName}-${nodeType}`;
+export const getNodeID = (snapshotID, nodeID) => `${snapshotID}/${nodeID}`;
 
 /**
  * Get unique, reproducible ID for each edge, based on its nodes
@@ -29,9 +23,7 @@ export const getNodeID = (snapshotID, nodeName, nodeType) =>
  * @param {Object} target - Name and type of the target node
  */
 export const getEdgeID = (snapshotID, source, target) =>
-  [source, target]
-    .map(node => getNodeID(snapshotID, node.name, node.type))
-    .join('|');
+  [source, target].map(nodeID => getNodeID(snapshotID, nodeID)).join('|');
 
 /**
  * Get unique, reproducible ID for each tag
@@ -46,7 +38,7 @@ export const getTagID = (snapshotID, tagID) => `${snapshotID}/${tagID}`;
  * @eturn {Object}
  */
 const formatSnapshots = data => {
-  if (!Array.isArray(data)) {
+  if (!Array.isArray(data.snapshots)) {
     return {};
   }
 
@@ -61,6 +53,7 @@ const formatSnapshots = data => {
   // Nodes
   const nodeID = {};
   const nodeName = {};
+  const nodeFullName = {};
   const nodeType = {};
   const nodeTags = {};
   // Edges
@@ -86,19 +79,17 @@ const formatSnapshots = data => {
      * @param {string} type - 'data' or 'task'
      * @param {Array} tags - List of associated tags
      */
-    const addNode = (name, type, tags = []) => {
-      const id = getNodeID(snapshotID, name, type);
+    const addNode = ({ name, type, tags = [], full_name, ...node }) => {
+      const id = getNodeID(snapshotID, node.id);
       if (nodeName[id]) {
         return;
       }
       snapshotNodes[snapshotID].push(id);
-      nodeID[id] = name;
-      nodeName[id] = name.replace(/_/g, ' ');
+      nodeID[id] = id;
+      nodeName[id] = name;
+      nodeFullName[id] = full_name;
       nodeType[id] = type;
-      if (!nodeTags[id]) {
-        nodeTags[id] = [];
-      }
-      tags.forEach(tag => addTag(tag, id));
+      nodeTags[id] = tags;
     };
 
     /**
@@ -106,163 +97,41 @@ const formatSnapshots = data => {
      * @param {Object} source - Parent node
      * @param {Object} target - Child node
      */
-    const addEdge = (source, target) => {
+    const addEdge = ({ source, target }) => {
       const id = getEdgeID(snapshotID, source, target);
       if (snapshotEdges[snapshotID].includes(id)) {
         return;
       }
       snapshotEdges[snapshotID].push(id);
-      edgeSources[id] = getNodeID(snapshotID, source.name, source.type);
-      edgeTargets[id] = getNodeID(snapshotID, target.name, target.type);
+      edgeSources[id] = getNodeID(snapshotID, source);
+      edgeTargets[id] = getNodeID(snapshotID, target);
     };
 
     /**
      * Add a new Tag if it doesn't already exist
      * @param {string} name - Default node name
      */
-    const addTag = (name, nodeID) => {
-      const id = getTagID(snapshotID, name);
-      if (!nodeTags[nodeID].includes(id)) {
-        nodeTags[nodeID].push(id);
-      }
-      if (!tagName[id]) {
-        snapshotTags[snapshotID].push(id);
-        tagName[id] = name.replace(/_/g, ' ');
-      }
-    };
-
-    /**
-     * Create data and task nodes for the inputs/outputs etc in the raw dataset
-     * @param {Object} node
-     */
-    const createNodes = node => {
-      addNode(node.name, 'task', node.tags);
-      node.inputs.forEach(name => addNode(name, 'data'));
-      node.outputs.forEach(name => addNode(name, 'data'));
-    };
-
-    /**
-     * Create links for the combined and data views
-     * @param {string} name - The task node name
-     * @param {Array} inputs - A list of data nodes that link to this task
-     * @param {Array} outputs - A list of data nodes linked to from this task
-     */
-    const createEdges = ({ name, inputs, outputs }) => {
-      inputs.forEach(source => {
-        // Create link between input data nodes and task node (for combined view)
-        addEdge({ name: source, type: 'data' }, { name: name, type: 'task' });
-
-        // Create link between input data nodes and output data nodes (for data view)
-        outputs.forEach(target => {
-          addEdge(
-            { name: source, type: 'data' },
-            { name: target, type: 'data' }
-          );
-        });
-      });
-
-      // Create link between task node and output data nodes (for combined view)
-      outputs.forEach(target => {
-        addEdge({ name: name, type: 'task' }, { name: target, type: 'data' });
-      });
-    };
-
-    /**
-     * Copy tags from task to data node, and filter duplicates
-     * @param {string} a Node ID
-     * @param {string} b Node ID
-     */
-    const copyTags = (a, b) => {
-      nodeTags[a] = nodeTags[a]
-        .concat(nodeTags[b])
-        .filter((d, i, arr) => arr.indexOf(d) === i);
-    };
-
-    /**
-     * Add list of linked nodes to each node
-     * @param {Object} edge Edge datum
-     */
-    const getLinkedNodeTags = ({ source, target }) => {
-      if (nodeType[source] === nodeType[target]) {
-        return;
-      }
-      if (nodeType[source] === 'task') {
-        copyTags(target, source);
-      } else {
-        copyTags(source, target);
-      }
-    };
-
-    /**
-     * Iterate through the raw data and create initial set formatted nodes and edges
-     */
-    const generatePreliminaryData = () => {
-      rawSnapshot.forEach(node => {
-        createNodes(node);
-        createEdges(node);
-      });
-    };
-
-    /**
-     * Get links between tagged nodes, and between task nodes
-     */
-    const generateAdditionalLinks = () => {
-      snapshotEdges[snapshotID].forEach(d => {
-        const d1 = {
-          source: edgeSources[d],
-          target: edgeTargets[d]
-        };
-        getLinkedNodeTags(d1);
-
-        // Create links between input task nodes and output task nodes (for task view)
-        if (nodeType[d1.source] === 'task') {
-          snapshotEdges[snapshotID].forEach(dd => {
-            const d2 = {
-              source: edgeSources[dd],
-              target: edgeTargets[dd]
-            };
-            if (nodeType[d2.target] === 'task' && d2.source === d1.target) {
-              addEdge(
-                { name: nodeID[d1.source], type: 'task' },
-                { name: nodeID[d2.target], type: 'task' }
-              );
-            }
-          });
-        }
-      });
-    };
-
-    /**
-     * Generate a formatted list of tags from node data
-     */
-    const generateTags = () => {
-      snapshotNodes[snapshotID].forEach(nodeID => {
-        nodeTags[nodeID].forEach(tagID => {
-          if (!snapshotTags[snapshotID]) {
-            snapshotTags[snapshotID] = [];
-          }
-          if (!snapshotTags[snapshotID].includes(tagID)) {
-            snapshotTags[snapshotID].push(tagID);
-          }
-        });
-      });
+    const addTag = tag => {
+      const id = getTagID(snapshotID, tag.id);
+      snapshotTags[snapshotID].push(id);
+      tagName[id] = tag.name;
     };
 
     // Begin formatting
     if (validateInput(rawSnapshot)) {
-      generatePreliminaryData();
-      generateAdditionalLinks();
-      generateTags();
+      rawSnapshot.nodes.forEach(addNode);
+      rawSnapshot.edges.forEach(addEdge);
+      rawSnapshot.tags.forEach(addTag);
     }
   };
 
-  data.forEach(d => {
-    const id = String(d.schema_id);
+  data.snapshots.forEach(snapshot => {
+    const id = String(snapshot.schema_id || '');
     snapshotIDs.push(id);
-    snapshotSchema[id] = d.json_schema;
-    snapshotTimestamp[id] = Number(d.created_ts);
-    snapshotMessage[id] = d.message;
-    formatSnapshotData(id, d.json_schema);
+    snapshotSchema[id] = snapshot;
+    snapshotTimestamp[id] = Number(snapshot.created_ts);
+    snapshotMessage[id] = snapshot.message;
+    formatSnapshotData(id, snapshot);
   });
 
   const snapshots = {
@@ -276,6 +145,7 @@ const formatSnapshots = data => {
     snapshotEdges,
     snapshotTags,
     nodeName,
+    nodeFullName,
     nodeActive: {},
     nodeDisabled: {},
     nodeType,

--- a/src/utils/format-data.js
+++ b/src/utils/format-data.js
@@ -89,7 +89,7 @@ const formatSnapshots = data => {
       nodeName[id] = name;
       nodeFullName[id] = full_name;
       nodeType[id] = type;
-      nodeTags[id] = tags;
+      nodeTags[id] = tags.map(tagID => getTagID(snapshotID, tagID));
     };
 
     /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -49,14 +49,6 @@ export const randomNumber = n => Math.ceil(Math.random() * n);
  */
 export const getRandom = range => range[randomIndex(range.length)];
 
-/**
- * Get a random datum from an array that matches a filter condition
- * @param {Array} array The array to select a random item from
- * @param {Function} condition Filter check
- */
-export const getRandomMatch = (array, condition) =>
-  getRandom(array.filter(condition));
-
 const LOREM_IPSUM = 'lorem ipsum dolor sit amet consectetur adipiscing elit vestibulum id turpis nunc nulla vitae diam dignissim fermentum elit sit amet viverra libero quisque condimentum pellentesque convallis sed consequat neque ac rhoncus finibus'.split(
   ' '
 );

--- a/src/utils/random-data.js
+++ b/src/utils/random-data.js
@@ -2,7 +2,7 @@ import {
   getNumberArray,
   randomIndex,
   randomNumber,
-  getRandomMatch,
+  getRandom,
   getRandomName,
   unique
 } from './index';
@@ -107,7 +107,7 @@ class Snapshot {
    */
   getConnectedNodes(condition) {
     return getNumberArray(this.CONNECTION_COUNT)
-      .map(() => getRandomMatch(this.nodes.data, condition))
+      .map(() => getRandom(this.nodes.data.filter(condition)))
       .filter(Boolean)
       .map(d => d.id)
       .filter(unique);

--- a/src/utils/random-data.js
+++ b/src/utils/random-data.js
@@ -48,13 +48,16 @@ class Snapshot {
    * @param {number} count The number of nodes to generate
    * @param {Function} getLayer A callback to create a random layer number
    * @param {number} paramFreq How often nodes should include 'parameters' in their name
+   * @param {string} type
    */
-  generateNodeList(count, getLayer, paramFreq) {
+  generateNodeList(count, getLayer, paramFreq, type) {
     return getNumberArray(count)
       .map(() => this.getRandomNodeName(paramFreq))
       .filter(unique)
       .map(id => ({
-        id,
+        id: `${type}/${id}`,
+        name: id.replace(/_/g, ' '),
+        type,
         layer: getLayer()
       }));
   }
@@ -67,12 +70,14 @@ class Snapshot {
       data: this.generateNodeList(
         DATA_NODE_COUNT,
         () => randomIndex(this.LAYER_COUNT + 1),
-        PARAMETERS_FREQUENCY
+        PARAMETERS_FREQUENCY,
+        'data'
       ),
       task: this.generateNodeList(
         TASK_NODE_COUNT,
         () => randomIndex(this.LAYER_COUNT) + 0.5,
-        0
+        0,
+        'task'
       )
     };
   }
@@ -111,12 +116,49 @@ class Snapshot {
    * Get a complete JSON schema
    */
   getSchema() {
-    return this.nodes.task.map(node => ({
-      inputs: this.getConnectedNodes(d => d.layer < node.layer),
-      name: node.id,
-      tags: this.getRandomTags(),
-      outputs: this.getConnectedNodes(d => d.layer > node.layer)
-    }));
+    let nodes = this.nodes.task
+      .concat(this.nodes.data)
+      .map(({ id, name, type }) => ({
+        id,
+        type,
+        name,
+        tags: this.getRandomTags()
+      }));
+
+    const edges = [];
+    this.nodes.task.forEach(node => {
+      this.getConnectedNodes(d => d.layer < node.layer).forEach(target => {
+        edges.push({
+          source: node.id,
+          target
+        });
+      });
+      this.getConnectedNodes(d => d.layer > node.layer).forEach(source => {
+        edges.push({
+          source,
+          target: node.id
+        });
+      });
+    });
+
+    // Remove unconnected nodes
+    nodes = nodes.filter(
+      node =>
+        edges.findIndex(
+          edge => node.id === edge.source || node.id === edge.target
+        ) !== -1
+    );
+
+    const tags = nodes
+      .reduce((tags, node) => tags.concat(node.tags), [])
+      .filter(unique)
+      .map(tag => ({ name: tag, id: tag }));
+
+    return {
+      nodes,
+      edges,
+      tags
+    };
   }
 
   /**
@@ -128,14 +170,15 @@ class Snapshot {
       schema_id: randomNumber(999999999999999),
       message: getRandomName(randomNumber(MAX_MESSAGE_WORD_LENGTH), ' '),
       created_ts: new Date().getTime() - randomNumber(MAX_TIMESTAMP_OFFSET),
-      json_schema: this.getSchema()
+      ...this.getSchema()
     };
   }
 }
 
-const generateRandomHistory = () =>
-  getNumberArray(randomNumber(MAX_SNAPSHOT_COUNT))
+const generateRandomHistory = () => ({
+  snapshots: getNumberArray(randomNumber(MAX_SNAPSHOT_COUNT))
     .map(() => new Snapshot().getDatum())
-    .sort((a, b) => b.created_ts - a.created_ts);
+    .sort((a, b) => b.created_ts - a.created_ts)
+});
 
 export default generateRandomHistory;

--- a/src/utils/random-data.js
+++ b/src/utils/random-data.js
@@ -57,6 +57,7 @@ class Snapshot {
       .map(id => ({
         id: `${type}/${id}`,
         name: id.replace(/_/g, ' '),
+        is_parameters: id.includes('param'),
         type,
         layer: getLayer()
       }));
@@ -118,12 +119,7 @@ class Snapshot {
   getSchema() {
     let nodes = this.nodes.task
       .concat(this.nodes.data)
-      .map(({ id, name, type }) => ({
-        id,
-        type,
-        name,
-        tags: this.getRandomTags()
-      }));
+      .map(node => ({ ...node, tags: this.getRandomTags() }));
 
     const edges = [];
     this.nodes.task.forEach(node => {

--- a/src/utils/state.mock.js
+++ b/src/utils/state.mock.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { mount, shallow } from 'enzyme';
+import store from '../store';
+import { getInitialState } from '../components/app/load-data';
+import formatSnapshots from './format-data';
+import mockData from './data.mock';
+
+/**
+ * Example state object for use in tests of redux-enabled components
+ */
+export const mockState = getInitialState(formatSnapshots(mockData), {
+  allowHistoryDeletion: true,
+  showHistory: true
+});
+
+// Redux store based on mock data
+export const mockStore = store(mockState);
+
+/**
+ * React-Redux Provider wrapper for testing connected components
+ * @param {Object} children A React component
+ * @param {Object} state Redux state object for creating the store
+ */
+export const MockProvider = ({ children, state = mockState }) => (
+  <Provider store={store(state)}>{children}</Provider>
+);
+
+/**
+ * Set up mounted/shallow Enzyme wrappers
+ */
+export const setup = {
+  /**
+   * Mount a React-Redux Provider wrapper for testing connected components
+   * @param {Object} children React component(s)
+   * @param {Object} state Redux state object for creating the store
+   */
+  mount: (children, state) =>
+    mount(<MockProvider state={state}>{children}</MockProvider>),
+  /**
+   * Render a pure React component in a shallow wrapper
+   * @param {Object} Component A React component
+   * @param {Object} props React component props
+   */
+  shallow: (Component, props = {}) => shallow(<Component {...props} />)
+};

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -5,7 +5,6 @@ import {
   randomIndex,
   randomNumber,
   getRandom,
-  getRandomMatch,
   getRandomName,
   unique
 } from './index';
@@ -106,20 +105,6 @@ describe('utils', () => {
     it('gets a random string from an array', () => {
       const arr = getNumberArray(20).map(String);
       expect(arr).toContain(getRandom(arr));
-    });
-  });
-
-  describe('getRandomMatch', () => {
-    it('gets a random number from an array that meets a condition', () => {
-      const arr = getNumberArray(10);
-      expect(getRandomMatch(arr, n => n === 1)).toEqual(1);
-    });
-  });
-
-  describe('getRandomMatch', () => {
-    it('gets a random number from an array that meets a condition', () => {
-      const arr = getNumberArray(10);
-      expect(getRandomMatch(arr, n => n === 1)).toEqual(1);
     });
   });
 


### PR DESCRIPTION
# Description

**This PR contains breaking changes for the API data format.** It must be merged after #2. When merged into master, we should bump the version number to v2.

## KED-824
We are moving to a new JSON data/API structure (See #2), which will allow us to add a great deal more metadata about each node, edge and tag in future. Instead of a list of task nodes, we're passing a list of snapshots, each of which will contain lists of the nodes (both task and data), edges and tags, associated with that snapshot. This is much closer to the data structure used in rendering the chart, so the data formatting required when receiving the initial data is less intense: Now instead of generating the nodes and edges from incomplete data then normalising it, all that needs to be done is to normalise the data. A lot of the calculations that were previously being handled in client-side JavaScript are now able to be handled when the data is generated, in Python.

## KED-788
I have also changed the way transitive links are generated, so that they are calculated on the fly when a chart is rendered, rather than when the initial data is formatted. Previously, they were only calculated for the node(task)/data views, and only worked to jump a single hidden node. This meant that when you manually disabled a node, the nodes on either side would be cut off from each other.

Now, when you hide a node that connects two other nodes, a new connection is formed, and you can do this for as many hidden nodes in a chain as you want, as long as there is a complete path running from the ultimate parent to the final child.

# Development notes

- There are a lot of files modified in this PR, but that's mainly because I split data.mock into data.mock and state.mock (because the mock data got really big with the API change).
- A lot of tests got updated in this PR, and I added/fixed some existing ones too.

# QA notes

- Transitive links (between the parents and children of disabled nodes) work differently now.
- I've had to update the random data generator and the way parameters work, so those should be checked too.
- I've changed the min-height of the node list on small screens to 400px, as 150px was too damn small.


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.