### PR TITLE
Redo Flask caching

### DIFF
--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -33,20 +33,21 @@ from collections import defaultdict
 from pathlib import Path
 
 import click
-from flask import Flask, jsonify
+from flask import Flask, jsonify, send_from_directory
 from kedro.cli import get_project_context
 
 app = Flask(  # pylint: disable=invalid-name
-    __name__,
-    static_folder=str(Path(__file__).parent.absolute() / "html"),
-    static_url_path="",
+    __name__, static_folder=str(Path(__file__).parent.absolute() / "html" / "static")
 )
 
 
 @app.route("/")
-def root():
-    """Serve the index file."""
-    return app.send_static_file("index.html")
+@app.route("/<path:subpath>")
+def root(subpath="index.html"):
+    """Serve the non static html and js etc"""
+    return send_from_directory(
+        str(Path(__file__).parent.absolute() / "html"), subpath, cache_timeout=0
+    )
 
 
 @app.route("/logs/nodes.json")


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Flask was treating all of the JS build artifacts as "static" and applying default cache forever headers.
I've changed it so only the static directory gets this treatment and all other file fetches are sent with max_age=0

## How has this been tested?
What testing strategies have you used?

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
