### PR TITLE
Fix SVG import issues

### DIFF
--- a/src/components/icon-toolbar/index.js
+++ b/src/components/icon-toolbar/index.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { toggleTextLabels, toggleTheme } from '../../actions';
-import { ReactComponent as ThemeIcon } from './theme-icon.svg';
-import { ReactComponent as LabelIcon } from './label-icon.svg';
+import LabelIcon from '../icons/label';
+import ThemeIcon from '../icons/theme';
 import './icon-toolbar.css';
 
 export const ThemeButton = ({ onToggle, theme }) => (

--- a/src/components/icon-toolbar/label-icon.svg
+++ b/src/components/icon-toolbar/label-icon.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 20"><path d="M22 0v20H7.3L0 10 7.3 0H22zm-6.2 5h-3.6L10 15h2l.3-1.8h3.4L16 15H18L15.8 5zm-1.5 1.7l1 4.7h-2.6l1-4.7h.6z"/></svg>

--- a/src/components/icon-toolbar/theme-icon.svg
+++ b/src/components/icon-toolbar/theme-icon.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M10 0a10 10 0 1 1 0 20 10 10 0 0 1 0-20zm0 2v16a8 8 0 1 0 0-16z"/></svg>

--- a/src/components/icons/label.js
+++ b/src/components/icons/label.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default ({ className }) => (
+  <svg
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 22 20">
+    <path d="M22 0v20H7.3L0 10 7.3 0H22zm-6.2 5h-3.6L10 15h2l.3-1.8h3.4L16 15H18L15.8 5zm-1.5 1.7l1 4.7h-2.6l1-4.7h.6z" />
+  </svg>
+);

--- a/src/components/icons/menu.js
+++ b/src/components/icons/menu.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default ({ className }) => (
+  <svg
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24">
+    <rect x="2" y="5" width="20" height="2" />
+    <rect x="2" y="11" width="20" height="2" />
+    <rect x="2" y="17" width="20" height="2" />
+  </svg>
+);

--- a/src/components/icons/theme.js
+++ b/src/components/icons/theme.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default ({ className }) => (
+  <svg
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 20 20">
+    <path d="M10 0a10 10 0 1 1 0 20 10 10 0 0 1 0-20zm0 2v16a8 8 0 1 0 0-16z" />
+  </svg>
+);

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -48,7 +48,7 @@ export const HideMenuButton = ({ onToggle, theme, visible }) => (
  * Main app container. Handles showing/hiding the sidebar nav, and theme classes.
  * @param {Object} props onToggle, theme, and visible
  */
-export const Sidebar = props => (
+const Sidebar = props => (
   <>
     <ShowMenuButton onToggle={props.onToggle} visible={!props.visible} />
     <nav

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import classnames from 'classnames';
 import Icon from '@quantumblack/kedro-ui/lib/components/icon';
 import ChartUI from '../chart-ui';
-import { ReactComponent as MenuIcon } from './menu-icon.svg';
+import MenuIcon from '../icons/menu';
 import './sidebar.css';
 
 /**

--- a/src/components/sidebar/menu-icon.svg
+++ b/src/components/sidebar/menu-icon.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="2" y="5" width="20" height="2" /><rect x="2" y="11" width="20" height="2" /><rect x="2" y="17" width="20" height="2" /></svg>

--- a/src/components/sidebar/sidebar.test.js
+++ b/src/components/sidebar/sidebar.test.js
@@ -1,4 +1,4 @@
-import { ShowMenuButton, HideMenuButton, Sidebar } from './index';
+import Sidebar, { ShowMenuButton, HideMenuButton } from './index';
 import { mockState, setup } from '../../utils/state.mock';
 
 const mockProps = {


### PR DESCRIPTION
## Description

- Convert SVG icons to JS components, in order to fix issues when importing Kedro-Viz in React apps that don't support webpack SVG loading. I'd prefer to have used babel to keep them as SVGs and convert them into inline React components on compile, but this didn't play well with Create-React-App's webpack config, so I've had to implement this workaround :(
- Remove unnecessary Sidebar component export

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
