### PR TITLE
[KED-1450] Move visibleNav/navWidth calculations into redux store

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 <!-- Add release notes for the upcoming release here -->
+- Move visibleNav/navWidth calculations into Redux store (#124)
 
 ## Thanks for supporting contributions
 [Ana Potje](https://github.com/ANA-POTJE)

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -39,6 +39,19 @@ export function toggleTagFilter(tagID, enabled) {
   };
 }
 
+export const TOGGLE_SIDEBAR = 'TOGGLE_SIDEBAR';
+
+/**
+ * Toggle sidebar visible/hidden
+ * @param {boolean} visible Whether sidebar nav is shown
+ */
+export function toggleSidebar(visible) {
+  return {
+    type: TOGGLE_SIDEBAR,
+    visible
+  };
+}
+
 export const TOGGLE_THEME = 'TOGGLE_THEME';
 
 /**

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -59,50 +59,15 @@ describe('FlowChart', () => {
     expect(spy2).not.toHaveBeenCalled();
   });
 
-  describe('getNavOffset', () => {
-    describe('if nav is visible', () => {
-      it('reduces the chart width by 300 on wider screens', () => {
-        const wrapper = setup.mount(<FlowChart visibleNav={true} />);
-        const instance = wrapper.find('FlowChart').instance();
-        expect(instance.getNavOffset(1000)).toEqual(300);
-        expect(instance.getNavOffset(500)).toEqual(300);
-      });
-
-      it('sets nav offset to zero on mobile', () => {
-        const instance = setup
-          .mount(<FlowChart visibleNav={true} />)
-          .find('FlowChart')
-          .instance();
-        expect(instance.getNavOffset(480)).toEqual(0);
-        expect(instance.getNavOffset(320)).toEqual(0);
-      });
-    });
-
-    describe('if nav is hidden', () => {
-      const instance = setup
-        .mount(<FlowChart visibleNav={false} />)
-        .find('FlowChart')
-        .instance();
-
-      it('sets nav offset to zero on desktop', () => {
-        expect(instance.getNavOffset(1000)).toEqual(0);
-      });
-
-      it('sets nav offset to zero on mobile', () => {
-        expect(instance.getNavOffset(480)).toEqual(0);
-        expect(instance.getNavOffset(320)).toEqual(0);
-      });
-    });
-  });
-
   it('maps state to props', () => {
     const expectedResult = {
+      centralNode: null,
       chartSize: expect.any(Object),
       edges: expect.any(Array),
-      nodes: expect.any(Array),
       linkedNodes: expect.any(Object),
-      centralNode: null,
+      nodes: expect.any(Array),
       textLabels: expect.any(Boolean),
+      visibleSidebar: expect.any(Boolean),
       zoom: expect.objectContaining({
         scale: expect.any(Number),
         translateX: expect.any(Number),

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -68,11 +68,7 @@ describe('FlowChart', () => {
       nodes: expect.any(Array),
       textLabels: expect.any(Boolean),
       visibleSidebar: expect.any(Boolean),
-      zoom: expect.objectContaining({
-        scale: expect.any(Number),
-        translateX: expect.any(Number),
-        translateY: expect.any(Number)
-      })
+      zoom: expect.any(Object)
     };
     expect(mapStateToProps(mockState.lorem)).toEqual(expectedResult);
   });

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -133,15 +133,15 @@ export class FlowChart extends Component {
    * Zoom and scale to fit
    */
   zoomChart() {
-    const { chartSize, zoom } = this.props;
-    const { scale, translateX, translateY } = zoom;
+    const { scale, translateX, translateY } = this.props.zoom;
+    const { sidebarWidth = 0 } = this.props.chartSize;
     this.el.svg
       .transition()
       .duration(this.DURATION)
       .call(
         this.zoomBehaviour.transform,
         zoomIdentity
-          .translate(translateX + chartSize.sidebarWidth, translateY)
+          .translate(translateX + sidebarWidth, translateY)
           .scale(scale)
       );
   }
@@ -208,7 +208,13 @@ export class FlowChart extends Component {
    * @param {Object} node A node datum
    */
   showTooltip(node) {
-    const { left, top, width, outerWidth, sidebarWidth } = this.props.chartSize;
+    const {
+      left,
+      top,
+      width,
+      outerWidth,
+      sidebarWidth = 0
+    } = this.props.chartSize;
     const eventOffset = event.target.getBoundingClientRect();
     const isRight = eventOffset.left - sidebarWidth > width / 2;
     const xOffset = isRight ? eventOffset.left - outerWidth : eventOffset.left;

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -54,7 +54,7 @@ export class FlowChart extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.visibleNav !== this.props.visibleNav) {
+    if (prevProps.visibleSidebar !== this.props.visibleSidebar) {
       this.updateChartSize();
     }
     if (prevProps.zoom !== this.props.zoom) {
@@ -299,8 +299,7 @@ export const mapStateToProps = state => ({
   linkedNodes: getLinkedNodes(state),
   nodes: getLayoutNodes(state),
   textLabels: state.textLabels,
-  view: state.view,
-  visibleNav: state.visible.sidebar,
+  visibleSidebar: state.visible.sidebar,
   zoom: getZoomPosition(state)
 });
 

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -133,16 +133,13 @@ export class FlowChart extends Component {
    * Zoom and scale to fit
    */
   zoomChart() {
-    const { scale, translateX, translateY } = this.props.zoom;
-    const { sidebarWidth = 0 } = this.props.chartSize;
+    const { scale = 1, translateX = 0, translateY = 0 } = this.props.zoom;
     this.el.svg
       .transition()
       .duration(this.DURATION)
       .call(
         this.zoomBehaviour.transform,
-        zoomIdentity
-          .translate(translateX + sidebarWidth, translateY)
-          .scale(scale)
+        zoomIdentity.translate(translateX, translateY).scale(scale)
       );
   }
 
@@ -208,13 +205,7 @@ export class FlowChart extends Component {
    * @param {Object} node A node datum
    */
   showTooltip(node) {
-    const {
-      left,
-      top,
-      width,
-      outerWidth,
-      sidebarWidth = 0
-    } = this.props.chartSize;
+    const { left, top, width, outerWidth, sidebarWidth } = this.props.chartSize;
     const eventOffset = event.target.getBoundingClientRect();
     const isRight = eventOffset.left - sidebarWidth > width / 2;
     const xOffset = isRight ? eventOffset.left - outerWidth : eventOffset.left;

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -7,6 +7,7 @@ import { zoom, zoomIdentity } from 'd3-zoom';
 import { updateChartSize } from '../../actions';
 import { toggleNodeClicked, toggleNodeHovered } from '../../actions/nodes';
 import {
+  getChartSize,
   getLayoutNodes,
   getLayoutEdges,
   getZoomPosition
@@ -79,31 +80,9 @@ export class FlowChart extends Component {
    * and apply them to the chart SVG
    */
   updateChartSize() {
-    const {
-      left,
-      top,
-      width,
-      height
-    } = this.containerRef.current.getBoundingClientRect();
-    const navOffset = this.getNavOffset(width);
-    this.props.onUpdateChartSize({
-      x: left,
-      y: top,
-      outerWidth: width,
-      outerHeight: height,
-      width: width - navOffset,
-      height,
-      navOffset
-    });
-  }
-
-  getNavOffset(width) {
-    const navWidth = 300; // from _variables.scss
-    const breakpointSmall = 480; // from _variables.scss
-    if (this.props.visibleNav && width > breakpointSmall) {
-      return navWidth;
-    }
-    return 0;
+    this.props.onUpdateChartSize(
+      this.containerRef.current.getBoundingClientRect()
+    );
   }
 
   /**
@@ -156,13 +135,14 @@ export class FlowChart extends Component {
   zoomChart() {
     const { chartSize, zoom } = this.props;
     const { scale, translateX, translateY } = zoom;
-    const navOffset = this.getNavOffset(chartSize.outerWidth);
     this.el.svg
       .transition()
       .duration(this.DURATION)
       .call(
         this.zoomBehaviour.transform,
-        zoomIdentity.translate(translateX + navOffset, translateY).scale(scale)
+        zoomIdentity
+          .translate(translateX + chartSize.sidebarWidth, translateY)
+          .scale(scale)
       );
   }
 
@@ -228,19 +208,16 @@ export class FlowChart extends Component {
    * @param {Object} node A node datum
    */
   showTooltip(node) {
-    const { chartSize } = this.props;
+    const { left, top, width, outerWidth, sidebarWidth } = this.props.chartSize;
     const eventOffset = event.target.getBoundingClientRect();
-    const navOffset = this.getNavOffset(chartSize.outerWidth);
-    const isRight = eventOffset.left - navOffset > chartSize.width / 2;
-    const xOffset = isRight
-      ? eventOffset.left - (chartSize.width + navOffset)
-      : eventOffset.left;
+    const isRight = eventOffset.left - sidebarWidth > width / 2;
+    const xOffset = isRight ? eventOffset.left - outerWidth : eventOffset.left;
     this.setState({
       tooltipVisible: true,
       tooltipIsRight: isRight,
       tooltipText: node.fullName,
-      tooltipX: xOffset - chartSize.x + eventOffset.width / 2,
-      tooltipY: eventOffset.top - chartSize.y
+      tooltipX: xOffset - left + eventOffset.width / 2,
+      tooltipY: eventOffset.top - top
     });
   }
 
@@ -317,7 +294,7 @@ export class FlowChart extends Component {
 
 export const mapStateToProps = state => ({
   centralNode: getCentralNode(state),
-  chartSize: state.chartSize,
+  chartSize: getChartSize(state),
   edges: getLayoutEdges(state),
   linkedNodes: getLinkedNodes(state),
   nodes: getLayoutNodes(state),

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -323,6 +323,7 @@ export const mapStateToProps = state => ({
   nodes: getLayoutNodes(state),
   textLabels: state.textLabels,
   view: state.view,
+  visibleNav: state.visible.sidebar,
   zoom: getZoomPosition(state)
 });
 

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import classnames from 'classnames';
 import Icon from '@quantumblack/kedro-ui/lib/components/icon';
+import { toggleSidebar } from '../../actions';
 import TagList from '../tag-list';
 import NodeList from '../node-list';
 import MenuIcon from '../icons/menu';
@@ -17,10 +19,10 @@ export const ShowMenuButton = ({ onToggle, visible }) => (
     className={classnames(
       'pipeline-sidebar__show-menu pipeline-sidebar__icon-button',
       {
-        'pipeline-sidebar__icon-button--visible': visible
+        'pipeline-sidebar__icon-button--visible': !visible
       }
     )}
-    onClick={onToggle}>
+    onClick={() => onToggle(!visible)}>
     <MenuIcon className="pipeline-icon" />
   </button>
 );
@@ -40,7 +42,9 @@ export const HideMenuButton = ({ onToggle, theme, visible }) => (
         'pipeline-sidebar__icon-button--visible': visible
       }
     )}
-    onClick={onToggle}>
+    onClick={() => {
+      onToggle(!visible);
+    }}>
     <Icon type="close" title="Close" theme={theme} />
   </button>
 );
@@ -51,7 +55,7 @@ export const HideMenuButton = ({ onToggle, theme, visible }) => (
  */
 const Sidebar = props => (
   <>
-    <ShowMenuButton onToggle={props.onToggle} visible={!props.visible} />
+    <ShowMenuButton {...props} />
     <nav
       className={classnames('pipeline-sidebar', {
         'pipeline-sidebar--visible': props.visible
@@ -65,4 +69,18 @@ const Sidebar = props => (
   </>
 );
 
-export default Sidebar;
+export const mapStateToProps = state => ({
+  theme: state.theme,
+  visible: state.visible.sidebar
+});
+
+export const mapDispatchToProps = dispatch => ({
+  onToggle: visible => {
+    dispatch(toggleSidebar(visible));
+  }
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Sidebar);

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -11,7 +11,7 @@ import './sidebar.css';
  * Main app container. Handles showing/hiding the sidebar nav, and theme classes.
  * @param {Object} props onToggle, theme, and visible
  */
-const Sidebar = props => (
+export const Sidebar = props => (
   <>
     <ShowMenuButton {...props} />
     <nav
@@ -27,12 +27,12 @@ const Sidebar = props => (
   </>
 );
 
-export const mapStateToProps = state => ({
+const mapStateToProps = state => ({
   theme: state.theme,
   visible: state.visible.sidebar
 });
 
-export const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = dispatch => ({
   onToggle: visible => {
     dispatch(toggleSidebar(visible));
   }

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -1,53 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import Icon from '@quantumblack/kedro-ui/lib/components/icon';
 import { toggleSidebar } from '../../actions';
 import TagList from '../tag-list';
 import NodeList from '../node-list';
-import MenuIcon from '../icons/menu';
+import { ShowMenuButton, HideMenuButton } from './menu-buttons';
 import './sidebar.css';
-
-/**
- * Hamburger menu button
- * @param {Function} props.onToggle Show menu on click
- * @param {Boolean} props.visible Whether nav is visible
- */
-export const ShowMenuButton = ({ onToggle, visible }) => (
-  <button
-    aria-label="Show menu"
-    className={classnames(
-      'pipeline-sidebar__show-menu pipeline-sidebar__icon-button',
-      {
-        'pipeline-sidebar__icon-button--visible': !visible
-      }
-    )}
-    onClick={() => onToggle(!visible)}>
-    <MenuIcon className="pipeline-icon" />
-  </button>
-);
-
-/**
- * ⨉-shaped button to close the menu. Hidden when menu is closed.
- * @param {Function} props.onToggle Show menu on click
- * @param {string} props.theme Kedro-UI theme: 'light' or 'dark'
- * @param {Boolean} props.visible Whether nav is visible
- */
-export const HideMenuButton = ({ onToggle, theme, visible }) => (
-  <button
-    aria-label="Hide menu"
-    className={classnames(
-      'pipeline-sidebar__hide-menu pipeline-sidebar__icon-button',
-      {
-        'pipeline-sidebar__icon-button--visible': visible
-      }
-    )}
-    onClick={() => {
-      onToggle(!visible);
-    }}>
-    <Icon type="close" title="Close" theme={theme} />
-  </button>
-);
 
 /**
  * Main app container. Handles showing/hiding the sidebar nav, and theme classes.

--- a/src/components/sidebar/menu-buttons.js
+++ b/src/components/sidebar/menu-buttons.js
@@ -6,15 +6,15 @@ import MenuIcon from '../icons/menu';
 /**
  * Hamburger menu button
  * @param {Function} props.onToggle Show menu on click
- * @param {Boolean} props.visible Whether nav is visible
+ * @param {Boolean} props.sidebarVisible Whether the sidebar is visible
  */
-export const ShowMenuButton = ({ onToggle, visible }) => (
+export const ShowMenuButton = ({ onToggle, visible: sidebarVisible }) => (
   <button
     aria-label="Show menu"
     className={classnames(
       'pipeline-sidebar__show-menu pipeline-sidebar__icon-button',
       {
-        'pipeline-sidebar__icon-button--visible': !visible
+        'pipeline-sidebar__icon-button--visible': !sidebarVisible
       }
     )}
     onClick={() => onToggle(true)}>
@@ -26,15 +26,19 @@ export const ShowMenuButton = ({ onToggle, visible }) => (
  * ⨉-shaped button to close the menu. Hidden when menu is closed.
  * @param {Function} props.onToggle Show menu on click
  * @param {string} props.theme Kedro-UI theme: 'light' or 'dark'
- * @param {Boolean} props.visible Whether nav is visible
+ * @param {Boolean} props.sidebarVisible Whether the sidebar is visible
  */
-export const HideMenuButton = ({ onToggle, theme, visible }) => (
+export const HideMenuButton = ({
+  onToggle,
+  theme,
+  visible: sidebarVisible
+}) => (
   <button
     aria-label="Hide menu"
     className={classnames(
       'pipeline-sidebar__hide-menu pipeline-sidebar__icon-button',
       {
-        'pipeline-sidebar__icon-button--visible': visible
+        'pipeline-sidebar__icon-button--visible': sidebarVisible
       }
     )}
     onClick={() => onToggle(false)}>

--- a/src/components/sidebar/menu-buttons.js
+++ b/src/components/sidebar/menu-buttons.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import classnames from 'classnames';
+import Icon from '@quantumblack/kedro-ui/lib/components/icon';
+import MenuIcon from '../icons/menu';
+
+/**
+ * Hamburger menu button
+ * @param {Function} props.onToggle Show menu on click
+ * @param {Boolean} props.visible Whether nav is visible
+ */
+export const ShowMenuButton = ({ onToggle, visible }) => (
+  <button
+    aria-label="Show menu"
+    className={classnames(
+      'pipeline-sidebar__show-menu pipeline-sidebar__icon-button',
+      {
+        'pipeline-sidebar__icon-button--visible': !visible
+      }
+    )}
+    onClick={() => onToggle(!visible)}>
+    <MenuIcon className="pipeline-icon" />
+  </button>
+);
+
+/**
+ * ⨉-shaped button to close the menu. Hidden when menu is closed.
+ * @param {Function} props.onToggle Show menu on click
+ * @param {string} props.theme Kedro-UI theme: 'light' or 'dark'
+ * @param {Boolean} props.visible Whether nav is visible
+ */
+export const HideMenuButton = ({ onToggle, theme, visible }) => (
+  <button
+    aria-label="Hide menu"
+    className={classnames(
+      'pipeline-sidebar__hide-menu pipeline-sidebar__icon-button',
+      {
+        'pipeline-sidebar__icon-button--visible': visible
+      }
+    )}
+    onClick={() => {
+      onToggle(!visible);
+    }}>
+    <Icon type="close" title="Close" theme={theme} />
+  </button>
+);

--- a/src/components/sidebar/menu-buttons.js
+++ b/src/components/sidebar/menu-buttons.js
@@ -17,7 +17,7 @@ export const ShowMenuButton = ({ onToggle, visible }) => (
         'pipeline-sidebar__icon-button--visible': !visible
       }
     )}
-    onClick={() => onToggle(!visible)}>
+    onClick={() => onToggle(true)}>
     <MenuIcon className="pipeline-icon" />
   </button>
 );
@@ -37,9 +37,7 @@ export const HideMenuButton = ({ onToggle, theme, visible }) => (
         'pipeline-sidebar__icon-button--visible': visible
       }
     )}
-    onClick={() => {
-      onToggle(!visible);
-    }}>
+    onClick={() => onToggle(false)}>
     <Icon type="close" title="Close" theme={theme} />
   </button>
 );

--- a/src/components/sidebar/sidebar.test.js
+++ b/src/components/sidebar/sidebar.test.js
@@ -22,14 +22,18 @@ describe('Sidebar', () => {
   });
 
   it('hides when clicking the hide menu button', () => {
-    const wrapper = setup.mount(<MountSidebar />);
+    const wrapper = setup.mount(<MountSidebar />, {
+      visible: { sidebar: true }
+    });
     wrapper.find('.pipeline-sidebar__hide-menu').simulate('click');
     const sidebar = wrapper.find('.pipeline-sidebar');
     expect(sidebar.hasClass('pipeline-sidebar--visible')).toBe(false);
   });
 
   it('shows when clicking the show menu button', () => {
-    const wrapper = setup.mount(<MountSidebar />);
+    const wrapper = setup.mount(<MountSidebar />, {
+      visible: { sidebar: false }
+    });
     wrapper.find('.pipeline-sidebar__show-menu').simulate('click');
     const sidebar = wrapper.find('.pipeline-sidebar');
     expect(sidebar.hasClass('pipeline-sidebar--visible')).toBe(true);

--- a/src/components/sidebar/sidebar.test.js
+++ b/src/components/sidebar/sidebar.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import Sidebar, { ShowMenuButton, HideMenuButton } from './index';
+import MountSidebar, { Sidebar } from './index';
+import { ShowMenuButton, HideMenuButton } from './menu-buttons';
 import { mockState, setup } from '../../utils/state.mock';
 
 const mockProps = {
@@ -7,6 +8,33 @@ const mockProps = {
   onToggle: () => {},
   visible: true
 };
+
+describe('Sidebar', () => {
+  it('renders without crashing', () => {
+    const wrapper = setup.shallow(Sidebar, mockProps);
+    const container = wrapper.find('.pipeline-sidebar');
+    expect(container.length).toBe(1);
+  });
+
+  it('is open by default', () => {
+    const sidebar = setup.shallow(Sidebar, mockProps).find('.pipeline-sidebar');
+    expect(sidebar.hasClass('pipeline-sidebar--visible')).toBe(true);
+  });
+
+  it('hides when clicking the hide menu button', () => {
+    const wrapper = setup.mount(<MountSidebar />);
+    wrapper.find('.pipeline-sidebar__hide-menu').simulate('click');
+    const sidebar = wrapper.find('.pipeline-sidebar');
+    expect(sidebar.hasClass('pipeline-sidebar--visible')).toBe(false);
+  });
+
+  it('shows when clicking the show menu button', () => {
+    const wrapper = setup.mount(<MountSidebar />);
+    wrapper.find('.pipeline-sidebar__show-menu').simulate('click');
+    const sidebar = wrapper.find('.pipeline-sidebar');
+    expect(sidebar.hasClass('pipeline-sidebar--visible')).toBe(true);
+  });
+});
 
 describe('ShowMenuButton', () => {
   it('renders without crashing', () => {
@@ -21,20 +49,5 @@ describe('HideMenuButton', () => {
     const wrapper = setup.shallow(HideMenuButton, mockProps);
     const container = wrapper.find('button');
     expect(container.length).toBe(1);
-  });
-});
-
-describe('Sidebar', () => {
-  it('renders without crashing', () => {
-    const wrapper = setup.shallow(Sidebar, mockProps);
-    const container = wrapper.find('.pipeline-sidebar');
-    expect(container.length).toBe(1);
-  });
-
-  it('has an open sidebar by default', () => {
-    const wrapper = setup.shallow(Sidebar, mockProps);
-    expect(
-      wrapper.find('.pipeline-sidebar').hasClass('pipeline-sidebar--visible')
-    ).toBe(true);
   });
 });

--- a/src/components/wrapper/index.js
+++ b/src/components/wrapper/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import FlowChart from '../flowchart';
@@ -9,43 +9,17 @@ import './wrapper.css';
 /**
  * Main app container. Handles showing/hiding the sidebar nav, and theme classes.
  */
-export class Wrapper extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      visibleNav: true
-    };
-  }
-
-  toggleNav() {
-    const visibleNav = !this.state.visibleNav;
-    this.setState({ visibleNav });
-  }
-
-  render() {
-    const { visibleNav } = this.state;
-    const { fontLoaded, theme } = this.props;
-
-    return (
-      <div
-        className={classnames('kedro-pipeline', {
-          'kui-theme--dark': theme === 'dark',
-          'kui-theme--light': theme === 'light'
-        })}>
-        <Sidebar
-          onToggle={this.toggleNav.bind(this)}
-          theme={theme}
-          visible={visibleNav}
-        />
-        {fontLoaded && <IconToolbar />}
-        <div className="pipeline-wrapper">
-          {fontLoaded && <FlowChart visibleNav={visibleNav} />}
-        </div>
-      </div>
-    );
-  }
-}
+export const Wrapper = ({ fontLoaded, theme }) => (
+  <div
+    className={classnames('kedro-pipeline', {
+      'kui-theme--dark': theme === 'dark',
+      'kui-theme--light': theme === 'light'
+    })}>
+    <Sidebar />
+    {fontLoaded && <IconToolbar />}
+    <div className="pipeline-wrapper">{fontLoaded && <FlowChart />}</div>
+  </div>
+);
 
 export const mapStateToProps = state => ({
   fontLoaded: state.fontLoaded,

--- a/src/components/wrapper/wrapper.test.js
+++ b/src/components/wrapper/wrapper.test.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Wrapper, mapStateToProps } from './index';
 import { mockState, setup } from '../../utils/state.mock';
 
@@ -17,20 +18,18 @@ describe('Wrapper', () => {
   it('sets a class based on the theme', () => {
     const wrapper = setup.shallow(Wrapper, mockProps);
     const container = wrapper.find('.kedro-pipeline');
-    const { theme } = wrapper.instance().props;
     expect(container.hasClass(`kui-theme--light`)).toBe(theme === 'light');
     expect(container.hasClass(`kui-theme--dark`)).toBe(theme === 'dark');
   });
 
-  it('has sidebar visible by default', () => {
-    const wrapper = setup.shallow(Wrapper, mockProps);
-    expect(wrapper.instance().state.visibleNav).toBe(true);
+  it("doesn't show the chart if fontLoaded is false", () => {
+    const wrapper = setup.mount(<Wrapper fontLoaded={false} />);
+    expect(wrapper.find('FlowChart').exists()).toBe(false);
   });
 
-  it('sets visibleNav to false when you run toggleNav', () => {
-    const wrapper = setup.shallow(Wrapper, mockProps);
-    wrapper.instance().toggleNav();
-    expect(wrapper.instance().state.visibleNav).toBe(false);
+  it('only shows the chart if fontLoaded is true', () => {
+    const wrapper = setup.mount(<Wrapper fontLoaded={true} />);
+    expect(wrapper.find('FlowChart').exists()).toBe(true);
   });
 
   it('maps state to props', () => {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import node from './nodes';
 import tag from './tags';
 import nodeType from './node-type';
+import visible from './visible';
 import {
   RESET_DATA,
   TOGGLE_TEXT_LABELS,
@@ -44,9 +45,9 @@ const combinedReducer = combineReducers({
   node,
   nodeType,
   tag,
+  visible,
   edge: (state = {}) => state,
   id: (state = null) => state,
-  visible: (state = {}) => state,
   chartSize: createReducer(UPDATE_CHART_SIZE, 'chartSize', {}),
   fontLoaded: createReducer(UPDATE_FONT_LOADED, 'fontLoaded', false),
   textLabels: createReducer(TOGGLE_TEXT_LABELS, 'textLabels', true),

--- a/src/reducers/visible.js
+++ b/src/reducers/visible.js
@@ -1,0 +1,15 @@
+import { TOGGLE_SIDEBAR } from '../actions';
+
+function visibleReducer(visibleState = {}, action) {
+  switch (action.type) {
+    case TOGGLE_SIDEBAR: {
+      return Object.assign({}, visibleState, {
+        sidebar: action.visible
+      });
+    }
+    default:
+      return visibleState;
+  }
+}
+
+export default visibleReducer;

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -74,9 +74,6 @@ export const getGraphSize = createSelector(
 export const getSidebarWidth = (visibleSidebar, outerChartWidth) => {
   const defaultSidebarWidth = 300; // from _variables.scss
   const breakpointSmall = 480; // from _variables.scss
-  if (isNaN(outerChartWidth)) {
-    return;
-  }
   if (visibleSidebar && outerChartWidth > breakpointSmall) {
     return defaultSidebarWidth;
   }
@@ -91,6 +88,9 @@ export const getChartSize = createSelector(
   [getVisibleSidebar, state => state.chartSize],
   (visibleSidebar, chartSize) => {
     const { left, top, width, height } = chartSize;
+    if (!width || !height) {
+      return {};
+    }
     const sidebarWidth = getSidebarWidth(visibleSidebar, width);
     return {
       left,
@@ -110,29 +110,22 @@ export const getChartSize = createSelector(
  */
 export const getZoomPosition = createSelector(
   [getGraphSize, getChartSize],
-  (graph, container) => {
-    const validDimensions = [
-      container.width,
-      container.height,
-      graph.width,
-      graph.height
-    ].every(n => !isNaN(n) && Number.isFinite(n));
-
-    if (validDimensions) {
-      const scale = Math.min(
-        container.width / graph.width,
-        container.height / graph.height
-      );
-      return {
-        scale,
-        translateX: container.width / 2 - (graph.width * scale) / 2,
-        translateY: container.height / 2 - (graph.height * scale) / 2
-      };
+  (graph, chart) => {
+    if (!Object.keys(chart).length) {
+      return {};
     }
+
+    const scale = Math.min(
+      chart.width / graph.width,
+      chart.height / graph.height
+    );
+    const translateX = chart.width / 2 - (graph.width * scale) / 2;
+    const translateY = chart.height / 2 - (graph.height * scale) / 2;
+
     return {
-      scale: 1,
-      translateX: 0,
-      translateY: 0
+      scale,
+      translateX: translateX + chart.sidebarWidth,
+      translateY
     };
   }
 );

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -4,7 +4,7 @@ import { getNodeActive, getVisibleNodes } from './nodes';
 import { getVisibleEdges } from './edges';
 
 const getNodeType = state => state.node.type;
-const getChartSize = state => state.chartSize;
+const getVisibleSidebar = state => state.visible.sidebar;
 
 /**
  * Calculate chart layout with Dagre.js.
@@ -66,6 +66,39 @@ export const getLayoutEdges = createSelector(
 export const getGraphSize = createSelector(
   [getGraph],
   graph => graph.graph()
+);
+
+/**
+ * Return the displayed width of the sidebar
+ */
+export const getSidebarWidth = (visibleSidebar, outerChartWidth) => {
+  const defaultSidebarWidth = 300; // from _variables.scss
+  const breakpointSmall = 480; // from _variables.scss
+  if (visibleSidebar && outerChartWidth > breakpointSmall) {
+    return defaultSidebarWidth;
+  }
+  return 0;
+};
+
+/**
+ * Convert the DOMRect into an Object, mutate some of the properties,
+ * and add some useful new ones
+ */
+export const getChartSize = createSelector(
+  [getVisibleSidebar, state => state.chartSize],
+  (visibleSidebar, chartSize) => {
+    const { left, top, width, height } = chartSize;
+    const sidebarWidth = getSidebarWidth(visibleSidebar, width);
+    return {
+      left,
+      top,
+      outerWidth: width,
+      outerHeight: height,
+      width: width - sidebarWidth,
+      height,
+      sidebarWidth
+    };
+  }
 );
 
 /**

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -74,6 +74,9 @@ export const getGraphSize = createSelector(
 export const getSidebarWidth = (visibleSidebar, outerChartWidth) => {
   const defaultSidebarWidth = 300; // from _variables.scss
   const breakpointSmall = 480; // from _variables.scss
+  if (isNaN(outerChartWidth)) {
+    return;
+  }
   if (visibleSidebar && outerChartWidth > breakpointSmall) {
     return defaultSidebarWidth;
   }
@@ -94,7 +97,7 @@ export const getChartSize = createSelector(
       top,
       outerWidth: width,
       outerHeight: height,
-      width: width - sidebarWidth,
+      width: width ? width - sidebarWidth : width,
       height,
       sidebarWidth
     };

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -97,7 +97,7 @@ export const getChartSize = createSelector(
       top,
       outerWidth: width,
       outerHeight: height,
-      width: width ? width - sidebarWidth : width,
+      width: width - sidebarWidth,
       height,
       sidebarWidth
     };

--- a/src/selectors/layout.test.js
+++ b/src/selectors/layout.test.js
@@ -150,15 +150,11 @@ describe('Selectors', () => {
   });
 
   describe('getZoomPosition', () => {
-    it('returns a default chart zoom translation/scale if none is specified', () => {
-      expect(getZoomPosition(mockState.lorem)).toEqual({
-        scale: 1,
-        translateX: 0,
-        translateY: 0
-      });
+    it('returns an empty object if chartSize is unset', () => {
+      expect(getZoomPosition(mockState.lorem)).toEqual({});
     });
 
-    it('returns the updated chart zoom translation/scale if set', () => {
+    it('returns the updated chart zoom translation/scale if chartSize is set', () => {
       const newMockState = reducer(
         mockState.lorem,
         updateChartSize({ width: 100, height: 100 })

--- a/src/selectors/layout.test.js
+++ b/src/selectors/layout.test.js
@@ -3,6 +3,7 @@ import {
   getGraph,
   getLayoutNodes,
   getLayoutEdges,
+  getSidebarWidth,
   getZoomPosition
 } from './layout';
 import { getVisibleNodes } from './nodes';
@@ -73,6 +74,31 @@ describe('Selectors', () => {
           })
         ])
       );
+    });
+  });
+
+  describe('getSidebarWidth', () => {
+    describe('if sidebar is visible', () => {
+      it('reduces the chart width by 300 on wider screens', () => {
+        expect(getSidebarWidth(true, 1000)).toEqual(300);
+        expect(getSidebarWidth(true, 500)).toEqual(300);
+      });
+
+      it('sets sidebar width to zero on mobile', () => {
+        expect(getSidebarWidth(true, 480)).toEqual(0);
+        expect(getSidebarWidth(true, 320)).toEqual(0);
+      });
+    });
+
+    describe('if sidebar is hidden', () => {
+      it('sets sidebar width to zero on desktop', () => {
+        expect(getSidebarWidth(false, 1000)).toEqual(0);
+      });
+
+      it('sets sidebar width to zero on mobile', () => {
+        expect(getSidebarWidth(false, 480)).toEqual(0);
+        expect(getSidebarWidth(false, 320)).toEqual(0);
+      });
     });
   });
 

--- a/src/selectors/layout.test.js
+++ b/src/selectors/layout.test.js
@@ -1,6 +1,8 @@
 import { mockState } from '../utils/state.mock';
 import {
+  getChartSize,
   getGraph,
+  getGraphSize,
   getLayoutNodes,
   getLayoutEdges,
   getSidebarWidth,
@@ -14,6 +16,7 @@ import reducer from '../reducers';
 describe('Selectors', () => {
   describe('getGraph', () => {
     const graph = getGraph(mockState.lorem);
+
     it('calculates chart layout and returns a Dagre object', () => {
       expect(graph).toEqual(
         expect.objectContaining({
@@ -77,6 +80,20 @@ describe('Selectors', () => {
     });
   });
 
+  describe('getGraphSize', () => {
+    it('returns width, height and margin of the graph', () => {
+      const graphSize = getGraphSize(mockState.lorem);
+      expect(graphSize).toEqual(
+        expect.objectContaining({
+          height: expect.any(Number),
+          marginx: expect.any(Number),
+          marginy: expect.any(Number),
+          width: expect.any(Number)
+        })
+      );
+    });
+  });
+
   describe('getSidebarWidth', () => {
     describe('if sidebar is visible', () => {
       it('reduces the chart width by 300 on wider screens', () => {
@@ -98,6 +115,36 @@ describe('Selectors', () => {
       it('sets sidebar width to zero on mobile', () => {
         expect(getSidebarWidth(false, 480)).toEqual(0);
         expect(getSidebarWidth(false, 320)).toEqual(0);
+      });
+    });
+  });
+
+  describe('getChartSize', () => {
+    it('returns a set of undefined properties if chartSize DOMRect is not supplied', () => {
+      expect(getChartSize(mockState.lorem)).toEqual({
+        height: undefined,
+        left: undefined,
+        outerHeight: undefined,
+        outerWidth: undefined,
+        sidebarWidth: undefined,
+        top: undefined,
+        width: undefined
+      });
+    });
+
+    it('returns a DOMRect converted into an Object, with some extra properties', () => {
+      const newMockState = {
+        ...mockState.lorem,
+        chartSize: { left: 100, top: 100, width: 1000, height: 1000 }
+      };
+      expect(getChartSize(newMockState)).toEqual({
+        height: expect.any(Number),
+        left: expect.any(Number),
+        outerHeight: expect.any(Number),
+        outerWidth: expect.any(Number),
+        sidebarWidth: expect.any(Number),
+        top: expect.any(Number),
+        width: expect.any(Number)
       });
     });
   });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -11,8 +11,13 @@ export default function configureStore(initialState) {
   const store = createStore(reducer, initialState);
 
   store.subscribe(() => {
-    const { textLabels, theme, nodeType } = store.getState();
-    saveState({ textLabels, theme, nodeTypeDisabled: nodeType.disabled });
+    const { textLabels, theme, nodeType, visibleSidebar } = store.getState();
+    saveState({
+      textLabels,
+      theme,
+      nodeTypeDisabled: nodeType.disabled,
+      visibleSidebar
+    });
   });
 
   return store;

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -90,7 +90,12 @@ const getInitialState = (props = {}) => {
   const theme = props.theme || localStorageState.theme || 'dark';
 
   const visible = Object.assign(
-    { exportBtn: true, labelBtn: true, themeBtn: true },
+    {
+      exportBtn: true,
+      labelBtn: true,
+      themeBtn: true,
+      sidebar: true
+    },
     props.visible
   );
 

--- a/src/utils/state.mock.js
+++ b/src/utils/state.mock.js
@@ -22,7 +22,7 @@ export const setup = {
    * @param {Object} props Store initialisation props
    */
   mount: (children, props = {}) => {
-    const initialState = getInitialState({ ...props, data: 'lorem' });
+    const initialState = getInitialState({ data: 'lorem', ...props });
     return mount(
       <Provider store={configureStore(initialState)}>{children}</Provider>
     );

--- a/src/utils/state.mock.js
+++ b/src/utils/state.mock.js
@@ -22,7 +22,10 @@ export const setup = {
    * @param {Object} props Store initialisation props
    */
   mount: (children, props = {}) => {
-    const initialState = getInitialState({ data: 'lorem', ...props });
+    const initialState = Object.assign(
+      {},
+      getInitialState({ data: 'lorem', ...props }, props)
+    );
     return mount(
       <Provider store={configureStore(initialState)}>{children}</Provider>
     );


### PR DESCRIPTION
## Description

The visibleNav calculation affects the flowchart width and is currently a class method used in multiple places, which is getting difficult to maintain. It's handled in this way because the boolean flag is stored in the Wrapper component state, so it can only be passed down as a prop. Moving this prop to the redux store and using selectors to manage the navWidth calculations will save time and make things more maintainable.

## Development notes

I've also added/changed some of the tests to improve coverage and make them more flexible, and done some slight sidebar refactoring.

## QA notes

No functionality changes

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
