### PR TITLE
Remove old API

### DIFF
--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -98,10 +98,10 @@ def _check_service_up(context):
     Args:
         context (behave.runner.Context): Test context
     """
-    data_json = json.loads(download_url("http://localhost:4141/logs/nodes.json"))
+    data_json = json.loads(download_url("http://localhost:4141/api/nodes.json"))
 
     try:
         assert context.result.poll() is None
-        assert "example_iris_data" in data_json[2]["inputs"]
+        assert data_json["snapshots"][0]["nodes"][0]["name"] == "Predict"
     finally:
         context.result.terminate()

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -50,23 +50,6 @@ def root(subpath="index.html"):
     )
 
 
-@app.route("/logs/nodes.json")
-def nodes_deprecated():
-    """Serve the pipeline data."""
-    pipeline = get_project_context("create_pipeline")()
-    return jsonify(
-        [
-            {
-                "name": n.name,
-                "inputs": [ds.split("@")[0] for ds in n.inputs],
-                "outputs": [ds.split("@")[0] for ds in n.outputs],
-                "tags": list(n.tags),
-            }
-            for n in sorted(pipeline.nodes)
-        ]
-    )
-
-
 @app.route("/api/nodes.json")
 def nodes_json():
     """Serve the pipeline data."""
@@ -84,7 +67,7 @@ def nodes_json():
     all_tags = set()
 
     for node in sorted(pipeline.nodes):
-        task_id = "task/" + node.name
+        task_id = "task/" + node.name.replace(" ", "")
         nodes.append(
             {
                 "type": "task",

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -37,37 +37,21 @@ from kedro.pipeline import Pipeline, node
 
 from kedro_viz import server
 
-EXPECTED_PIPELINE_DATA_DEPRECATED = [
-    {
-        "name": "func([bob_in,parameters]) -> [bob_out]",
-        "inputs": ["bob_in", "parameters"],
-        "outputs": ["bob_out"],
-        "tags": [],
-    },
-    {
-        "name": "my_node",
-        "inputs": ["fred_in", "parameters"],
-        "outputs": ["fred_out"],
-        "tags": ["bob"],
-    },
-]
-
-
 EXPECTED_PIPELINE_DATA = {
     "snapshots": [
         {
             "edges": [
                 {
-                    "target": "task/func([bob_in,parameters]) -> [bob_out]",
+                    "target": "task/func([bob_in,parameters])->[bob_out]",
                     "source": "data/bob_in",
                 },
                 {
-                    "target": "task/func([bob_in,parameters]) -> [bob_out]",
+                    "target": "task/func([bob_in,parameters])->[bob_out]",
                     "source": "data/parameters",
                 },
                 {
                     "target": "data/bob_out",
-                    "source": "task/func([bob_in,parameters]) -> [bob_out]",
+                    "source": "task/func([bob_in,parameters])->[bob_out]",
                 },
                 {"target": "task/my_node", "source": "data/fred_in"},
                 {"target": "task/my_node", "source": "data/parameters"},
@@ -77,7 +61,7 @@ EXPECTED_PIPELINE_DATA = {
                 {
                     "name": "Func",
                     "type": "task",
-                    "id": "task/func([bob_in,parameters]) -> [bob_out]",
+                    "id": "task/func([bob_in,parameters])->[bob_out]",
                     "full_name": "func([bob_in,parameters]) -> [bob_out]",
                     "tags": [],
                 },
@@ -206,22 +190,11 @@ def test_no_browser(cli_runner):
     assert server.webbrowser.open_new.called
 
 
-# Test endpoints
-
-
 def test_root_endpoint(client):
     """Test `/` endoint is functional"""
     response = client.get("/")
     assert response.status_code == 200
     assert "Kedro Viz" in response.data.decode()
-
-
-def test_deprecated_nodes_endpoint(client):
-    """Test `/log/nodes.json` endoint is functional and returns a valid JSON"""
-    response = client.get("/logs/nodes.json")
-    assert response.status_code == 200
-    data = json.loads(response.data.decode())
-    assert data == EXPECTED_PIPELINE_DATA_DEPRECATED
 
 
 def test_nodes_endpoint(client):


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context

This API shouldn't be needed now that the JS is using the new API

## How has this been tested?
What testing strategies have you used?

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
