### PR TITLE
Don't ignore gh-pages branch in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,18 +161,9 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_35:
-          filters:
-            branches:
-              ignore: gh-pages
-      - build_36:
-          filters:
-            branches:
-              ignore: gh-pages
-      - build_37:
-          filters:
-            branches:
-              ignore: gh-pages
+      - build_35
+      - build_36
+      - build_37
       - deploy_demo:
           requires:
               - build_35

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,9 @@
 # Upcoming release:
 Add release notes for the upcoming release here.
 
+## Bug fixes and other changes
+- Don't ignore gh-pages branch in CircleCI (#33)
+
 # Release 2.1.0:
 
 ## Major features and improvements


### PR DESCRIPTION
## Description

Ignoring builds on the `gh-pages` branch is already being handled by the `[ci skip]` command in the commit message. Besides, the CircleCI config isn't even present on that branch, so these lines of config are redundant.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
