### PR TITLE
Add explicit dependency on `psutil`

### DIFF
--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-psutil>= 5.6.7, < 5.7
+psutil==5.4.7  # same as Kedro for now
 pytest>=4.4.2, <5.0
 pytest-cov>=2.7.1, <3.0
 pytest-coverage

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+psutil >= 5.6.7, < 5.7
 pytest>=4.4.2, <5.0
 pytest-cov>=2.7.1, <3.0
 pytest-coverage

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-psutil >= 5.6.7, < 5.7
+psutil>= 5.6.7, < 5.7
 pytest>=4.4.2, <5.0
 pytest-cov>=2.7.1, <3.0
 pytest-coverage


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
[This commit](https://github.com/quantumblacklabs/kedro/commit/45265624de52efdc3f51a73eee984cdb4ee116ab) removed `memory-profiler` from Kedro core dependencies, which had a downstream dependency on `psutil`. This now means means the CI image is constructed with no `psutil` installed, as it's pointing at the default branch (`develop`) of Kedro (see [this line](https://github.com/quantumblacklabs/kedro-viz/blob/c869a2e8363516bd9fc761bdfaf24e3a290d1c0b/.circleci/config.yml#L35)).

## How has this been tested?
CI

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Assigned myself to the PR
- [ ] Added `Type` label to the PR
