### PR TITLE
Allow chart to resize with parent container

### DIFF
--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -48,11 +48,11 @@ export class FlowChart extends Component {
     this.initZoomBehaviour();
     this.drawChart();
     this.zoomChart();
-    window.addEventListener('resize', this.handleWindowResize);
+    this.addResizeObserver();
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.handleWindowResize);
+    this.removeResizeObserver();
   }
 
   componentDidUpdate(prevProps) {
@@ -107,6 +107,32 @@ export class FlowChart extends Component {
       return navWidth;
     }
     return 0;
+  }
+
+  /**
+   * Add ResizeObserver to listen for any changes in the container's width/height
+   * (with event listener fallback)
+   */
+  addResizeObserver() {
+    if (window.ResizeObserver) {
+      this.resizeObserver =
+        this.resizeObserver ||
+        new window.ResizeObserver(this.handleWindowResize);
+      this.resizeObserver.observe(this.containerRef.current);
+    } else {
+      window.addEventListener('resize', this.handleWindowResize);
+    }
+  }
+
+  /**
+   * Remove ResizeObserver (or event listener fallback) on unmount
+   */
+  removeResizeObserver() {
+    if (window.ResizeObserver) {
+      this.resizeObserver.unobserve(this.containerRef.current);
+    } else {
+      window.removeEventListener('resize', this.handleWindowResize);
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

The 'resize' event listener only responds to window resizes. Instead, use ResizeObserver, so that Kedro-Viz will resize when its parent changes size, if it is included as a child component.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
