### PR TITLE
Fix secretscan by pinning gitdb2

### DIFF
--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -10,3 +10,4 @@ requests-mock>=1.6.0, <2.0
 flake8>=3.5, <4.0
 isort
 trufflehog>=2.0.99, <3.0
+gitdb2==2.0.6

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -10,4 +10,4 @@ requests-mock>=1.6.0, <2.0
 flake8>=3.5, <4.0
 isort
 trufflehog>=2.0.99, <3.0
-gitdb2==2.0.6
+gitdb2==2.0.6 # pinned trufflehog dependency to make trufflehog work again


### PR DESCRIPTION
## Description

Fix failing secretscan trufflehog circleci step

## Development notes

Pinned gitdb2 to last working version. Looks like it updated itself and broke something trufflehog relied on.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
