### PR TITLE
Fix closing of the navbar on smaller screens

### DIFF
--- a/src/components/wrapper/wrapper.scss
+++ b/src/components/wrapper/wrapper.scss
@@ -81,9 +81,13 @@
   visibility: hidden;
   opacity: 0;
   transition: all ease 0.4s;
+  z-index: 1;
 
-  &--offset {
-    right: -50px;
+  @media (min-width: $breakpoint-small) {
+    &--offset {
+      right: -50px;
+      z-index: auto;
+    }
   }
 
   &--visible {


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Previously, you couldn't access the nav button on mobile when the snapshots panel wasn't visible. Now you can.

Before:
![image](https://user-images.githubusercontent.com/1155816/63365940-911f1e80-c370-11e9-9ed5-9df9b9aac074.png)
After:
![image](https://user-images.githubusercontent.com/1155816/63365958-9b411d00-c370-11e9-9ade-b112a9f04699.png)

## How has this been tested?
Manually

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
