### PR TITLE
Move drawChart method to its own JS file

### DIFF
--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -1,4 +1,3 @@
-import { DURATION } from './index';
 import 'd3-transition';
 import { interpolatePath } from 'd3-interpolate-path';
 import { select } from 'd3-selection';
@@ -39,7 +38,7 @@ const draw = function() {
   this.el.edges
     .exit()
     .transition('exit-edges')
-    .duration(DURATION)
+    .duration(this.DURATION)
     .attr('opacity', 0)
     .remove();
 
@@ -52,13 +51,13 @@ const draw = function() {
         centralNode && (!linkedNodes[source] || !linkedNodes[target])
     )
     .transition('show-edges')
-    .duration(DURATION)
+    .duration(this.DURATION)
     .attr('opacity', 1);
 
   this.el.edges
     .select('path')
     .transition('update-edges')
-    .duration(DURATION)
+    .duration(this.DURATION)
     .attrTween('d', function(edge) {
       const current = edge.points && lineShape(edge.points);
       const previous = select(this).attr('d') || current;
@@ -91,7 +90,7 @@ const draw = function() {
   this.el.nodes
     .exit()
     .transition('exit-nodes')
-    .duration(DURATION)
+    .duration(this.DURATION)
     .attr('opacity', 0)
     .remove();
 
@@ -114,7 +113,7 @@ const draw = function() {
 
   this.el.nodes
     .transition('update-nodes')
-    .duration(DURATION)
+    .duration(this.DURATION)
     .attr('opacity', 1)
     .attr('transform', node => `translate(${node.x}, ${node.y})`)
     .end()

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -1,0 +1,136 @@
+import { DURATION } from './index';
+import 'd3-transition';
+import { interpolatePath } from 'd3-interpolate-path';
+import { select } from 'd3-selection';
+import { curveBasis, line } from 'd3-shape';
+import icon from './icon';
+
+/**
+ * Render chart to the DOM with D3
+ */
+const draw = function() {
+  const { centralNode, linkedNodes, textLabels } = this.props;
+  const { nodes, edges } = this.props.layout;
+
+  // Create selections
+  this.el.edges = this.el.edgeGroup
+    .selectAll('.edge')
+    .data(edges, edge => edge.id);
+
+  this.el.nodes = this.el.nodeGroup
+    .selectAll('.node')
+    .data(nodes, node => node.id);
+
+  // Set up line shape function
+  const lineShape = line()
+    .x(d => d.x)
+    .y(d => d.y)
+    .curve(curveBasis);
+
+  // Create edges
+  const enterEdges = this.el.edges
+    .enter()
+    .append('g')
+    .attr('class', 'edge')
+    .attr('opacity', 0);
+
+  enterEdges.append('path').attr('marker-end', d => `url(#arrowhead)`);
+
+  this.el.edges
+    .exit()
+    .transition('exit-edges')
+    .duration(DURATION)
+    .attr('opacity', 0)
+    .remove();
+
+  this.el.edges = this.el.edges.merge(enterEdges);
+
+  this.el.edges
+    .classed(
+      'edge--faded',
+      ({ source, target }) =>
+        centralNode && (!linkedNodes[source] || !linkedNodes[target])
+    )
+    .transition('show-edges')
+    .duration(DURATION)
+    .attr('opacity', 1);
+
+  this.el.edges
+    .select('path')
+    .transition('update-edges')
+    .duration(DURATION)
+    .attrTween('d', function(edge) {
+      const current = edge.points && lineShape(edge.points);
+      const previous = select(this).attr('d') || current;
+      return interpolatePath(previous, current);
+    });
+
+  // Create nodes
+  const enterNodes = this.el.nodes
+    .enter()
+    .append('g')
+    .attr('tabindex', '0')
+    .attr('class', 'node');
+
+  enterNodes
+    .attr('transform', node => `translate(${node.x}, ${node.y})`)
+    .attr('opacity', 0);
+
+  enterNodes.append('circle').attr('r', 25);
+
+  enterNodes.append('rect');
+
+  enterNodes.append(icon);
+
+  enterNodes
+    .append('text')
+    .text(node => node.name)
+    .attr('text-anchor', 'middle')
+    .attr('dy', 4);
+
+  this.el.nodes
+    .exit()
+    .transition('exit-nodes')
+    .duration(DURATION)
+    .attr('opacity', 0)
+    .remove();
+
+  this.el.nodes = this.el.nodes
+    .merge(enterNodes)
+    .classed('node--parameters', node => node.type === 'parameters')
+    .classed('node--data', node => node.type === 'data')
+    .classed('node--task', node => node.type === 'task')
+    .classed('node--icon', !textLabels)
+    .classed('node--text', textLabels)
+    .classed('node--active', node => node.active)
+    .classed('node--highlight', node => centralNode && linkedNodes[node.id])
+    .classed('node--faded', node => centralNode && !linkedNodes[node.id])
+    .on('click', this.handleNodeClick)
+    .on('mouseover', this.handleNodeMouseOver)
+    .on('mouseout', this.handleNodeMouseOut)
+    .on('focus', this.handleNodeMouseOver)
+    .on('blur', this.handleNodeMouseOut)
+    .on('keydown', this.handleNodeKeyDown);
+
+  this.el.nodes
+    .transition('update-nodes')
+    .duration(DURATION)
+    .attr('opacity', 1)
+    .attr('transform', node => `translate(${node.x}, ${node.y})`)
+    .end()
+    .catch(() => {})
+    .finally(() => {
+      // Sort nodes so tab focus order follows X/Y position
+      this.el.nodes.sort((a, b) => a.order - b.order);
+    });
+
+  this.el.nodes
+    .select('rect')
+    .attr('width', node => node.width - 5)
+    .attr('height', node => node.height - 5)
+    .attr('x', node => (node.width - 5) / -2)
+    .attr('y', node => (node.height - 5) / -2)
+    .attr('rx', node => (node.type === 'data' ? node.height / 2 : 0));
+};
+
+export default draw;

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -14,8 +14,6 @@ import { getCentralNode, getLinkedNodes } from '../../selectors/linked-nodes';
 import draw from './draw';
 import './styles/flowchart.css';
 
-export const DURATION = 700;
-
 /**
  * Display a pipeline flowchart, mostly rendered with D3
  */
@@ -30,6 +28,8 @@ export class FlowChart extends Component {
       tooltipX: 0,
       tooltipY: 0
     };
+
+    this.DURATION = 700;
 
     this.containerRef = React.createRef();
     this.svgRef = React.createRef();
@@ -127,7 +127,7 @@ export class FlowChart extends Component {
     const navOffset = this.getNavOffset(chartSize.outerWidth);
     this.el.svg
       .transition()
-      .duration(DURATION)
+      .duration(this.DURATION)
       .call(
         this.zoomBehaviour.transform,
         zoomIdentity.translate(translateX + navOffset, translateY).scale(scale)

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -2,9 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import 'd3-transition';
-import { interpolatePath } from 'd3-interpolate-path';
 import { select, event } from 'd3-selection';
-import { curveBasis, line } from 'd3-shape';
 import { zoom, zoomIdentity } from 'd3-zoom';
 import {
   toggleNodeClicked,
@@ -13,10 +11,10 @@ import {
 } from '../../actions';
 import { getLayout, getZoomPosition } from '../../selectors/layout';
 import { getCentralNode, getLinkedNodes } from '../../selectors/linked-nodes';
-import icon from './icon';
+import draw from './draw';
 import './styles/flowchart.css';
 
-const DURATION = 700;
+export const DURATION = 700;
 
 /**
  * Display a pipeline flowchart, mostly rendered with D3
@@ -140,128 +138,7 @@ export class FlowChart extends Component {
    * Render chart to the DOM with D3
    */
   drawChart() {
-    const { centralNode, layout, linkedNodes, textLabels } = this.props;
-    const { nodes, edges } = layout;
-
-    // Create selections
-    this.el.edges = this.el.edgeGroup
-      .selectAll('.edge')
-      .data(edges, edge => edge.id);
-
-    this.el.nodes = this.el.nodeGroup
-      .selectAll('.node')
-      .data(nodes, node => node.id);
-
-    // Set up line shape function
-    const lineShape = line()
-      .x(d => d.x)
-      .y(d => d.y)
-      .curve(curveBasis);
-
-    // Create edges
-    const enterEdges = this.el.edges
-      .enter()
-      .append('g')
-      .attr('class', 'edge')
-      .attr('opacity', 0);
-
-    enterEdges.append('path').attr('marker-end', d => `url(#arrowhead)`);
-
-    this.el.edges
-      .exit()
-      .transition('exit-edges')
-      .duration(DURATION)
-      .attr('opacity', 0)
-      .remove();
-
-    this.el.edges = this.el.edges.merge(enterEdges);
-
-    this.el.edges
-      .classed(
-        'edge--faded',
-        ({ source, target }) =>
-          centralNode && (!linkedNodes[source] || !linkedNodes[target])
-      )
-      .transition('show-edges')
-      .duration(DURATION)
-      .attr('opacity', 1);
-
-    this.el.edges
-      .select('path')
-      .transition('update-edges')
-      .duration(DURATION)
-      .attrTween('d', function(edge) {
-        const current = edge.points && lineShape(edge.points);
-        const previous = select(this).attr('d') || current;
-        return interpolatePath(previous, current);
-      });
-
-    // Create nodes
-    const enterNodes = this.el.nodes
-      .enter()
-      .append('g')
-      .attr('tabindex', '0')
-      .attr('class', 'node');
-
-    enterNodes
-      .attr('transform', node => `translate(${node.x}, ${node.y})`)
-      .attr('opacity', 0);
-
-    enterNodes.append('circle').attr('r', 25);
-
-    enterNodes.append('rect');
-
-    enterNodes.append(icon);
-
-    enterNodes
-      .append('text')
-      .text(node => node.name)
-      .attr('text-anchor', 'middle')
-      .attr('dy', 4);
-
-    this.el.nodes
-      .exit()
-      .transition('exit-nodes')
-      .duration(DURATION)
-      .attr('opacity', 0)
-      .remove();
-
-    this.el.nodes = this.el.nodes
-      .merge(enterNodes)
-      .classed('node--parameters', node => node.type === 'parameters')
-      .classed('node--data', node => node.type === 'data')
-      .classed('node--task', node => node.type === 'task')
-      .classed('node--icon', !textLabels)
-      .classed('node--text', textLabels)
-      .classed('node--active', node => node.active)
-      .classed('node--highlight', node => centralNode && linkedNodes[node.id])
-      .classed('node--faded', node => centralNode && !linkedNodes[node.id])
-      .on('click', this.handleNodeClick)
-      .on('mouseover', this.handleNodeMouseOver)
-      .on('mouseout', this.handleNodeMouseOut)
-      .on('focus', this.handleNodeMouseOver)
-      .on('blur', this.handleNodeMouseOut)
-      .on('keydown', this.handleNodeKeyDown);
-
-    this.el.nodes
-      .transition('update-nodes')
-      .duration(DURATION)
-      .attr('opacity', 1)
-      .attr('transform', node => `translate(${node.x}, ${node.y})`)
-      .end()
-      .catch(() => {})
-      .finally(() => {
-        // Sort nodes so tab focus order follows X/Y position
-        this.el.nodes.sort((a, b) => a.order - b.order);
-      });
-
-    this.el.nodes
-      .select('rect')
-      .attr('width', node => node.width - 5)
-      .attr('height', node => node.height - 5)
-      .attr('x', node => (node.width - 5) / -2)
-      .attr('y', node => (node.height - 5) / -2)
-      .attr('rx', node => (node.type === 'data' ? node.height / 2 : 0));
+    draw.call(this);
   }
 
   /**

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -39,14 +39,7 @@ export class FlowChart extends Component {
   }
 
   componentDidMount() {
-    // Create D3 element selectors
-    this.el = {
-      svg: select(this.svgRef.current),
-      wrapper: select(this.wrapperRef.current),
-      edgeGroup: select(this.edgesRef.current),
-      nodeGroup: select(this.nodesRef.current)
-    };
-
+    this.selectD3Elements();
     this.updateChartSize();
     this.initZoomBehaviour();
     this.drawChart();
@@ -66,6 +59,18 @@ export class FlowChart extends Component {
       this.zoomChart();
     }
     this.drawChart();
+  }
+
+  /**
+   * Create D3 element selectors
+   */
+  selectD3Elements() {
+    this.el = {
+      svg: select(this.svgRef.current),
+      wrapper: select(this.wrapperRef.current),
+      edgeGroup: select(this.edgesRef.current),
+      nodeGroup: select(this.nodesRef.current)
+    };
   }
 
   /**


### PR DESCRIPTION
## Description

The FlowChart component is too long, so I've moved the drawChart logic to its own file, seeing as we're shelving the React refactor for now.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
