### PR TITLE
Make Viz compatible with Kedro 0.14.0

### DIFF
--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -66,7 +66,7 @@ def nodes_json():
     namespace_tags = defaultdict(set)
     all_tags = set()
 
-    for node in sorted(pipeline.nodes):
+    for node in sorted(pipeline.nodes, key=lambda n: n.name):
         task_id = "task/" + node.name.replace(" ", "")
         nodes.append(
             {

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,2 +1,2 @@
 Flask>=1.0, <2.0
-kedro
+kedro>=0.14.0


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
It's come to light that KedroViz is only compatible with Kedro 0.14.2 and up due to that being the version where Kedro nodes became orderable.
This change removes the dependency on nodes having a native ordering and so opens up compatibility with 0.14.0 
Compatibility with 0.13.x is problematic for other reasons.

## How has this been tested?
What testing strategies have you used?

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
