### PR TITLE
Use mocker instead of mock in Python unit tests

### DIFF
--- a/package/.isort.cfg
+++ b/package/.isort.cfg
@@ -8,3 +8,4 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 known_third_party=behave
+known_first_party=kedro-viz

--- a/package/.isort.cfg
+++ b/package/.isort.cfg
@@ -8,4 +8,3 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 known_third_party=behave
-known_first_party=kedro-viz

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -30,7 +30,6 @@ Tests for Kedro-Viz server
 """
 
 import json
-from unittest import mock
 
 import pytest
 from kedro.context import KedroContextError
@@ -134,21 +133,18 @@ def create_pipeline():
     )
 
 
-def setup_function():
-    mock.patch("kedro_viz.server.webbrowser").start()
-    mock.patch("kedro_viz.server.app.run").start()
-
-
-def teardown_function():
-    mock.patch.stopall()
+@pytest.fixture(autouse=True)
+def start_app(mocker):
+    mocker.patch("kedro_viz.server.webbrowser")
+    mocker.patch("kedro_viz.server.app.run")
 
 
 @pytest.fixture
-def patched_get_project_context():
+def patched_get_project_context(mocker):
     def get_project_context(
         key: str = "context", **kwargs  # pylint: disable=bad-continuation
     ):  # pylint: disable=unused-argument
-        mocked_context = mock.Mock()
+        mocked_context = mocker.Mock()
         mocked_context._get_pipeline = get_pipeline  # pylint: disable=protected-access
         mocked_context.catalog = lambda x: None
         mocked_context.pipeline = create_pipeline()
@@ -158,7 +154,7 @@ def patched_get_project_context():
             "context": mocked_context,
         }[key]
 
-    mock.patch("kedro_viz.server.get_project_context", new=get_project_context).start()
+    mocker.patch("kedro_viz.server.get_project_context", new=get_project_context)
 
 
 @pytest.fixture
@@ -278,50 +274,48 @@ def test_pipeline_flag_non_existent(cli_runner):
     assert "Failed to find the pipeline." in result.output
 
 
-@mock.patch("kedro.__version__", "0.15.0")
-def test_viz_kedro15(cli_runner):
+def test_viz_kedro15(mocker, cli_runner):
     """Test that running viz in Kedro 0.15.0."""
+    mocker.patch("kedro.__version__", "0.15.0")
 
     def get_project_context(
         key: str = "context", **kwargs  # pylint: disable=bad-continuation
     ):  # pylint: disable=unused-argument
-        mocked_context = mock.Mock()
+        mocked_context = mocker.Mock()
         mocked_context.pipeline = create_pipeline()
         return {"context": mocked_context}[key]
 
-    mock.patch("kedro_viz.server.get_project_context", new=get_project_context).start()
+    mocker.patch("kedro_viz.server.get_project_context", new=get_project_context)
     result = cli_runner.invoke(server.commands, "viz")
     assert result.exit_code == 0, result.output
 
 
-@mock.patch("kedro.__version__", "0.15.0")
-def test_viz_kedro15_pipeline_flag(cli_runner):
+def test_viz_kedro15_pipeline_flag(mocker, cli_runner):
     """Test that running viz with `--pipeline` flag in Kedro 0.15.0."""
+    mocker.patch("kedro.__version__", "0.15.0")
 
     def get_project_context(
         key: str = "context", **kwargs  # pylint: disable=bad-continuation
     ):  # pylint: disable=unused-argument
-        return {"context": mock.Mock()}[key]
+        return {"context": mocker.Mock()}[key]
 
-    mock.patch("kedro_viz.server.get_project_context", new=get_project_context).start()
+    mocker.patch("kedro_viz.server.get_project_context", new=get_project_context)
     result = cli_runner.invoke(server.commands, ["viz", "--pipeline", "another"])
     assert "`--pipeline` flag was provided" in result.output
 
 
-@mock.patch("kedro.__version__", "0.15.0")
-def test_viz_kedro15_invalid(cli_runner):
+def test_viz_kedro15_invalid(mocker, cli_runner):
     """Test that running viz in Kedro 0.15.0,
     and it is outside of a Kedro project root."""
-    mock.patch(
-        "kedro_viz.server.get_project_context", side_effect=KedroContextError
-    ).start()
+    mocker.patch("kedro.__version__", "0.15.0")
+    mocker.patch("kedro_viz.server.get_project_context", side_effect=KedroContextError)
     result = cli_runner.invoke(server.commands, "viz")
     assert "Could not find a Kedro project root." in result.output
 
 
-@mock.patch("kedro.__version__", "0.14.0")
-def test_viz_kedro14(cli_runner):
+def test_viz_kedro14(mocker, cli_runner):
     """Test that running viz in Kedro 0.14.0."""
+    mocker.patch("kedro.__version__", "0.14.0")
 
     def create_catalog(config):  # pylint: disable=unused-argument,bad-continuation
         return lambda x: None
@@ -338,14 +332,14 @@ def test_viz_kedro14(cli_runner):
             "get_config": get_config,
         }[key]
 
-    mock.patch("kedro_viz.server.get_project_context", new=get_project_context).start()
+    mocker.patch("kedro_viz.server.get_project_context", new=get_project_context)
     result = cli_runner.invoke(server.commands, "viz")
     assert result.exit_code == 0, result.output
 
 
-@mock.patch("kedro.__version__", "0.14.0")
-def test_viz_kedro14_pipeline_flag(cli_runner):
+def test_viz_kedro14_pipeline_flag(mocker, cli_runner):
     """Test that running viz with `--pipeline` flag in Kedro 0.14.0 is not supported."""
+    mocker.patch("kedro.__version__", "0.14.0")
 
     def create_catalog(config):  # pylint: disable=unused-argument,bad-continuation
         return lambda x: None
@@ -362,16 +356,16 @@ def test_viz_kedro14_pipeline_flag(cli_runner):
             "get_config": get_config,
         }[key]
 
-    mock.patch("kedro_viz.server.get_project_context", new=get_project_context).start()
+    mocker.patch("kedro_viz.server.get_project_context", new=get_project_context)
     result = cli_runner.invoke(server.commands, ["viz", "--pipeline", "another"])
     assert "`--pipeline` flag was provided" in result.output
 
 
-@mock.patch("kedro.__version__", "0.14.0")
-def test_viz_kedro14_invalid(cli_runner):
+def test_viz_kedro14_invalid(mocker, cli_runner):
     """Test that running viz in Kedro 0.14.0,
     while outside of a Kedro project is not supported."""
-    mock.patch("kedro_viz.server.get_project_context", side_effect=KeyError).start()
+    mocker.patch("kedro.__version__", "0.14.0")
+    mocker.patch("kedro_viz.server.get_project_context", side_effect=KeyError)
     result = cli_runner.invoke(server.commands, "viz")
     assert "Could not find a Kedro project root." in result.output
 

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -134,7 +134,7 @@ def create_pipeline():
 
 
 @pytest.fixture(autouse=True)
-def start_app(mocker):
+def start_server(mocker):
     mocker.patch("kedro_viz.server.webbrowser")
     mocker.patch("kedro_viz.server.app.run")
 


### PR DESCRIPTION
## Description

Refactored the Python unit tests to use mocker for consistency. No functionality has changed. 

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
