### PR TITLE
[KED-1143] Improve tabbing order

### DIFF
--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -9,6 +9,7 @@
   width: 100%;
   transform: translateX(-100%);
   padding-top: 12px;
+  z-index: 1;
 
   .pipeline-ui {
     visibility: hidden;

--- a/src/components/wrapper/index.js
+++ b/src/components/wrapper/index.js
@@ -34,17 +34,17 @@ export class Wrapper extends Component {
           'kui-theme--dark': theme === 'dark',
           'kui-theme--light': theme === 'light'
         })}>
-        <div className="pipeline-wrapper">
-          <FontLoadChecker>
-            <FlowChart visibleNav={visibleNav} />
-          </FontLoadChecker>
-        </div>
-        <IconToolbar />
         <Sidebar
           onToggle={this.toggleNav.bind(this)}
           theme={theme}
           visible={visibleNav}
         />
+        <IconToolbar />
+        <div className="pipeline-wrapper">
+          <FontLoadChecker>
+            <FlowChart visibleNav={visibleNav} />
+          </FontLoadChecker>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Description

Make the graph come after the UI controls when tabbing through the interface. Resolves #66

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
