### PR TITLE
Detect and use the OS's default theme if set

### DIFF
--- a/src/components/app/load-data.js
+++ b/src/components/app/load-data.js
@@ -5,7 +5,7 @@ import formatData from '../../utils/format-data';
 import loremIpsum from '../../utils/data/lorem-ipsum.mock';
 import animals from '../../utils/data/animals.mock';
 import demo from '../../utils/data/demo.mock';
-import { loadState } from '../../utils';
+import { detectSystemTheme, loadState } from '../../utils';
 
 /**
  * Configure the redux store's initial state
@@ -17,7 +17,7 @@ export const getInitialState = pipelineData => {
   const {
     parameters = true,
     textLabels = false,
-    theme = 'dark',
+    theme = detectSystemTheme('dark'),
     view = 'combined'
   } = loadState();
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -102,3 +102,17 @@ export const saveState = state => {
     console.error(err);
   }
 };
+
+/**
+ * Detect the operating system's default theme (light/dark) if set.
+ * @param {string} defaultTheme Fallback theme (light/dark)
+ */
+export const detectSystemTheme = defaultTheme => {
+  if (window && window.matchMedia) {
+    const match = ['light', 'dark'].find(
+      theme => window.matchMedia(`(prefers-color-scheme: ${theme})`).matches
+    );
+    return match || defaultTheme;
+  }
+  return defaultTheme;
+};


### PR DESCRIPTION
## Description

Use [window.matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) and [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) to detect the OS's default theme (light/dark) if set, and use it by default

See https://hankchizljaw.com/wrote/create-a-user-controlled-dark-or-light-mode/

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
