### PR TITLE
[KED-976] Use What Input? to set obvious keyboard focus state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16200,6 +16200,11 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
+    "what-input": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/what-input/-/what-input-5.2.3.tgz",
+      "integrity": "sha512-ekQJmKNVEPcFIE2YI1L7iXm/m2QTQWe9QqewSCCFZs2ZPo3yOfA8TV8ioBx/JnWZrDUNVGj/YdDJCH5uagMEgg=="
+    },
     "whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "@quantumblack/kedro-ui": "^1.0.2",
     "classnames": "^2.2.6",
     "d3-fetch": "^1.1.2",
+    "d3-interpolate-path": "^2.1.0",
     "d3-scale": "^3.0.0",
     "d3-selection": "^1.4.0",
     "d3-shape": "^1.3.5",
     "d3-transition": "^1.2.0",
     "d3-zoom": "^1.7.3",
-    "d3-interpolate-path": "^2.1.0",
     "dagre": "^0.8.4",
     "react": "^16.8.6",
     "react-custom-scrollbars": "^4.2.1",
@@ -44,7 +44,8 @@
     "react-test-renderer": "^16.8.6",
     "redux": "^4.0.1",
     "reselect": "^4.0.0",
-    "snyk": "^1.204.0"
+    "snyk": "^1.204.0",
+    "what-input": "^5.2.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -15,11 +15,44 @@
     min-width: 20px;
   }
 
-  // Change radio button focus outline to blue
+  // Change Kedro-UI focus outlines to blue
   &.kui-theme--dark,
   &.kui-theme--light {
     .kui-switch__input:focus + .kui-switch-radio__label .kui-switch-radio__box {
-      box-shadow: 0 0 0 4px rgba(0, 191, 255, 0.6);
+      box-shadow: 0 0 0 4px $color-link;
+
+      [data-whatinput='mouse'] & {
+        box-shadow: none;
+      }
+    }
+
+    .kui-input--focused,
+    .kui-dropdown__label:focus,
+    .kui-switch__input:focus
+      + .kui-switch-checkbox__label
+      .kui-switch-checkbox__box {
+      outline: 4px solid $color-link;
+
+      [data-whatintent='mouse'] & {
+        outline-color: transparent;
+      }
+    }
+
+    .kui-switch__input + .kui-toggle__switch {
+      border: 7px solid transparent;
+      margin: -7px;
+      background-color: transparent;
+      outline-width: 4px;
+      transition: outline-color 0.1s;
+      user-select: none;
+    }
+    .kui-switch__input:active + .kui-toggle__switch,
+    .kui-switch__input:focus + .kui-toggle__switch {
+      outline-color: $color-link;
+
+      [data-whatinput='mouse'] & {
+        outline-color: transparent;
+      }
     }
   }
 
@@ -52,6 +85,10 @@
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 3px rgba(0, 191, 255, 0.6);
+    box-shadow: 0 0 0 3px $color-link;
+
+    [data-whatinput='mouse'] & {
+      box-shadow: none;
+    }
   }
 }

--- a/src/components/flowchart/styles/_node-icon.scss
+++ b/src/components/flowchart/styles/_node-icon.scss
@@ -48,6 +48,11 @@
         fill: $node-iconbg-fill-dark-active;
         stroke: $node-iconbg-stroke-dark-active;
       }
+
+      [data-whatintent='keyboard'] & {
+        stroke-width: 3.5px;
+        stroke: $color-link;
+      }
     }
   }
 

--- a/src/components/flowchart/styles/_node-text.scss
+++ b/src/components/flowchart/styles/_node-text.scss
@@ -73,6 +73,11 @@
         fill: $node-labelbg-fill-dark-active;
         stroke: $node-labelbg-stroke-dark-active;
       }
+
+      [data-whatintent='keyboard'] & {
+        stroke-width: 3.5px;
+        stroke: $color-link;
+      }
     }
   }
 

--- a/src/components/node-list/node-list.scss
+++ b/src/components/node-list/node-list.scss
@@ -56,31 +56,25 @@
 
 .pipeline-node-list__toggle {
   background: none;
-  padding: 2px 0 1px;
+  padding: 1px 6px 2px;
+  margin: -1px -6px -2px;
   box-shadow: none;
   border: none;
   color: inherit;
   font-size: 1.6em;
   cursor: pointer;
   opacity: 0.8;
-  outline: none;
-  border-bottom: 1px solid transparent;
 
   &:focus {
-    border-bottom-width: 1px;
-    border-bottom-style: solid;
+    opacity: 1;
+    outline: 4px solid $color-link;
 
-    .kui-theme--light & {
-      border-bottom-color: rgba(black, 0.5);
-    }
-
-    .kui-theme--dark & {
-      border-bottom-color: rgba(white, 0.5);
+    [data-whatintent='mouse'] & {
+      outline: none;
     }
   }
 
-  &:hover,
-  &:focus {
+  &:hover {
     opacity: 1;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import 'what-input';
 import App from './components/app';
 import config from './config';
 import './styles/index.css';

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -31,6 +31,8 @@ $color-bg-dark: #1d2f3a;
 $color-bg-dark-alt: #122531;
 $color-header-dark: #111f2a;
 $color-line-dark: #081c28;
+$color-link: rgba(#00bfff, 0.85);
+
 //-- typography --//
 $rem-base: 10px;
 $font-base: 10px;


### PR DESCRIPTION
## Description
Use [What Input?](https://github.com/ten1seven/what-input/) to add a consistent and obvious tabbed focus state for keyboard users only, while preventing mouse users from needing to see the massive colourful outline. ([demo](https://twitter.com/RichardWestenra/status/1164909513125900288))

### Note
A lot of these styles are temporary overrides for [Kedro-UI](https://github.com/quantumblacklabs/kedro-ui), and should ultimately be added to that repo instead. So in the medium term, I'm planning to improve the Kedro-UI styles, then remove these overrides. But this works as a short term fix and a demonstration of how well this technique works.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":
- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
