### PR TITLE
Add python-dateutil==2.8.0 to unblock release

### DIFF
--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,3 +1,5 @@
+python-dateutil==2.8.0 # explicit hard pin to resolve random pip dependency resolution failure,
+# in order to unblock release. This needs to be removed later.
 Flask>=1.0, <2.0
 kedro>=0.14.0
 ipython>=7.0.0, <8.0

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,5 +1,7 @@
 python-dateutil==2.8.0 # explicit hard pin to resolve random pip dependency resolution failure,
-# in order to unblock release. This needs to be removed later.
+# in order to unblock release.
+# botocore requires <2.8.1, whereas pandas requires >=2.6.0. Pip dependency resolution ramdomly
+# picks either and sometimes fails. This pinning needs to be removed later.
 Flask>=1.0, <2.0
 kedro>=0.14.0
 ipython>=7.0.0, <8.0


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Why was this PR created?

Pip dependency resolution installs python-dateutil==2.8.1 in CI, which is blocking the release. 
As a temporary hack, we hardpin it in `requirements.txt` to unblock the release. 

## How has this been tested?
What testing strategies have you used?
CI

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Assigned myself to the PR
- [ ] Added `Type` label to the PR
