### PR TITLE
[KED1356] Add e2e-tests to check backward-compatibility for Kedro 0.15.0 and latest 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ pytest: build
 	cd package && python3 setup.py test
 
 e2e-tests: build
-	cd package && behave --tags="not @wip"
+	cd package && behave
 
 pylint:
 	cd package && isort

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@
 
 ## Major features and improvements
 
+**BREAKING CHANGE:**  Kedro<0.15.0 no longer works with this version of Kedro-Viz(#72)
 - Allow users to export graph as a transparent SVG/PNG image (#82)
 - Add theme prop and icon button visibility prop (#80)
 - Rename `get_data_from_kedro` to `format_pipeline_data` (#72)

--- a/package/features/jupyter.feature
+++ b/package/features/jupyter.feature
@@ -27,15 +27,15 @@
 # limitations under the License.
 
 
-Feature: Running viz in Jupyter notebook
+# Feature: Running viz in Jupyter notebook
 
-    Background:
-        Given I have prepared a config file with example code
-        And I have run a non-interactive kedro new
-        And I have executed the kedro command "install"
+#     Background:
+#         Given I have prepared a config file with example code
+#         And I have run a non-interactive kedro new
+#         And I have executed the kedro command "install"
 
-    @wip
-    Scenario: Execute viz in a notebook cell
-        When I execute the kedro jupyter command "notebook --no-browser"
-        When I execute line magic "run_viz"
-        Then kedro-viz should start successfully
+#     @wip
+#     Scenario: Execute viz in a notebook cell
+#         When I execute the kedro jupyter command "notebook --no-browser"
+#         When I execute line magic "run_viz"
+#         Then kedro-viz should start successfully

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -88,6 +88,21 @@ def exec_kedro_target_checked(context, command):
         assert False
 
 
+@given('I have installed kedro version "{version}"')
+def install_kedro(context, version):
+    """Execute Kedro command and check the status."""
+    if version == "latest":
+        cmd = [context.pip, "install", "-U", "kedro"]
+    else:
+        cmd = [context.pip, "install", "kedro=={}".format(version)]
+    res = run(cmd, env=context.env)
+
+    if res.returncode != OK_EXIT_CODE:
+        print(res.stdout)
+        print(res.stderr)
+        assert False
+
+
 @when('I execute the kedro jupyter command "{command}"')
 def exec_notebook(context, command):
     """Execute Kedro Jupyter target."""

--- a/package/features/viz.feature
+++ b/package/features/viz.feature
@@ -29,11 +29,16 @@
 
 Feature: Viz plugin in new project
 
-    Background:
-        Given I have prepared a config file with example code
+    Scenario: Execute viz with Kedro 0.15.0
+        Given I have installed kedro version "0.15.0"
+        And I have prepared a config file with example code
         And I have run a non-interactive kedro new
+        When I execute the kedro viz command "viz"
+        Then kedro-viz should start successfully
 
-
-    Scenario: Execute viz target
+    Scenario: Execute viz with latest Kedro
+        Given I have installed kedro version "latest"
+        And I have prepared a config file with example code
+        And I have run a non-interactive kedro new
         When I execute the kedro viz command "viz"
         Then kedro-viz should start successfully

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -3,5 +3,5 @@ python-dateutil==2.8.0 # explicit hard pin to resolve random pip dependency reso
 # botocore requires <2.8.1, whereas pandas requires >=2.6.0. Pip dependency resolution ramdomly
 # picks either and sometimes fails. This pinning needs to be removed later.
 Flask>=1.0, <2.0
-kedro>=0.14.0
+kedro>=0.15.0
 ipython>=7.0.0, <8.0


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Why was this PR created?

The line 
`catalog = get_project_context("create_catalog")(None)` introduced in https://github.com/quantumblacklabs/kedro-viz/commit/5cf85167bafa1a9f6fc51e6460560ec3a5cba9ad
does not work with Kedro<0.15.0, since `create_catalog(conf)` needs `conf` variable. 
Since 3.1.0 was already released, so I've pumped up the lower version of Kedro to be 0.15 rather than 0.14. 

To prevent this from happening in the future, I'm adding e2e-tests for pre/post modular pipelines in 0.15.*. 

## How has this been tested?
What testing strategies have you used?
e2e-tests

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
