### PR TITLE
Set the 'show sidebar' button to hidden when open

### DIFF
--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -8,11 +8,17 @@ import './sidebar.css';
 /**
  * Hamburger menu button
  * @param {Function} props.onToggle Show menu on click
+ * @param {Boolean} props.visible Whether nav is visible
  */
-export const ShowMenuButton = ({ onToggle }) => (
+export const ShowMenuButton = ({ onToggle, visible }) => (
   <button
     aria-label="Show menu"
-    className="pipeline-sidebar__show-menu pipeline-sidebar__icon-button"
+    className={classnames(
+      'pipeline-sidebar__show-menu pipeline-sidebar__icon-button',
+      {
+        'pipeline-sidebar__icon-button--visible': visible
+      }
+    )}
     onClick={onToggle}>
     <MenuIcon className="pipeline-icon" />
   </button>
@@ -30,7 +36,7 @@ export const HideMenuButton = ({ onToggle, theme, visible }) => (
     className={classnames(
       'pipeline-sidebar__hide-menu pipeline-sidebar__icon-button',
       {
-        'pipeline-sidebar__hide-menu--visible': visible
+        'pipeline-sidebar__icon-button--visible': visible
       }
     )}
     onClick={onToggle}>
@@ -44,7 +50,7 @@ export const HideMenuButton = ({ onToggle, theme, visible }) => (
  */
 export const Sidebar = props => (
   <>
-    <ShowMenuButton onToggle={props.onToggle} />
+    <ShowMenuButton onToggle={props.onToggle} visible={!props.visible} />
     <nav
       className={classnames('pipeline-sidebar', {
         'pipeline-sidebar--visible': props.visible

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -57,19 +57,11 @@
   position: absolute;
   top: 20px;
   right: 20px;
-  visibility: hidden;
-  opacity: 0;
-  transition: all ease 0.4s;
   z-index: 1;
 
   @media (min-width: $breakpoint-small) {
     right: -50px;
     z-index: auto;
-  }
-
-  &--visible {
-    visibility: visible;
-    opacity: 1;
   }
 }
 
@@ -87,6 +79,13 @@
   height: 3.2em;
   transition: all ease 0.1s;
   transform: scale(1.3);
+  visibility: hidden;
+  opacity: 0;
+
+  &--visible {
+    visibility: visible;
+    opacity: 1;
+  }
 
   &:hover {
     transform: scale(1.5);


### PR DESCRIPTION
## Description

Set the sidebar hamburger button to `visibility: hidden` when the sidebar is open, so that it's not included in the tabbing order when it's hidden behind the sidebar.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Why was this PR created?

## How has this been tested?
What testing strategies have you used?

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
