### PR TITLE
Pin pip version to be less than 19.2

### DIFF
--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -81,7 +81,7 @@ def before_all(context):
     # install this plugin by resolving the requirements using pip-compile
     # from pip-tools due to this bug in pip: https://github.com/pypa/pip/issues/988
     #
-    # pip<19.2 can be unpinned when 19.3 is released.
+    # pip<19.2 can be unpinned when pip-tools>3.9.0 is released.
     call([context.python, "-m", "pip", "install", "-U", "pip<19.2", "pip-tools"])
     pip_compile = str(bin_dir / "pip-compile")
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -81,8 +81,7 @@ def before_all(context):
     # install this plugin by resolving the requirements using pip-compile
     # from pip-tools due to this bug in pip: https://github.com/pypa/pip/issues/988
     #
-    # pip can be unpinned when the issue is resolved in
-    # https://github.com/jazzband/pip-tools/issues/856
+    # pip<19.2 can be unpinned when 19.3 is released.
     call([context.python, "-m", "pip", "install", "-U", "pip<19.2", "pip-tools"])
     pip_compile = str(bin_dir / "pip-compile")
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -80,6 +80,9 @@ def before_all(context):
 
     # install this plugin by resolving the requirements using pip-compile
     # from pip-tools due to this bug in pip: https://github.com/pypa/pip/issues/988
+    #
+    # pip can be unpinned when the issue is resolved in
+    # https://github.com/jazzband/pip-tools/issues/856
     call([context.python, "-m", "pip", "install", "-U", "pip<19.2", "pip-tools"])
     pip_compile = str(bin_dir / "pip-compile")
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -80,7 +80,7 @@ def before_all(context):
 
     # install this plugin by resolving the requirements using pip-compile
     # from pip-tools due to this bug in pip: https://github.com/pypa/pip/issues/988
-    call([context.python, "-m", "pip", "install", "-U", "pip", "pip-tools"])
+    call([context.python, "-m", "pip", "install", "-U", "pip<19.2", "pip-tools"])
     pip_compile = str(bin_dir / "pip-compile")
     with tempfile.TemporaryDirectory() as tmpdirname:
         reqs = Path("requirements.txt").read_text()

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -86,7 +86,6 @@ def before_all(context):
     pip_compile = str(bin_dir / "pip-compile")
     with tempfile.TemporaryDirectory() as tmpdirname:
         reqs = Path("requirements.txt").read_text()
-        reqs = reqs.replace("kedro", "git+https://github.com/quantumblacklabs/kedro")
         complied_reqs = Path(tmpdirname) / "requirements.txt"
         complied_reqs.write_text(reqs)
         call([pip_compile, str(complied_reqs)])


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Why was this PR created?

pip 19.2 dropped the index_urls keyword argument from the `PackageFinder`. I pinned it to be less than 19.2 until the issue is resolved (see https://github.com/jazzband/pip-tools/issues/856 for details). 


## How has this been tested?
What testing strategies have you used?
CI
## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
