### PR TITLE
Add data-id attributes on nodes and edges

### DIFF
--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -44,6 +44,7 @@ const draw = function() {
   this.el.edges = this.el.edges.merge(enterEdges);
 
   this.el.edges
+    .attr('data-id', edge => edge.id)
     .classed(
       'edge--faded',
       ({ source, target }) =>
@@ -94,6 +95,7 @@ const draw = function() {
 
   this.el.nodes = this.el.nodes
     .merge(enterNodes)
+    .attr('data-id', node => node.id)
     .classed('node--parameters', node => node.type === 'parameters')
     .classed('node--data', node => node.type === 'data')
     .classed('node--task', node => node.type === 'task')


### PR DESCRIPTION
## Description

This is to provide an ID selector, to make it easier for users to hook into them and add their own additional functionality on top of the existing viz, should they wish.

I've used `data-id` attributes instead of element IDs or classes, because node/edge IDs often contain special characters or hexadecimal strings starting with a number, which would be invalid in ID/class selectors, but should be fine in a CSS attribute value selector (e.g. `.edge[data-id="data/parameters|task/split"]` or `.node[data-id="814ef273"]`).

CC @WaylonWalker

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR