### PR TITLE
Fix path animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4267,6 +4267,14 @@
         "d3-color": "1"
       }
     },
+    "d3-interpolate-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate-path/-/d3-interpolate-path-2.1.0.tgz",
+      "integrity": "sha512-x5+CbxMnGTgPq+HSzcQNZbiJAjhNvEied2P0rETfGN4V4VpBR+b84ust2HUgHzdrpfwbXtR396v3z/FwWplSfA==",
+      "requires": {
+        "d3-interpolate": "^1.1.1"
+      }
+    },
     "d3-path": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "d3-shape": "^1.3.5",
     "d3-transition": "^1.2.0",
     "d3-zoom": "^1.7.3",
+    "d3-interpolate-path": "^2.1.0",
     "dagre": "^0.8.4",
     "react": "^16.8.6",
     "react-custom-scrollbars": "^4.2.1",

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import 'd3-transition';
+import { interpolatePath } from 'd3-interpolate-path';
 import { select, event } from 'd3-selection';
 import { curveBasis, line } from 'd3-shape';
 import { zoom, zoomIdentity } from 'd3-zoom';
@@ -184,7 +185,11 @@ export class FlowChart extends Component {
       .select('path')
       .transition('update-edges')
       .duration(DURATION)
-      .attr('d', edge => edge.points && lineShape(edge.points));
+      .attrTween('d', function(edge) {
+        const current = edge.points && lineShape(edge.points);
+        const previous = select(this).attr('d') || current;
+        return interpolatePath(previous, current);
+      });
 
     // Create nodes
     const enterNodes = this.el.nodes


### PR DESCRIPTION
## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Animation of SVG path changes where the before and after paths have different lengths is not very smooth. So we use the d3-interpolate-path plugin to normalize the lengths before animating.

https://bocoup.com/blog/improving-d3-path-animation

## How has this been tested?
What testing strategies have you used?

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
