### PR TITLE
[KED-786] Fix zoom offset

### DIFF
--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -135,13 +135,8 @@ export class FlowChart extends Component {
    * Render chart to the DOM with D3
    */
   drawChart() {
-    const { chartSize, layout, textLabels } = this.props;
+    const { layout, textLabels } = this.props;
     const { nodes, edges } = layout;
-
-    // Update SVG dimensions
-    this.el.svg
-      .attr('width', chartSize.outerWidth)
-      .attr('height', chartSize.outerHeight);
 
     // Create selections
     this.el.edges = this.el.edgeGroup
@@ -304,6 +299,7 @@ export class FlowChart extends Component {
    * Render React elements
    */
   render() {
+    const { outerWidth, outerHeight } = this.props.chartSize;
     const {
       tooltipVisible,
       tooltipIsRight,
@@ -311,9 +307,14 @@ export class FlowChart extends Component {
       tooltipX,
       tooltipY
     } = this.state;
+
     return (
       <div className="pipeline-flowchart kedro" ref={this.containerRef}>
-        <svg className="pipeline-flowchart__graph" ref={this.svgRef}>
+        <svg
+          className="pipeline-flowchart__graph"
+          width={outerWidth}
+          height={outerHeight}
+          ref={this.svgRef}>
           <defs>
             <marker
               id="arrowhead"

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -93,8 +93,12 @@ export class FlowChart extends Component {
   }
 
   getNavOffset(width) {
-    const navWidth = width > 480 ? 300 : 0;
-    return this.props.visibleNav ? navWidth : 0;
+    const navWidth = 300; // from _variables.scss
+    const breakpointSmall = 480; // from _variables.scss
+    if (this.props.visibleNav && width > breakpointSmall) {
+      return navWidth;
+    }
+    return 0;
   }
 
   /**

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -19,6 +19,7 @@ const DURATION = 700;
 export class FlowChart extends Component {
   constructor(props) {
     super(props);
+
     this.state = {
       tooltipVisible: false,
       tooltipIsRight: false,
@@ -26,18 +27,25 @@ export class FlowChart extends Component {
       tooltipX: 0,
       tooltipY: 0
     };
+
+    this.containerRef = React.createRef();
+    this.svgRef = React.createRef();
+    this.wrapperRef = React.createRef();
+    this.edgesRef = React.createRef();
+    this.nodesRef = React.createRef();
+
     this.handleWindowResize = this.handleWindowResize.bind(this);
     this.handleNodeMouseOver = this.handleNodeMouseOver.bind(this);
     this.handleNodeMouseOut = this.handleNodeMouseOut.bind(this);
   }
 
   componentDidMount() {
-    // Select d3 elements
+    // Create D3 element selectors
     this.el = {
-      svg: select(this._svg),
-      wrapper: select(this._gWrapper),
-      edgeGroup: select(this._gEdges),
-      nodeGroup: select(this._gNodes)
+      svg: select(this.svgRef.current),
+      wrapper: select(this.wrapperRef.current),
+      edgeGroup: select(this.edgesRef.current),
+      nodeGroup: select(this.nodesRef.current)
     };
 
     this.updateChartSize();
@@ -71,7 +79,7 @@ export class FlowChart extends Component {
       top,
       width,
       height
-    } = this._container.getBoundingClientRect();
+    } = this.containerRef.current.getBoundingClientRect();
     const navOffset = this.getNavOffset(width);
     this.props.onUpdateChartSize({
       x: left,
@@ -304,10 +312,8 @@ export class FlowChart extends Component {
       tooltipY
     } = this.state;
     return (
-      <div
-        className="pipeline-flowchart kedro"
-        ref={el => (this._container = el)}>
-        <svg className="pipeline-flowchart__graph" ref={el => (this._svg = el)}>
+      <div className="pipeline-flowchart kedro" ref={this.containerRef}>
+        <svg className="pipeline-flowchart__graph" ref={this.svgRef}>
           <defs>
             <marker
               id="arrowhead"
@@ -322,15 +328,12 @@ export class FlowChart extends Component {
               <path d="M 0 0 L 10 5 L 0 10 L 4 5 z" />
             </marker>
           </defs>
-          <g ref={el => (this._gWrapper = el)}>
-            <g
-              className="pipeline-flowchart__edges"
-              ref={el => (this._gEdges = el)}
-            />
+          <g ref={this.wrapperRef}>
+            <g className="pipeline-flowchart__edges" ref={this.edgesRef} />
             <g
               id="nodes"
               className="pipeline-flowchart__nodes"
-              ref={el => (this._gNodes = el)}
+              ref={this.nodesRef}
             />
           </g>
         </svg>

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -35,7 +35,6 @@ export class FlowChart extends Component {
     // Select d3 elements
     this.el = {
       svg: select(this._svg),
-      inner: select(this._gInner),
       wrapper: select(this._gWrapper),
       edgeGroup: select(this._gEdges),
       nodeGroup: select(this._gNodes)
@@ -102,7 +101,7 @@ export class FlowChart extends Component {
    */
   initZoomBehaviour() {
     this.zoomBehaviour = zoom().on('zoom', () => {
-      this.el.inner.attr('transform', event.transform);
+      this.el.wrapper.attr('transform', event.transform);
       this.hideTooltip();
     });
     this.el.svg.call(this.zoomBehaviour);
@@ -112,13 +111,15 @@ export class FlowChart extends Component {
    * Zoom and scale to fit
    */
   zoomChart() {
-    const { scale, translateX, translateY } = this.props.zoom;
+    const { chartSize, zoom } = this.props;
+    const { scale, translateX, translateY } = zoom;
+    const navOffset = this.getNavOffset(chartSize.outerWidth);
     this.el.svg
       .transition()
       .duration(DURATION)
       .call(
         this.zoomBehaviour.transform,
-        zoomIdentity.translate(translateX, translateY).scale(scale)
+        zoomIdentity.translate(translateX + navOffset, translateY).scale(scale)
       );
   }
 
@@ -128,18 +129,11 @@ export class FlowChart extends Component {
   drawChart() {
     const { chartSize, layout, textLabels } = this.props;
     const { nodes, edges } = layout;
-    const navOffset = this.getNavOffset(chartSize.outerWidth);
 
     // Update SVG dimensions
     this.el.svg
       .attr('width', chartSize.outerWidth)
       .attr('height', chartSize.outerHeight);
-
-    // Animate the wrapper translation when nav is toggled
-    this.el.wrapper
-      .transition('wrapper-navoffset')
-      .duration(DURATION)
-      .attr('transform', () => `translate(${navOffset}, 0)`);
 
     // Create selections
     this.el.edges = this.el.edgeGroup
@@ -329,17 +323,15 @@ export class FlowChart extends Component {
             </marker>
           </defs>
           <g ref={el => (this._gWrapper = el)}>
-            <g ref={el => (this._gInner = el)}>
-              <g
-                className="pipeline-flowchart__edges"
-                ref={el => (this._gEdges = el)}
-              />
-              <g
-                id="nodes"
-                className="pipeline-flowchart__nodes"
-                ref={el => (this._gNodes = el)}
-              />
-            </g>
+            <g
+              className="pipeline-flowchart__edges"
+              ref={el => (this._gEdges = el)}
+            />
+            <g
+              id="nodes"
+              className="pipeline-flowchart__nodes"
+              ref={el => (this._gNodes = el)}
+            />
           </g>
         </svg>
         <div


### PR DESCRIPTION
## Description
Previously, when nav sidebar was open, zooming the chart would kind of skew the viewport to the left. This change fixes this, and also helpfully removes an extra animation element, so performance will hopefully be improved, if anything.

## Development notes
I've also improved React ref usage on the Flowchart component:
- Improve naming (remove underscores etc, as these are not a widely-recognised naming pattern).
- Use React.createRef instead of callback refs.

## QA notes
Check zoom when nav is both open and closed. Check different screen sizes, and hover on tooltips.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR


## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.