### PR TITLE
[KED-1318] Refactor reducers

### DIFF
--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -3,7 +3,8 @@ import $ from 'cheerio';
 import FlowChart, { mapStateToProps, mapDispatchToProps } from './index';
 import { mockState, setup } from '../../utils/state.mock';
 
-const getNodes = state => state.nodes;
+const getNodeIDs = state => state.node.ids;
+const getNodeName = state => state.node.name;
 
 describe('FlowChart', () => {
   it('renders without crashing', () => {
@@ -16,8 +17,8 @@ describe('FlowChart', () => {
     const wrapper = setup.mount(<FlowChart />);
     const nodes = wrapper.render().find('.node');
     const nodeNames = nodes.map((i, el) => $(el).text()).get();
-    const mockNodes = getNodes(mockState.lorem);
-    const mockNodeNames = mockNodes.map(d => mockState.lorem.nodeName[d]);
+    const mockNodes = getNodeIDs(mockState.lorem);
+    const mockNodeNames = mockNodes.map(d => getNodeName(mockState.lorem)[d]);
     expect(nodes.length).toEqual(mockNodes.length);
     expect(nodeNames.sort()).toEqual(mockNodeNames.sort());
   });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,98 +1,59 @@
+import { combineReducers } from 'redux';
+import node from './nodes';
+import tag from './tags';
+import nodeType from './node-type';
 import {
   RESET_DATA,
-  TOGGLE_NODE_CLICKED,
-  TOGGLE_NODES_DISABLED,
-  TOGGLE_NODE_HOVERED,
-  TOGGLE_TAG_ACTIVE,
-  TOGGLE_TAG_FILTER,
   TOGGLE_TEXT_LABELS,
   TOGGLE_THEME,
-  TOGGLE_TYPE_DISABLED,
   UPDATE_CHART_SIZE,
   UPDATE_FONT_LOADED
 } from '../actions';
 
-function reducer(state = {}, action) {
-  const updateState = newState => Object.assign({}, state, newState);
-
-  switch (action.type) {
-    case RESET_DATA:
-      return updateState(action.data);
-
-    case TOGGLE_NODE_CLICKED: {
-      return updateState({
-        nodeClicked: action.nodeClicked
-      });
-    }
-
-    case TOGGLE_NODES_DISABLED: {
-      return updateState({
-        nodeDisabled: action.nodeIDs.reduce(
-          (nodeDisabled, id) =>
-            Object.assign({}, nodeDisabled, {
-              [id]: action.isDisabled
-            }),
-          state.nodeDisabled
-        )
-      });
-    }
-
-    case TOGGLE_NODE_HOVERED: {
-      return updateState({
-        nodeHovered: action.nodeHovered
-      });
-    }
-
-    case TOGGLE_TEXT_LABELS:
-      return updateState({
-        textLabels: action.textLabels
-      });
-
-    case TOGGLE_TAG_ACTIVE: {
-      return updateState({
-        tagActive: Object.assign({}, state.tagActive, {
-          [action.tagID]: action.active
-        })
-      });
-    }
-
-    case TOGGLE_TAG_FILTER: {
-      return updateState({
-        tagEnabled: Object.assign({}, state.tagEnabled, {
-          [action.tagID]: action.enabled
-        })
-      });
-    }
-
-    case TOGGLE_THEME: {
-      return updateState({
-        theme: action.theme
-      });
-    }
-
-    case TOGGLE_TYPE_DISABLED: {
-      return updateState({
-        typeDisabled: Object.assign({}, state.typeDisabled, {
-          [action.typeID]: action.disabled
-        })
-      });
-    }
-
-    case UPDATE_CHART_SIZE: {
-      return updateState({
-        chartSize: action.chartSize
-      });
-    }
-
-    case UPDATE_FONT_LOADED: {
-      return updateState({
-        fontLoaded: action.fontLoaded
-      });
-    }
-
-    default:
-      return state;
+/**
+ * Create a generic reducer
+ * @param {string} type Action type
+ * @param {string} key Action payload key
+ * @param {*} initialState Default state
+ * @return {*} Updated state
+ */
+const createReducer = (type, key, initialState) => (
+  state = initialState,
+  action
+) => {
+  if (action.type === type) {
+    return action[key];
   }
+  return state;
+};
+
+/**
+ * Reset/update application-wide data
+ * @param {Object} state Complete app state
+ * @param {Object} action Redux action
+ * @return {Object} Updated(?) state
+ */
+function resetDataReducer(state = {}, action) {
+  if (action.type === RESET_DATA) {
+    return Object.assign({}, state, action.data);
+  }
+  return state;
 }
 
-export default reducer;
+const combinedReducer = combineReducers({
+  id: (state = null) => state,
+  edge: (state = {}) => state,
+  visible: (state = {}) => state,
+  chartSize: createReducer(UPDATE_CHART_SIZE, 'chartSize', {}),
+  fontLoaded: createReducer(UPDATE_FONT_LOADED, 'fontLoaded', false),
+  node,
+  nodeType,
+  tag,
+  textLabels: createReducer(TOGGLE_TEXT_LABELS, 'textLabels', true),
+  theme: createReducer(TOGGLE_THEME, 'theme', 'dark')
+});
+
+const rootReducer = (state, action) =>
+  resetDataReducer(combinedReducer(state, action), action);
+
+export default rootReducer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -41,14 +41,14 @@ function resetDataReducer(state = {}, action) {
 }
 
 const combinedReducer = combineReducers({
-  id: (state = null) => state,
-  edge: (state = {}) => state,
-  visible: (state = {}) => state,
-  chartSize: createReducer(UPDATE_CHART_SIZE, 'chartSize', {}),
-  fontLoaded: createReducer(UPDATE_FONT_LOADED, 'fontLoaded', false),
   node,
   nodeType,
   tag,
+  edge: (state = {}) => state,
+  id: (state = null) => state,
+  visible: (state = {}) => state,
+  chartSize: createReducer(UPDATE_CHART_SIZE, 'chartSize', {}),
+  fontLoaded: createReducer(UPDATE_FONT_LOADED, 'fontLoaded', false),
   textLabels: createReducer(TOGGLE_TEXT_LABELS, 'textLabels', true),
   theme: createReducer(TOGGLE_THEME, 'theme', 'dark')
 });

--- a/src/reducers/node-type.js
+++ b/src/reducers/node-type.js
@@ -1,0 +1,17 @@
+import { TOGGLE_TYPE_DISABLED } from '../actions';
+
+function nodeTypeReducer(nodeTypeState = {}, action) {
+  switch (action.type) {
+    case TOGGLE_TYPE_DISABLED: {
+      return Object.assign({}, nodeTypeState, {
+        disabled: Object.assign({}, nodeTypeState.disabled, {
+          [action.typeID]: action.disabled
+        })
+      });
+    }
+    default:
+      return nodeTypeState;
+  }
+}
+
+export default nodeTypeReducer;

--- a/src/reducers/nodes.js
+++ b/src/reducers/nodes.js
@@ -1,0 +1,40 @@
+import {
+  TOGGLE_NODE_CLICKED,
+  TOGGLE_NODES_DISABLED,
+  TOGGLE_NODE_HOVERED
+} from '../actions';
+
+function nodeReducer(nodeState = {}, action) {
+  const updateState = newState => Object.assign({}, nodeState, newState);
+
+  switch (action.type) {
+    case TOGGLE_NODE_CLICKED: {
+      return updateState({
+        clicked: action.nodeClicked
+      });
+    }
+
+    case TOGGLE_NODES_DISABLED: {
+      return updateState({
+        disabled: action.nodeIDs.reduce(
+          (disabled, id) =>
+            Object.assign({}, disabled, {
+              [id]: action.isDisabled
+            }),
+          nodeState.disabled
+        )
+      });
+    }
+
+    case TOGGLE_NODE_HOVERED: {
+      return updateState({
+        hovered: action.nodeHovered
+      });
+    }
+
+    default:
+      return nodeState;
+  }
+}
+
+export default nodeReducer;

--- a/src/reducers/reducers.test.js
+++ b/src/reducers/reducers.test.js
@@ -6,8 +6,8 @@ import * as action from '../actions';
 import normalizeData from '../store/normalize-data';
 
 describe('Reducer', () => {
-  it('should return the initial state', () => {
-    expect(reducer(undefined, {})).toEqual({});
+  it('should return an Object', () => {
+    expect(reducer(undefined, {})).toEqual(expect.any(Object));
   });
 
   describe('RESET_DATA', () => {
@@ -36,7 +36,7 @@ describe('Reducer', () => {
         type: action.TOGGLE_NODE_CLICKED,
         nodeClicked
       });
-      expect(newState.nodeClicked).toEqual(nodeClicked);
+      expect(newState.node.clicked).toEqual(nodeClicked);
     });
   });
 
@@ -47,7 +47,7 @@ describe('Reducer', () => {
         type: action.TOGGLE_NODE_HOVERED,
         nodeHovered
       });
-      expect(newState.nodeHovered).toEqual(nodeHovered);
+      expect(newState.node.hovered).toEqual(nodeHovered);
     });
   });
 
@@ -58,7 +58,7 @@ describe('Reducer', () => {
         nodeIDs: ['123', 'abc'],
         isDisabled: true
       });
-      expect(newState.nodeDisabled).toEqual({ '123': true, abc: true });
+      expect(newState.node.disabled).toEqual({ '123': true, abc: true });
     });
   });
 
@@ -80,7 +80,7 @@ describe('Reducer', () => {
         tagID: 'huge',
         active: true
       });
-      expect(newState.tagActive).toEqual({ huge: true });
+      expect(newState.tag.active).toEqual({ huge: true });
     });
   });
 
@@ -91,7 +91,7 @@ describe('Reducer', () => {
         tagID: 'small',
         enabled: true
       });
-      expect(newState.tagEnabled).toEqual({ small: true });
+      expect(newState.tag.enabled).toEqual({ small: true });
     });
   });
 
@@ -112,7 +112,7 @@ describe('Reducer', () => {
         typeID: '123',
         disabled: true
       });
-      expect(newState.typeDisabled).toEqual({ 123: true });
+      expect(newState.nodeType.disabled).toEqual({ 123: true });
     });
   });
 

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -6,7 +6,7 @@ function tagReducer(tagState = {}, action) {
   switch (action.type) {
     case TOGGLE_TAG_ACTIVE: {
       return updateState({
-        tagActive: Object.assign({}, tagState.tagActive, {
+        active: Object.assign({}, tagState.active, {
           [action.tagID]: action.active
         })
       });
@@ -14,7 +14,7 @@ function tagReducer(tagState = {}, action) {
 
     case TOGGLE_TAG_FILTER: {
       return updateState({
-        tagEnabled: Object.assign({}, tagState.tagEnabled, {
+        enabled: Object.assign({}, tagState.enabled, {
           [action.tagID]: action.enabled
         })
       });

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -1,0 +1,28 @@
+import { TOGGLE_TAG_ACTIVE, TOGGLE_TAG_FILTER } from '../actions';
+
+function tagReducer(tagState = {}, action) {
+  const updateState = newState => Object.assign({}, tagState, newState);
+
+  switch (action.type) {
+    case TOGGLE_TAG_ACTIVE: {
+      return updateState({
+        tagActive: Object.assign({}, tagState.tagActive, {
+          [action.tagID]: action.active
+        })
+      });
+    }
+
+    case TOGGLE_TAG_FILTER: {
+      return updateState({
+        tagEnabled: Object.assign({}, tagState.tagEnabled, {
+          [action.tagID]: action.enabled
+        })
+      });
+    }
+
+    default:
+      return tagState;
+  }
+}
+
+export default tagReducer;

--- a/src/selectors/edges.js
+++ b/src/selectors/edges.js
@@ -72,14 +72,17 @@ export const getTransitiveEdges = createSelector(
       });
     };
 
-    // Examine the children of every enabled node. The walk only needs
-    // to be run in a single direction (i.e. top down), because links
-    // that end in a terminus can never be transitive.
-    nodeIDs.forEach(nodeID => {
-      if (!nodeDisabled[nodeID]) {
-        walkGraphEdges([nodeID]);
-      }
-    });
+    // Only run walk if some nodes are disabled
+    if (nodeIDs.some(nodeID => nodeDisabled[nodeID])) {
+      // Examine the children of every enabled node. The walk only needs
+      // to be run in a single direction (i.e. top down), because links
+      // that end in a terminus can never be transitive.
+      nodeIDs.forEach(nodeID => {
+        if (!nodeDisabled[nodeID]) {
+          walkGraphEdges([nodeID]);
+        }
+      });
+    }
 
     return transitiveEdges;
   }

--- a/src/selectors/edges.js
+++ b/src/selectors/edges.js
@@ -2,16 +2,16 @@ import { createSelector } from 'reselect';
 import { arrayToObject } from '../utils';
 import { getNodeDisabled } from './nodes';
 
-const getNodes = state => state.nodes;
-const getEdges = state => state.edges;
-const getEdgeSources = state => state.edgeSources;
-const getEdgeTargets = state => state.edgeTargets;
+const getNodeIDs = state => state.node.ids;
+const getEdgeIDs = state => state.edge.ids;
+const getEdgeSources = state => state.edge.sources;
+const getEdgeTargets = state => state.edge.targets;
 
 /**
  * Calculate whether edges should be disabled based on their source/target nodes
  */
 export const getEdgeDisabledNode = createSelector(
-  [getEdges, getNodeDisabled, getEdgeSources, getEdgeTargets],
+  [getEdgeIDs, getNodeDisabled, getEdgeSources, getEdgeTargets],
   (edges, nodeDisabled, edgeSources, edgeTargets) =>
     arrayToObject(edges, edgeID => {
       const source = edgeSources[edgeID];
@@ -24,7 +24,7 @@ export const getEdgeDisabledNode = createSelector(
  * Determine whether an edge should be disabled
  */
 export const getEdgeDisabled = createSelector(
-  [getEdges, getEdgeDisabledNode],
+  [getEdgeIDs, getEdgeDisabledNode],
   (edges, edgeDisabledNode) =>
     arrayToObject(edges, edgeID => Boolean(edgeDisabledNode[edgeID]))
 );
@@ -87,7 +87,7 @@ export const findTransitiveEdges = (
  * in between them
  */
 export const getTransitiveEdges = createSelector(
-  [getNodes, getEdges, getNodeDisabled, getEdgeSources, getEdgeTargets],
+  [getNodeIDs, getEdgeIDs, getNodeDisabled, getEdgeSources, getEdgeTargets],
   (nodes, edges, nodeDisabled, edgeSources, edgeTargets) => {
     const transitiveEdges = {
       edgeIDs: [],
@@ -116,7 +116,7 @@ export const getTransitiveEdges = createSelector(
  */
 export const getVisibleEdges = createSelector(
   [
-    getEdges,
+    getEdgeIDs,
     getEdgeDisabled,
     getEdgeSources,
     getEdgeTargets,

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -3,7 +3,7 @@ import dagre from 'dagre';
 import { getNodeActive, getVisibleNodes } from './nodes';
 import { getVisibleEdges } from './edges';
 
-const getNodeType = state => state.nodeType;
+const getNodeType = state => state.node.type;
 const getChartSize = state => state.chartSize;
 
 /**

--- a/src/selectors/linked-nodes.js
+++ b/src/selectors/linked-nodes.js
@@ -1,10 +1,10 @@
 import { createSelector } from 'reselect';
 
-const getEdges = state => state.edges;
-const getEdgeSources = state => state.edgeSources;
-const getEdgeTargets = state => state.edgeTargets;
-const getClickedNode = state => state.nodeClicked;
-const getHoveredNode = state => state.nodeHovered;
+const getEdgeIDs = state => state.edge.ids;
+const getEdgeSources = state => state.edge.sources;
+const getEdgeTargets = state => state.edge.targets;
+const getClickedNode = state => state.node.clicked;
+const getHoveredNode = state => state.node.hovered;
 
 /**
  * Get the node that should be used as the center of the set of linked nodes
@@ -22,7 +22,7 @@ export const getCentralNode = createSelector(
  * @param {string} nodeID
  */
 export const getLinkedNodes = createSelector(
-  [getEdges, getEdgeSources, getEdgeTargets, getCentralNode],
+  [getEdgeIDs, getEdgeSources, getEdgeTargets, getCentralNode],
   (edges, edgeSources, edgeTargets, nodeID) => {
     if (!nodeID) {
       return {};

--- a/src/selectors/node-types.js
+++ b/src/selectors/node-types.js
@@ -1,14 +1,14 @@
 import { createSelector } from 'reselect';
 
-const getTypes = state => state.types;
-const getTypeName = state => state.typeName;
-const getTypeDisabled = state => state.typeDisabled;
+const getNodeTypeIDs = state => state.nodeType.ids;
+const getNodeTypeName = state => state.nodeType.name;
+const getNodeTypeDisabled = state => state.nodeType.disabled;
 
 /**
  * Get formatted list of node type objects
  */
 export const getNodeTypes = createSelector(
-  [getTypes, getTypeName, getTypeDisabled],
+  [getNodeTypeIDs, getNodeTypeName, getNodeTypeDisabled],
   (types, typeName, typeDisabled) =>
     types.map(id => ({
       id,

--- a/src/selectors/nodes.test.js
+++ b/src/selectors/nodes.test.js
@@ -18,7 +18,10 @@ import {
 } from '../actions';
 import reducer from '../reducers';
 
-const getNodes = state => state.nodes;
+const getNodeIDs = state => state.node.ids;
+const getNodeName = state => state.node.name;
+const getNodeTags = state => state.node.tags;
+const getNodeType = state => state.node.type;
 
 describe('Selectors', () => {
   describe('getNodeDisabledTag', () => {
@@ -28,7 +31,7 @@ describe('Selectors', () => {
 
     it("returns an object whose keys match the current pipeline's nodes", () => {
       expect(Object.keys(getNodeDisabledTag(mockState.lorem))).toEqual(
-        getNodes(mockState.lorem)
+        getNodeIDs(mockState.lorem)
       );
     });
 
@@ -48,10 +51,10 @@ describe('Selectors', () => {
     });
 
     it('disables a node only if all of its tags are disabled', () => {
-      const { nodeTags } = mockState.animals;
+      const nodeTags = getNodeTags(mockState.animals);
       // Get list of task nodes from the current pipeline
-      const taskNodes = getNodes(mockState.animals).filter(
-        id => mockState.animals.nodeType[id] === 'task'
+      const taskNodes = getNodeIDs(mockState.animals).filter(
+        id => getNodeType(mockState.animals)[id] === 'task'
       );
       // Choose a node that has some tags (and which should be enabled)
       const hasTags = id => Boolean(nodeTags[id].length);
@@ -77,7 +80,7 @@ describe('Selectors', () => {
 
     it("returns an object whose keys match the current pipeline's nodes", () => {
       expect(Object.keys(getNodeDisabled(mockState.lorem))).toEqual(
-        getNodes(mockState.lorem)
+        getNodeIDs(mockState.lorem)
       );
     });
 
@@ -97,7 +100,7 @@ describe('Selectors', () => {
 
     it("returns an object whose keys match the current pipeline's nodes", () => {
       expect(Object.keys(getNodeActive(mockState.lorem))).toEqual(
-        getNodes(mockState.lorem)
+        getNodeIDs(mockState.lorem)
       );
     });
 
@@ -110,7 +113,7 @@ describe('Selectors', () => {
     });
 
     it('returns true when a given node is clicked', () => {
-      const nodes = getNodes(mockState.lorem);
+      const nodes = getNodeIDs(mockState.lorem);
       const nodeID = nodes[0];
       const inactiveNodes = nodes.filter(id => id !== nodeID);
       const newMockState = reducer(mockState.lorem, toggleNodeClicked(nodeID));
@@ -120,7 +123,7 @@ describe('Selectors', () => {
     });
 
     it('returns true when a given node is hovered', () => {
-      const nodes = getNodes(mockState.lorem);
+      const nodes = getNodeIDs(mockState.lorem);
       const nodeID = nodes[0];
       const inactiveNodes = nodes.filter(id => id !== nodeID);
       const newMockState = reducer(mockState.lorem, toggleNodeHovered(nodeID));
@@ -148,9 +151,9 @@ describe('Selectors', () => {
     });
 
     it('returns nodes sorted by name', () => {
-      const { nodeName } = mockState.lorem;
+      const nodeName = getNodeName(mockState.lorem);
       const nodeIDs = getNodeData(mockState.lorem).map(d => d.id);
-      const activeNodeIDs = getNodes(mockState.lorem).sort((a, b) => {
+      const activeNodeIDs = getNodeIDs(mockState.lorem).sort((a, b) => {
         if (nodeName[a] < nodeName[b]) return -1;
         if (nodeName[a] > nodeName[b]) return 1;
         return 0;
@@ -277,7 +280,7 @@ describe('Selectors', () => {
     });
 
     it('returns only visible nodes', () => {
-      const nodes = getNodes(mockState.lorem);
+      const nodes = getNodeIDs(mockState.lorem);
       const nodeID = nodes[0];
       const newMockState = reducer(
         mockState.lorem,

--- a/src/selectors/tags.js
+++ b/src/selectors/tags.js
@@ -7,13 +7,11 @@ const getTagEnabled = state => state.tag.enabled;
 
 /**
  * Retrieve the formatted list of tag filters
- * @param {Object} tags Active pipeline tag data
- * @return {Array} Tag data list
  */
 export const getTagData = createSelector(
   [getTagIDs, getTagName, getTagActive, getTagEnabled],
-  (tags, tagName, tagActive, tagEnabled) =>
-    tags.sort().map(id => ({
+  (tagIDs, tagName, tagActive, tagEnabled) =>
+    tagIDs.sort().map(id => ({
       id,
       name: tagName[id],
       active: Boolean(tagActive[id]),
@@ -23,13 +21,11 @@ export const getTagData = createSelector(
 
 /**
  * Get the total and enabled number of tags
- * @param {Array} tags List of tag objects
- * @return {Object} total / enabled tags
  */
 export const getTagCount = createSelector(
   [getTagIDs, getTagEnabled],
-  (tags, tagEnabled) => ({
-    total: tags.length,
-    enabled: tags.filter(id => tagEnabled[id]).length
+  (tagIDs, tagEnabled) => ({
+    total: tagIDs.length,
+    enabled: tagIDs.filter(id => tagEnabled[id]).length
   })
 );

--- a/src/selectors/tags.js
+++ b/src/selectors/tags.js
@@ -1,9 +1,9 @@
 import { createSelector } from 'reselect';
 
-const getTags = state => state.tags;
-const getTagName = state => state.tagName;
-const getTagActive = state => state.tagActive;
-const getTagEnabled = state => state.tagEnabled;
+const getTagIDs = state => state.tag.ids;
+const getTagName = state => state.tag.name;
+const getTagActive = state => state.tag.active;
+const getTagEnabled = state => state.tag.enabled;
 
 /**
  * Retrieve the formatted list of tag filters
@@ -11,7 +11,7 @@ const getTagEnabled = state => state.tagEnabled;
  * @return {Array} Tag data list
  */
 export const getTagData = createSelector(
-  [getTags, getTagName, getTagActive, getTagEnabled],
+  [getTagIDs, getTagName, getTagActive, getTagEnabled],
   (tags, tagName, tagActive, tagEnabled) =>
     tags.sort().map(id => ({
       id,
@@ -27,7 +27,7 @@ export const getTagData = createSelector(
  * @return {Object} total / enabled tags
  */
 export const getTagCount = createSelector(
-  [getTags, getTagEnabled],
+  [getTagIDs, getTagEnabled],
   (tags, tagEnabled) => ({
     total: tags.length,
     enabled: tags.filter(id => tagEnabled[id]).length

--- a/src/selectors/tags.test.js
+++ b/src/selectors/tags.test.js
@@ -3,8 +3,8 @@ import { getTagData, getTagCount } from './tags';
 import { toggleTagFilter } from '../actions';
 import reducer from '../reducers';
 
-const getTags = state => state.tags;
-const tags = getTags(mockState.lorem);
+const getTagIDs = state => state.tag.ids;
+const tagIDs = getTagIDs(mockState.lorem);
 const tagData = getTagData(mockState.lorem);
 
 describe('Selectors', () => {
@@ -23,21 +23,21 @@ describe('Selectors', () => {
     });
 
     it('retrieves a list of tags sorted by ID name', () => {
-      expect(tagData.map(d => d.id)).toEqual(tags.sort());
+      expect(tagData.map(d => d.id)).toEqual(tagIDs.sort());
     });
   });
 
   describe('getTagCount', () => {
     const newMockState = reducer(
       mockState.lorem,
-      toggleTagFilter(tags[0], true)
+      toggleTagFilter(tagIDs[0], true)
     );
 
     it('retrieves the total and enabled number of tags', () => {
       expect(getTagCount(mockState.lorem)).toEqual(
         expect.objectContaining({
           enabled: 0,
-          total: tags.length
+          total: tagIDs.length
         })
       );
     });
@@ -46,7 +46,7 @@ describe('Selectors', () => {
       expect(getTagCount(newMockState)).toEqual(
         expect.objectContaining({
           enabled: 1,
-          total: tags.length
+          total: tagIDs.length
         })
       );
     });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -11,8 +11,8 @@ export default function configureStore(initialState) {
   const store = createStore(reducer, initialState);
 
   store.subscribe(() => {
-    const { textLabels, theme, typeDisabled } = store.getState();
-    saveState({ textLabels, theme, typeDisabled });
+    const { textLabels, theme, nodeType } = store.getState();
+    saveState({ textLabels, theme, nodeTypeDisabled: nodeType.disabled });
   });
 
   return store;

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -43,35 +43,39 @@ export const getPipelineData = data => {
  */
 export const getInitialPipelineState = () => ({
   id: null,
-  // Nodes
-  nodes: [],
-  nodeName: {},
-  nodeFullName: {},
-  nodeType: {},
-  nodeIsParam: {},
-  nodeTags: {},
-  nodeDisabled: {},
-  nodeClicked: null,
-  nodeHovered: null,
-  // Edges
-  edges: [],
-  edgeSources: {},
-  edgeTargets: {},
-  edgeActive: {},
-  edgeDisabled: {},
-  // Tags
-  tags: [],
-  tagName: {},
-  tagActive: {},
-  tagEnabled: {},
-  // Node types
-  types: ['task', 'data', 'parameters'],
-  typeName: {
-    data: 'Datasets',
-    task: 'Nodes',
-    parameters: 'Parameters'
+  node: {
+    ids: [],
+    name: {},
+    fullName: {},
+    type: {},
+    isParam: {},
+    tags: {},
+    disabled: {},
+    clicked: null,
+    hovered: null
   },
-  typeDisabled: {}
+  nodeType: {
+    ids: ['task', 'data', 'parameters'],
+    name: {
+      data: 'Datasets',
+      task: 'Nodes',
+      parameters: 'Parameters'
+    },
+    disabled: {}
+  },
+  edge: {
+    ids: [],
+    sources: {},
+    targets: {},
+    active: {},
+    disabled: {}
+  },
+  tag: {
+    ids: [],
+    name: {},
+    active: {},
+    enabled: {}
+  }
 });
 
 /**
@@ -84,7 +88,7 @@ const getInitialState = (props = {}) => {
 
   // Load properties from localStorage if defined, else use defaults
   const localStorageState = loadState();
-  const { textLabels = true, typeDisabled = {} } = localStorageState;
+  const { textLabels = true, nodeTypeDisabled } = localStorageState;
   const theme = props.theme || localStorageState.theme || 'dark';
 
   const visible = Object.assign(
@@ -92,14 +96,17 @@ const getInitialState = (props = {}) => {
     props.visible
   );
 
+  if (nodeTypeDisabled) {
+    pipelineData.nodeType.disabled = nodeTypeDisabled;
+  }
+
   return {
     ...pipelineData,
     chartSize: {},
     fontLoaded: false,
     textLabels,
     visible,
-    theme,
-    typeDisabled
+    theme
   };
 };
 

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -66,9 +66,7 @@ export const getInitialPipelineState = () => ({
   edge: {
     ids: [],
     sources: {},
-    targets: {},
-    active: {},
-    disabled: {}
+    targets: {}
   },
   tag: {
     ids: [],

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -26,15 +26,15 @@ const getEdgeID = (source, target) => [source, target].join('|');
  */
 const addNode = state => node => {
   const { id } = node;
-  if (state.nodeName[id]) {
+  if (state.node.name[id]) {
     return;
   }
-  state.nodes.push(id);
-  state.nodeName[id] = node.name;
-  state.nodeFullName[id] = node.full_name || node.name;
-  state.nodeType[id] = node.type;
-  state.nodeIsParam[id] = node.type === 'parameters';
-  state.nodeTags[id] = node.tags || [];
+  state.node.ids.push(id);
+  state.node.name[id] = node.name;
+  state.node.fullName[id] = node.full_name || node.name;
+  state.node.type[id] = node.type;
+  state.node.isParam[id] = node.type === 'parameters';
+  state.node.tags[id] = node.tags || [];
 };
 
 /**
@@ -44,12 +44,12 @@ const addNode = state => node => {
  */
 const addEdge = state => ({ source, target }) => {
   const id = getEdgeID(source, target);
-  if (state.edges.includes(id)) {
+  if (state.edge.ids.includes(id)) {
     return;
   }
-  state.edges.push(id);
-  state.edgeSources[id] = source;
-  state.edgeTargets[id] = target;
+  state.edge.ids.push(id);
+  state.edge.sources[id] = source;
+  state.edge.targets[id] = target;
 };
 
 /**
@@ -58,8 +58,8 @@ const addEdge = state => ({ source, target }) => {
  */
 const addTag = state => tag => {
   const { id } = tag;
-  state.tags.push(id);
-  state.tagName[id] = tag.name;
+  state.tag.ids.push(id);
+  state.tag.name[id] = tag.name;
 };
 
 /**
@@ -71,7 +71,9 @@ const formatData = data => {
   const state = getInitialPipelineState();
 
   if (validateInput(data)) {
-    state.id = data.schema_id;
+    if (data.schema_id) {
+      state.id = data.schema_id;
+    }
     data.nodes.forEach(addNode(state));
     data.edges.forEach(addEdge(state));
     data.tags.forEach(addTag(state));


### PR DESCRIPTION
## Description

- Refactor Redux state shape to improve property naming (e.g. change `nodeName` to `node.name`)
- Refactor reducers to split them into multiple files with `combineReducers`

## Development notes

- I've simplified and improved some function/variable naming and reduced/condenced a couple of functions, to make things easier to read/understand and reduce complexity.
- I introduced a check on the getTransitiveEdges selector to ensure that the walkGraphEdges function won't run if no nodes are disabled. This should save time where no nodes are disabled.

## QA notes

Pure refactor only, no functionality changes

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
