### PR TITLE
Fix sidebar show/hide transitions in Safari

### DIFF
--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -12,7 +12,7 @@
 
   .pipeline-ui {
     visibility: hidden;
-    transition: visibility 0s;
+    transition: visibility 0.3s;
   }
 
   @media (min-width: $breakpoint-small) {
@@ -29,7 +29,7 @@
 
     .pipeline-ui {
       visibility: visible;
-      transition: visibility 0.3s;
+      transition: visibility 0s;
     }
   }
 
@@ -84,6 +84,7 @@
 
   &--visible {
     visibility: visible;
+    transition: all 0.1s, visibility 0s;
     opacity: 1;
   }
 


### PR DESCRIPTION
## Description

Safari handles CSS transitions on the `visibility` property differently from other browsers: Chrome will toggle to `visible` at the start of the transition and to `hidden` at the end, but Safari will toggle both at the start. So to make the sidebar transition work flawlessly in Safari, a different value needs to be provided for each of the two use-cases.

There are some related issues happening with some of the Kedro-UI components: I had created a separate PR to fix them: https://github.com/quantumblacklabs/kedro-ui/pull/45

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
