### PR TITLE
[KED-1355] Dynamic port allocation for Viz process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,6 @@ jobs:
   build_35: &DEFAULT
     docker:
       - image: circleci/node:10.15
-    resource_class: medium+
     working_directory: ~/repo
     environment:
       CONDA_ENV_PY_VERSION: '3.5'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ jobs:
   build_35: &DEFAULT
     docker:
       - image: circleci/node:10.15
+    resource_class: medium+
     working_directory: ~/repo
     environment:
       CONDA_ENV_PY_VERSION: '3.5'

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ e2e-tests: build
 pylint:
 	cd package && isort
 	pylint -j 0 --disable=bad-continuation,unnecessary-pass package/kedro_viz
-	pylint -j 0 --disable=missing-docstring,redefined-outer-name,no-self-use,invalid-name,too-few-public-methods,no-member package/tests
+	pylint -j 0 --disable=bad-continuation,missing-docstring,redefined-outer-name,no-self-use,invalid-name,too-few-public-methods,no-member package/tests
 	pylint -j 0 --disable=missing-docstring,no-name-in-module package/features
 	flake8 package
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes and other changes
 - Fixed the backward-compatibility with Kedro 0.14.* (#93)
+- `%run_viz` magic now dynamically allocates the first available port to Viz process starting from 4141 (#109)
 
 # Release 3.1.0:
 

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -454,13 +454,63 @@ class TestRunViz:
         assert not server._check_viz_up(8888)  # pylint: disable=protected-access
 
 
-@pytest.mark.parametrize(
-    "kwargs", [{"start_at": 5, "end_at": 4}, {"start_at": 65536}, {"start_at": 4141}]
-)
-def test_allocate_port_error(kwargs, mocker):
-    mock_socket = mocker.patch("socket.socket")
-    mock_socket.return_value.connect_ex.return_value = 0
+class TestAllocatePort:
+    @pytest.mark.parametrize(
+        "viz_processes,kwargs,expected_port",
+        [
+            ([4321], {"start_at": 4141}, 4321),
+            ([4140, 4141], {"start_at": 4140}, 4140),
+            ([4140, 4141], {"start_at": 4141}, 4141),
+            ([4140], {"start_at": 4141}, 4141),
+            ([4140, 4141], {"start_at": 1, "end_at": 4141}, 4140),
+            ([4140, 4141], {"start_at": 4141, "end_at": 4141}, 4141),
+            ([65535], {"start_at": 1}, 65535),
+        ],
+    )
+    def test_allocate_from_viz_processes(
+        self, mocker, viz_processes, kwargs, expected_port
+    ):
+        """Test allocation of the port from the one that was already captured
+        in _VIZ_PROCESSES"""
+        mocker.patch.dict(
+            "kedro_viz.server._VIZ_PROCESSES", {k: None for k in viz_processes}
+        )
 
-    pattern = "Cannot allocate an open TCP port for Kedro-Viz"
-    with pytest.raises(ValueError, match=re.escape(pattern)):
-        _allocate_port(**kwargs)
+        allocated_port = _allocate_port(**kwargs)
+        assert allocated_port == expected_port
+
+    @pytest.mark.parametrize(
+        "kwargs,expected_port",
+        [
+            ({"start_at": 4141}, 4142),
+            ({"start_at": 80}, 80),
+            ({"start_at": 82, "end_at": 82}, 82),
+            ({"start_at": 83, "end_at": 84}, 84),
+        ],
+    )
+    def test_allocate_from_available_ports(self, mocker, kwargs, expected_port):
+        """Test allocation of one of unoccupied ports"""
+
+        def _mock_even_port_available(host_and_port):
+            # Mock availability of every even port number
+            port = host_and_port[1]
+            return 1 - port % 2
+
+        mock_socket = mocker.patch("socket.socket")
+        mock_socket.return_value.connect_ex.side_effect = _mock_even_port_available
+
+        allocated_port = _allocate_port(**kwargs)
+        assert allocated_port == expected_port
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{"start_at": 5, "end_at": 4}, {"start_at": 65536}, {"start_at": 4141}],
+    )
+    def test_allocation_error(self, kwargs, mocker):
+        """Test an error when no TCP port can be allocated from the given range"""
+        mock_socket = mocker.patch("socket.socket")
+        mock_socket.return_value.connect_ex.return_value = 0  # any port is unavailable
+
+        pattern = "Cannot allocate an open TCP port for Kedro-Viz"
+        with pytest.raises(ValueError, match=re.escape(pattern)):
+            _allocate_port(**kwargs)


### PR DESCRIPTION
## Description

Dynamically allocate the port number for Viz subprocess created by `%run_viz`

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

Unit test for dynamic port allocation

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [ ] Added `Type` label to the PR
