### PR TITLE
Draft Pull Request: show data size in flow

### DIFF
--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -32,7 +32,30 @@ const draw = function() {
     .attr('class', 'edge')
     .attr('opacity', 0);
 
-  enterEdges.append('path').attr('marker-end', d => `url(#arrowhead)`);
+  enterEdges
+    .append('path') //.attr('marker-end', 'url(#arrowhead)')
+    .attr('id', edge => 'curve_' + edge.id);
+
+  // this.el.edges.exit();
+
+  const labelEdges = this.el.edges
+    .enter()
+    .append('text')
+    .attr('x', 0)
+    .attr('dy', -3.5)
+    .append('textPath')
+    .attr('font-weight', 'bold')
+    .attr('font-size', '8px')
+    .attr('text-anchor', 'middle')
+    .attr('startOffset', '50%')
+    .attr('xlink:href', edge => '#curve_' + edge.id)
+    .text(edge => {
+      for (let n = 0; n < nodes.length; n++) {
+        if (nodes[n].id === edge.target) {
+          return nodes[n].size ? nodes[n].size.toLocaleString() : '';
+        }
+      }
+    });
 
   this.el.edges
     .exit()
@@ -42,6 +65,7 @@ const draw = function() {
     .remove();
 
   this.el.edges = this.el.edges.merge(enterEdges);
+  this.el.edges = this.el.edges.merge(labelEdges);
 
   this.el.edges
     .attr('data-id', edge => edge.id)
@@ -59,6 +83,9 @@ const draw = function() {
     .transition('update-edges')
     .duration(this.DURATION)
     .attrTween('d', function(edge) {
+      if (edge.points[0].x > edge.points[2].x) {
+        edge.points.reverse();
+      }
       const current = edge.points && lineShape(edge.points);
       const previous = select(this).attr('d') || current;
       return interpolatePath(previous, current);
@@ -75,7 +102,7 @@ const draw = function() {
     .attr('transform', node => `translate(${node.x}, ${node.y})`)
     .attr('opacity', 0);
 
-  enterNodes.append('rect');
+  enterNodes.append('rect').classed('sized', node => !!node.size);
 
   enterNodes.append(icon);
 
@@ -125,10 +152,18 @@ const draw = function() {
 
   this.el.nodes
     .select('rect')
-    .attr('width', node => node.width - 5)
-    .attr('height', node => node.height - 5)
-    .attr('x', node => (node.width - 5) / -2)
-    .attr('y', node => (node.height - 5) / -2)
+    .attr('width', node =>
+      node.size ? Math.log(node.size) * 6 : node.width - 5
+    )
+    .attr('height', node =>
+      node.size ? Math.log(node.size) * 6 : node.height - 5
+    )
+    .attr('x', node =>
+      node.size ? Math.log(node.size) * -3 : (node.width - 5) / -2
+    )
+    .attr('y', node =>
+      node.size ? Math.log(node.size) * -3 : (node.height - 5) / -2
+    )
     .attr('rx', node => (node.type === 'task' ? 0 : node.height / 2));
 
   this.el.nodes

--- a/src/components/flowchart/styles/_node.scss
+++ b/src/components/flowchart/styles/_node.scss
@@ -22,6 +22,10 @@
     stroke-width: 1px;
     transition: all ease 0.1s;
 
+    &.sized {
+      rx: 50%;
+    }
+
     .kui-theme--light & {
       fill: $node-fill-light;
       stroke: $node-stroke-light;

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -4,6 +4,7 @@ import { getNodeActive, getVisibleNodes } from './nodes';
 import { getVisibleEdges } from './edges';
 
 const getNodeType = state => state.nodeType;
+const getNodeRadius = state => state.nodeRadius;
 const getChartSize = state => state.chartSize;
 
 /**
@@ -40,14 +41,15 @@ export const getGraph = createSelector(
  * and recombine with other data that doesn't affect layout
  */
 export const getLayoutNodes = createSelector(
-  [getGraph, getNodeType, getNodeActive],
-  (graph, nodeType, nodeActive) =>
+  [getGraph, getNodeType, getNodeActive, getNodeRadius],
+  (graph, nodeType, nodeActive, nodeRadius) =>
     graph.nodes().map(nodeID => {
       const node = graph.node(nodeID);
       return Object.assign({}, node, {
         type: nodeType[nodeID],
         order: node.x + node.y * 9999,
-        active: nodeActive[nodeID]
+        active: nodeActive[nodeID],
+        size: nodeRadius[nodeID]
       });
     })
 );

--- a/src/utils/format-data.js
+++ b/src/utils/format-data.js
@@ -28,6 +28,7 @@ const createPipelineState = () => ({
   nodeName: {},
   nodeFullName: {},
   nodeType: {},
+  nodeRadius: {},
   nodeIsParam: {},
   nodeTags: {},
   nodeDisabled: {},
@@ -61,6 +62,7 @@ const addNode = state => node => {
   state.nodeName[id] = node.name;
   state.nodeFullName[id] = node.full_name || node.name;
   state.nodeType[id] = node.type;
+  state.nodeRadius[id] = node.size;
   state.nodeIsParam[id] = node.type === 'parameters';
   state.nodeTags[id] = node.tags || [];
 };


### PR DESCRIPTION
## Show relative size of data in graph
How do you feel about proportional area or logarithmic circles?

![Screen Shot 2020-01-30 at 8 16 14 PM](https://user-images.githubusercontent.com/643918/73505019-4255c600-439f-11ea-813f-40ef1307d8a0.png)

I'm putting the number on a ```textPath```, and using a log scale because of the major differences in data size that I'm working on, but proportional circles (radius = Math.sqrt) could be a good toggle option.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Why was this PR created?

- Show if any graph steps are not being used due to logic or data error (0 rows)
- See relative sizes of labels / categories

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Assigned myself to the PR
- [ ] Added `Type` label to the PR
