### PR TITLE
[KED-1315] Add secret scan CircleCI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,11 @@ utils:
     command: |
       make pylint
 
+  run_secret_scan: &run_secret_scan
+    name: Run secret scan
+    command: |
+      make secret-scan
+
   run_python_tests: &run_python_tests
     name: Run Python tests
     command: make pytest
@@ -131,6 +136,7 @@ jobs:
       - run: *run_javascript_tests
       - run: *test_lib_transpilation
       - run: *run_pylint_and_flake8
+      - run: *run_secret_scan
       - run: *run_python_tests
       - run: *run_e2e_tests
       - run: *cleanup

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ pylint:
 	pylint -j 0 --disable=missing-docstring,no-name-in-module package/features
 	flake8 package
 
+secret-scan:
+	trufflehog --max_depth 1 --exclude_path trufflehog-ignore.txt .
+
 version:
 	python3 tools/versioning.py $(VERSION)
 

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -9,3 +9,4 @@ pytest-mock>=1.7.1,<2.0
 requests-mock>=1.6.0, <2.0
 flake8>=3.5, <4.0
 isort
+trufflehog>=2.0.99, <3.0

--- a/trufflehog-ignore.txt
+++ b/trufflehog-ignore.txt
@@ -1,0 +1,4 @@
+package.json
+package-lock.json
+RELEASE.md
+README.md


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
This PR was created to add in a secret scanning step into our CI, using trufflehog to detect any high entropy strings that may acidentally find their way into the repo.

The CircleCI step simply runs trufflehog, ignoring certain files that have high entropy strings (READM/RELEASE/npm package json files) and only runs of the diff of the change (to keep it fast).

## How has this been tested?
Manually tested locally and verified it works by looking in CircleCI.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
