### PR TITLE
[KED-1218] Add App props to specify theme and hide theme/label icon buttons

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,9 +58,7 @@ If you are just using Kedro-Viz with Kedro as a Python package, you won't need t
   {
     snapshots: [
       {
-        created_ts: '1551452832000',
         schema_id: '310750827599783',
-        message: 'Lorem ipsum dolor sit amet',
         nodes: [...],
         edges: [...],
         tags: [...],

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -53,14 +53,21 @@ App.propTypes = {
       nodes: PropTypes.array.isRequired,
       tags: PropTypes.array
     })
-  ])
+  ]),
+  theme: PropTypes.oneOf(['dark', 'light']),
+  visible: PropTypes.shape({
+    labelBtn: PropTypes.bool,
+    themeBtn: PropTypes.bool
+  })
 };
 
 App.defaultProps = {
   /**
    * String (e.g. 'json') or pipeline data
    */
-  data: null
+  data: null,
+  theme: null,
+  visible: {}
 };
 
 export default App;

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -45,7 +45,7 @@ class App extends React.Component {
 
 App.propTypes = {
   data: PropTypes.oneOfType([
-    PropTypes.string,
+    PropTypes.oneOf(['random', 'lorem', 'animals', 'demo', 'json']),
     PropTypes.shape({
       schema_id: PropTypes.string,
       edges: PropTypes.array.isRequired,
@@ -62,10 +62,25 @@ App.propTypes = {
 
 App.defaultProps = {
   /**
-   * String (e.g. 'json') or pipeline data
+   * Determines what pipeline data will be displayed on the chart.
+   * You can supply one of the following strings:
+     - 'random': Use randomly-generated data
+     - 'lorem': Use data from the 'lorem-ipsum' test dataset
+     - 'animals': Use data from the 'animals' test dataset
+     - 'demo': Use data from the 'demo' test dataset
+     - 'json': Load data from a local json file (in /public/api/nodes.json)
+   * Alternatively, you can supply an object containing lists of edges, nodes, tags.
+   * See /src/utils/data for examples of the expected data format.
    */
   data: null,
+  /**
+   * Specify the theme: Either 'light' or 'dark'.
+   * If set, this will override the localStorage value.
+   */
   theme: null,
+  /**
+   * Show/hide the icon buttons with { labelBtn:false } and/or { themeBtn:false }
+   */
   visible: {}
 };
 

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -47,9 +47,8 @@ App.propTypes = {
   data: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.shape({
-      created_ts: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      schema_id: PropTypes.string,
       edges: PropTypes.array.isRequired,
-      message: PropTypes.string,
       nodes: PropTypes.array.isRequired,
       tags: PropTypes.array
     })

--- a/src/components/app/load-data.js
+++ b/src/components/app/load-data.js
@@ -16,7 +16,7 @@ export const getInitialState = pipelineData => {
   // Load properties from localStorage if defined, else use defaults
   const {
     parameters = true,
-    textLabels = false,
+    textLabels = true,
     theme = 'dark',
     view = 'combined'
   } = loadState();

--- a/src/components/app/load-data.js
+++ b/src/components/app/load-data.js
@@ -46,19 +46,25 @@ export const getInitialState = (pipelineData, props = {}) => {
 export const loadData = (data, onLoadData) => {
   switch (data) {
     case 'random':
+      // Use randomly-generated data
       return formatData(getRandomPipeline());
     case 'lorem':
+      // Use data from the 'lorem-ipsum' test dataset
       return formatData(loremIpsum);
     case 'animals':
+      // Use data from the 'animals' test dataset
       return formatData(animals);
     case 'demo':
+      // Use data from the 'demo' test dataset
       return formatData(demo);
     case 'json':
+      // Load data from a local json file (in /public/api/nodes.json)
       loadJsonData().then(onLoadData);
       return formatData();
     case null:
       throw new Error('No data was provided to App component via props');
     default:
+      // Use data provided via component prop
       return formatData(data);
   }
 };

--- a/src/components/app/load-data.js
+++ b/src/components/app/load-data.js
@@ -12,7 +12,7 @@ import { loadState } from '../../utils';
  * @param {Object}   pipelineData Formatted pipeline data
  * @param {Object}   props App component props
  */
-export const getInitialState = (pipelineData, props) => {
+export const getInitialState = (pipelineData, props = {}) => {
   // Load properties from localStorage if defined, else use defaults
   const {
     parameters = true,

--- a/src/components/app/load-data.js
+++ b/src/components/app/load-data.js
@@ -12,7 +12,7 @@ import { loadState } from '../../utils';
  * @param {Object}   pipelineData Formatted pipeline data
  * @param {Object}   props App component props
  */
-export const getInitialState = pipelineData => {
+export const getInitialState = (pipelineData, props) => {
   // Load properties from localStorage if defined, else use defaults
   const {
     parameters = true,
@@ -21,13 +21,19 @@ export const getInitialState = pipelineData => {
     view = 'combined'
   } = loadState();
 
+  const visible = Object.assign(
+    { labelBtn: true, themeBtn: true },
+    props.visible
+  );
+
   return {
     ...pipelineData,
     chartSize: {},
     parameters,
     textLabels,
     view,
-    theme
+    visible,
+    theme: props.theme || theme
   };
 };
 

--- a/src/components/app/load-data.test.js
+++ b/src/components/app/load-data.test.js
@@ -31,16 +31,15 @@ describe('load-data', () => {
       });
     });
 
-    it('returns mutated visible state if prop is set', () => {
-      const visible = { themeBtn: false };
-      expect(getInitialState(loremData, { visible })).toMatchObject({
-        visible: { labelBtn: true, themeBtn: false }
-      });
-    });
-
     it('uses prop values instead of defaults if provided', () => {
-      expect(getInitialState(loremData, { theme: 'light' })).toMatchObject({
-        theme: 'light'
+      expect(
+        getInitialState(loremData, {
+          theme: 'light',
+          visible: { themeBtn: false }
+        })
+      ).toMatchObject({
+        theme: 'light',
+        visible: { labelBtn: true, themeBtn: false }
       });
     });
 

--- a/src/components/app/load-data.test.js
+++ b/src/components/app/load-data.test.js
@@ -64,7 +64,10 @@ describe('load-data', () => {
 
   describe('loadData', () => {
     it('returns the correct dataset when passed a dataset string', () => {
-      expect(loadData('random')).toEqual(expect.any(Object));
+      expect(loadData('random')).toMatchObject({
+        nodes: expect.any(Array),
+        nodeName: expect.any(Object)
+      });
       expect(loadData('lorem')).toEqual(formatData(loremIpsum));
       expect(loadData('animals')).toEqual(formatData(animals));
       expect(loadData('demo')).toEqual(formatData(demo));

--- a/src/components/app/load-data.test.js
+++ b/src/components/app/load-data.test.js
@@ -1,0 +1,74 @@
+import { getInitialState, loadData } from './load-data';
+import { saveState } from '../../utils';
+import formatData from '../../utils/format-data';
+import loremIpsum from '../../utils/data/lorem-ipsum.mock';
+import animals from '../../utils/data/animals.mock';
+import demo from '../../utils/data/demo.mock';
+
+describe('load-data', () => {
+  describe('getInitialState', () => {
+    const loremData = loadData('lorem');
+
+    it('returns an object', () => {
+      expect(getInitialState(loremData)).toEqual(expect.any(Object));
+    });
+
+    it('does not require the second argument', () => {
+      expect(getInitialState(loremData)).toEqual(
+        getInitialState(loremData, {})
+      );
+    });
+
+    it('returns full initial state', () => {
+      expect(getInitialState(loremData)).toMatchObject({
+        ...loremData,
+        chartSize: {},
+        parameters: true,
+        textLabels: true,
+        theme: 'dark',
+        view: 'combined',
+        visible: { labelBtn: true, themeBtn: true }
+      });
+    });
+
+    it('returns mutated visible state if prop is set', () => {
+      const visible = { themeBtn: false };
+      expect(getInitialState(loremData, { visible })).toMatchObject({
+        visible: { labelBtn: true, themeBtn: false }
+      });
+    });
+
+    it('uses prop values instead of defaults if provided', () => {
+      expect(getInitialState(loremData, { theme: 'light' })).toMatchObject({
+        theme: 'light'
+      });
+    });
+
+    it('uses localstorage values instead of defaults if provided', () => {
+      const storeValues = {
+        parameters: false,
+        textLabels: false,
+        theme: 'light',
+        view: 'task'
+      };
+      saveState(storeValues);
+      expect(getInitialState(loremData)).toMatchObject(storeValues);
+    });
+
+    it('uses prop values instead of localstorage if provided', () => {
+      saveState({ theme: 'light' });
+      expect(getInitialState(loremData, { theme: 'dark' })).toMatchObject({
+        theme: 'dark'
+      });
+    });
+  });
+
+  describe('loadData', () => {
+    it('returns the correct dataset when passed a dataset string', () => {
+      expect(loadData('random')).toEqual(expect.any(Object));
+      expect(loadData('lorem')).toEqual(formatData(loremIpsum));
+      expect(loadData('animals')).toEqual(formatData(animals));
+      expect(loadData('demo')).toEqual(formatData(demo));
+    });
+  });
+});

--- a/src/components/icon-toolbar/icon-toolbar.test.js
+++ b/src/components/icon-toolbar/icon-toolbar.test.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import IconToolbar, { mapStateToProps, mapDispatchToProps } from './index';
 import { mockState, setup } from '../../utils/state.mock';
+import { getInitialState } from '../app/load-data';
+import formatData from '../../utils/format-data';
+import loremIpsum from '../../utils/data/lorem-ipsum.mock';
 
 describe('IconToolbar', () => {
   it('renders without crashing', () => {
@@ -8,6 +11,34 @@ describe('IconToolbar', () => {
     expect(wrapper.find('.pipeline-icon-toolbar').length).toBe(1);
     expect(wrapper.find('.pipeline-toggle-theme').length).toBe(1);
     expect(wrapper.find('.pipeline-toggle-labels').length).toBe(1);
+  });
+
+  const getState = visible =>
+    getInitialState(formatData(loremIpsum), {
+      visible
+    });
+
+  it('hides both buttons when visible prop is false for each of them', () => {
+    const wrapper = setup.mount(
+      <IconToolbar />,
+      getState({
+        themeBtn: false,
+        labelBtn: false
+      })
+    );
+    expect(wrapper.find('.pipeline-toggle-theme').length).toBe(0);
+    expect(wrapper.find('.pipeline-toggle-labels').length).toBe(0);
+  });
+
+  it('hides one button when visible prop is false for one of them', () => {
+    const wrapper = setup.mount(
+      <IconToolbar />,
+      getState({
+        labelBtn: false
+      })
+    );
+    expect(wrapper.find('.pipeline-toggle-theme').length).toBe(1);
+    expect(wrapper.find('.pipeline-toggle-labels').length).toBe(0);
   });
 
   it('maps state to props', () => {

--- a/src/components/icon-toolbar/icon-toolbar.test.js
+++ b/src/components/icon-toolbar/icon-toolbar.test.js
@@ -1,9 +1,45 @@
 import React from 'react';
-import IconToolbar, { mapStateToProps, mapDispatchToProps } from './index';
+import IconToolbar, {
+  ThemeButton,
+  LabelButton,
+  mapStateToProps,
+  mapDispatchToProps
+} from './index';
 import { mockState, setup } from '../../utils/state.mock';
 import { getInitialState } from '../app/load-data';
 import formatData from '../../utils/format-data';
 import loremIpsum from '../../utils/data/lorem-ipsum.mock';
+
+describe('ThemeButton', () => {
+  it('toggles the theme on button click', () => {
+    let theme = 'dark';
+    const onToggle = t => {
+      theme = t;
+    };
+    const wrapper = setup.shallow(ThemeButton, { theme, onToggle });
+    wrapper.find('button').simulate('click');
+    expect(theme).toBe('light');
+  });
+});
+
+describe('LabelButton', () => {
+  it('toggles labels on button click', () => {
+    let textLabels = false;
+    const onToggle = t => {
+      textLabels = t;
+    };
+    const wrapper = setup.shallow(LabelButton, { textLabels, onToggle });
+    wrapper.find('button').simulate('click');
+    expect(textLabels).toBe(true);
+  });
+
+  it('changes text depending on whether labels are visible', () => {
+    const wrapper1 = setup.shallow(LabelButton, { textLabels: false });
+    expect(wrapper1.find('span').text()).toBe('Show text labels');
+    const wrapper2 = setup.shallow(LabelButton, { textLabels: true });
+    expect(wrapper2.find('span').text()).toBe('Hide text labels');
+  });
+});
 
 describe('IconToolbar', () => {
   it('renders without crashing', () => {

--- a/src/components/icon-toolbar/icon-toolbar.test.js
+++ b/src/components/icon-toolbar/icon-toolbar.test.js
@@ -13,7 +13,11 @@ describe('IconToolbar', () => {
   it('maps state to props', () => {
     const expectedResult = {
       textLabels: expect.any(Boolean),
-      theme: expect.stringMatching(/light|dark/)
+      theme: expect.stringMatching(/light|dark/),
+      visible: expect.objectContaining({
+        themeBtn: expect.any(Boolean),
+        labelBtn: expect.any(Boolean)
+      })
     };
     expect(mapStateToProps(mockState.lorem)).toEqual(expectedResult);
   });

--- a/src/components/icon-toolbar/index.js
+++ b/src/components/icon-toolbar/index.js
@@ -43,21 +43,27 @@ export const IconToolbar = ({
   onToggleTextLabels,
   onToggleTheme,
   textLabels,
-  theme
+  theme,
+  visible
 }) => (
   <ul className="pipeline-icon-toolbar kedro">
-    <li>
-      <ThemeButton onToggle={onToggleTheme} theme={theme} />
-    </li>
-    <li>
-      <LabelButton onToggle={onToggleTextLabels} textLabels={textLabels} />
-    </li>
+    {visible.themeBtn && (
+      <li>
+        <ThemeButton onToggle={onToggleTheme} theme={theme} />
+      </li>
+    )}
+    {visible.labelBtn && (
+      <li>
+        <LabelButton onToggle={onToggleTextLabels} textLabels={textLabels} />
+      </li>
+    )}
   </ul>
 );
 
 export const mapStateToProps = state => ({
   textLabels: state.textLabels,
-  theme: state.theme
+  theme: state.theme,
+  visible: state.visible
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/reducers/reducers.test.js
+++ b/src/reducers/reducers.test.js
@@ -116,7 +116,7 @@ describe('Reducer', () => {
         type: action.TOGGLE_TEXT_LABELS,
         textLabels: true
       });
-      expect(mockState.lorem.textLabels).toBe(false);
+      expect(mockState.lorem.textLabels).toBe(true);
       expect(newState.textLabels).toBe(true);
     });
   });

--- a/src/utils/data/animals.mock.js
+++ b/src/utils/data/animals.mock.js
@@ -1,4 +1,5 @@
 export default {
+  schema_id: '09876543210987654321',
   tags: [
     {
       id: 'small',

--- a/src/utils/data/demo.mock.js
+++ b/src/utils/data/demo.mock.js
@@ -1,4 +1,5 @@
 export default {
+  schema_id: '12345678901234567890',
   edges: [
     {
       source: '33920f3a',

--- a/src/utils/data/lorem-ipsum.mock.js
+++ b/src/utils/data/lorem-ipsum.mock.js
@@ -1,7 +1,5 @@
 export default {
-  created_ts: '1551452832000',
   schema_id: '310750827599783',
-  message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
   tags: [
     {
       id: 'Nulla',

--- a/src/utils/random-data.js
+++ b/src/utils/random-data.js
@@ -12,10 +12,8 @@ import {
 const DATA_NODE_COUNT = 30;
 const MAX_CONNECTED_NODES = 4;
 const MAX_LAYER_COUNT = 20;
-const MAX_MESSAGE_WORD_LENGTH = 15;
 const MAX_NODE_TAG_COUNT = 5;
 const MAX_TAG_COUNT = 20;
-const MAX_TIMESTAMP_OFFSET = 9999999999;
 const PARAMETERS_FREQUENCY = 0.05;
 const TASK_NODE_COUNT = 10;
 
@@ -160,16 +158,10 @@ class Pipeline {
   }
 
   /**
-   * Generate the full pipeline datum, including ID, timestamp,
-   * random message and JSON schema
+   * Generate the full pipeline datum
    */
   getDatum() {
-    return {
-      schema_id: randomNumber(999999999999999),
-      message: getRandomName(randomNumber(MAX_MESSAGE_WORD_LENGTH), ' '),
-      created_ts: new Date().getTime() - randomNumber(MAX_TIMESTAMP_OFFSET),
-      ...this.getSchema()
-    };
+    return this.getSchema();
   }
 }
 

--- a/src/utils/state.mock.js
+++ b/src/utils/state.mock.js
@@ -11,8 +11,8 @@ import loremIpsum from './data/lorem-ipsum.mock';
  * Example state objects for use in tests of redux-enabled components
  */
 export const mockState = {
-  lorem: getInitialState(formatData(loremIpsum), {}),
-  animals: getInitialState(formatData(animals), {})
+  lorem: getInitialState(formatData(loremIpsum)),
+  animals: getInitialState(formatData(animals))
 };
 
 // Redux stores based on mock data

--- a/src/utils/state.mock.js
+++ b/src/utils/state.mock.js
@@ -11,8 +11,8 @@ import loremIpsum from './data/lorem-ipsum.mock';
  * Example state objects for use in tests of redux-enabled components
  */
 export const mockState = {
-  lorem: getInitialState(formatData(loremIpsum)),
-  animals: getInitialState(formatData(animals))
+  lorem: getInitialState(formatData(loremIpsum), {}),
+  animals: getInitialState(formatData(animals), {})
 };
 
 // Redux stores based on mock data


### PR DESCRIPTION
## Description

JavaScript component consumers of the application have requested the ability to override the theme, and to hide the theme button. This PR adds extra props to facilitate this and also allow users to hide future features like the upcoming export button.

This PR also removes leftover traces of the `created_ts` and `message` data properties, which are no longer used.

Finally, it also turns on text labels by default

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
