### PR TITLE
[KED-1347] Fix PNG exports

### DIFF
--- a/src/components/icon-toolbar/export-modal.js
+++ b/src/components/icon-toolbar/export-modal.js
@@ -7,26 +7,37 @@ import downloadSvg, { downloadPng } from 'svg-crowbar';
 
 /**
  * Handle onClick for the SVG/PNG download button
- * @param {Function} download SVG-crowbar function to download SVG or PNG
+ * @param {string} format Must be 'svg' or 'png'
  * @param {number} param.width Graph width
  * @param {number} param.height Graph height
  * @return {Function} onClick handler
  */
-export const exportGraph = (download, { width, height }) => {
+export const exportGraph = (format, { width, height }) => {
   const svg = document.querySelector('#pipeline-graph');
   // Create clone of graph SVG to avoid breaking the original
   const clone = svg.parentNode.appendChild(svg.cloneNode(true));
   // Reset zoom/translate
+  clone.setAttribute('viewBox', `0 0 ${width} ${height}`);
+  clone.querySelector('#zoom-wrapper').removeAttribute('transform');
+  // Impose a maximum size on PNGs because otherwise they break when downloading
+  if (format === 'png') {
+    const maxWidth = 5000;
+    width = Math.min(width, maxWidth);
+    height = Math.min(height, maxWidth * (height / width));
+  }
   clone.setAttribute('width', width);
   clone.setAttribute('height', height);
-  clone.querySelector('#zoom-wrapper').removeAttribute('transform');
   // Add webfont
   const style = document.createElement('style');
   style.innerHTML =
     '@import url(https://fonts.googleapis.com/css?family=Titillium+Web:400);';
   clone.prepend(style);
   // Download SVG/PNG
-  download(clone, 'kedro-pipeline');
+  const download = {
+    png: downloadPng,
+    svg: downloadSvg
+  };
+  download[format](clone, 'kedro-pipeline');
   // Delete cloned SVG
   svg.parentNode.removeChild(clone);
 };
@@ -44,7 +55,7 @@ const ExportModal = ({ graphSize, theme, toggleModal, visible }) => (
       <Button
         theme={theme}
         onClick={() => {
-          exportGraph(downloadPng, graphSize);
+          exportGraph('png', graphSize);
           toggleModal(false);
         }}>
         Download PNG
@@ -52,7 +63,7 @@ const ExportModal = ({ graphSize, theme, toggleModal, visible }) => (
       <Button
         theme={theme}
         onClick={() => {
-          exportGraph(downloadSvg, graphSize);
+          exportGraph('svg', graphSize);
           toggleModal(false);
         }}>
         Download SVG

--- a/src/components/icon-toolbar/export-modal.js
+++ b/src/components/icon-toolbar/export-modal.js
@@ -16,9 +16,11 @@ export const exportGraph = (format, { width, height }) => {
   const svg = document.querySelector('#pipeline-graph');
   // Create clone of graph SVG to avoid breaking the original
   const clone = svg.parentNode.appendChild(svg.cloneNode(true));
+
   // Reset zoom/translate
   clone.setAttribute('viewBox', `0 0 ${width} ${height}`);
   clone.querySelector('#zoom-wrapper').removeAttribute('transform');
+
   // Impose a maximum size on PNGs because otherwise they break when downloading
   if (format === 'png') {
     const maxWidth = 5000;
@@ -27,11 +29,21 @@ export const exportGraph = (format, { width, height }) => {
   }
   clone.setAttribute('width', width);
   clone.setAttribute('height', height);
-  // Add webfont
+
   const style = document.createElement('style');
-  style.innerHTML =
-    '@import url(https://fonts.googleapis.com/css?family=Titillium+Web:400);';
+  if (format === 'svg') {
+    // Add webfont
+    style.innerHTML =
+      '@import url(https://fonts.googleapis.com/css?family=Titillium+Web:400);';
+  } else {
+    // Add websafe fallback font
+    style.innerHTML = `.kedro {
+      font-family: "Trebuchet MS", "Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", Tahoma, sans-serif;
+      letter-spacing: -0.4px;
+    }`;
+  }
   clone.prepend(style);
+
   // Download SVG/PNG
   const download = {
     png: downloadPng,

--- a/src/components/icon-toolbar/export-modal.js
+++ b/src/components/icon-toolbar/export-modal.js
@@ -7,12 +7,13 @@ import downloadSvg, { downloadPng } from 'svg-crowbar';
 
 /**
  * Handle onClick for the SVG/PNG download button
+ * @param {Function} download SVG-crowbar function to download SVG or PNG
  * @param {string} format Must be 'svg' or 'png'
  * @param {number} param.width Graph width
  * @param {number} param.height Graph height
  * @return {Function} onClick handler
  */
-export const exportGraph = (format, { width, height }) => {
+export const exportGraph = (download, format, { width, height }) => {
   const svg = document.querySelector('#pipeline-graph');
   // Create clone of graph SVG to avoid breaking the original
   const clone = svg.parentNode.appendChild(svg.cloneNode(true));
@@ -45,11 +46,8 @@ export const exportGraph = (format, { width, height }) => {
   clone.prepend(style);
 
   // Download SVG/PNG
-  const download = {
-    png: downloadPng,
-    svg: downloadSvg
-  };
-  download[format](clone, 'kedro-pipeline');
+  download(clone, 'kedro-pipeline');
+
   // Delete cloned SVG
   svg.parentNode.removeChild(clone);
 };
@@ -67,7 +65,7 @@ const ExportModal = ({ graphSize, theme, toggleModal, visible }) => (
       <Button
         theme={theme}
         onClick={() => {
-          exportGraph('png', graphSize);
+          exportGraph(downloadPng, 'png', graphSize);
           toggleModal(false);
         }}>
         Download PNG
@@ -75,7 +73,7 @@ const ExportModal = ({ graphSize, theme, toggleModal, visible }) => (
       <Button
         theme={theme}
         onClick={() => {
-          exportGraph('svg', graphSize);
+          exportGraph(downloadSvg, 'svg', graphSize);
           toggleModal(false);
         }}>
         Download SVG

--- a/src/components/icon-toolbar/export-modal.test.js
+++ b/src/components/icon-toolbar/export-modal.test.js
@@ -22,16 +22,25 @@ describe('IconToolbar', () => {
   });
 
   describe('exportGraph', () => {
-    document.body.innerHTML = `
-      <svg id="pipeline-graph">
-        <g id="zoom-wrapper" />
-      </svg>
-    `;
-    const downloadFn = jest.fn();
     const graphSize = { width: 1000, height: 500 };
-    exportGraph(downloadFn, graphSize);
 
-    it('downloads a screenshot', () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <svg id="pipeline-graph">
+          <g id="zoom-wrapper" />
+        </svg>
+      `;
+    });
+
+    it('downloads an SVG', () => {
+      const downloadFn = jest.fn();
+      exportGraph(downloadFn, 'svg', graphSize);
+      expect(downloadFn.mock.calls.length).toBe(1);
+    });
+
+    it('downloads a PNG', () => {
+      const downloadFn = jest.fn();
+      exportGraph(downloadFn, 'png', graphSize);
       expect(downloadFn.mock.calls.length).toBe(1);
     });
 


### PR DESCRIPTION
## Description

- The extremely large image sizes were breaking exports on large pipelines. This change fixes this by scaling the SVG down to a max width of 5000px, so that it doesn't go over ~1MG when converted to PNG, which avoids breaking when encoded and converted to an inline attribute.
- Use fallback websafe font (Trebuchet MS) when exporting PNGs, as the webfont doesn't work in the PNG images. This is so that the font shown will at least be a similar size/width to the final output.

## Development notes

The changes to `exportGraph` include a variable reassignment for a couple of arguments, but I don't think this is likely to be a problem.

## QA notes

- Need to use a very large dataset to replicate the issue with PNG exports
- The font issue is only visible in PNGs, and is most identifiable by the reduced gap between the text and the icons.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
