### PR TITLE
[KED-1462] Guard global window references to fix SSR

### DIFF
--- a/src/components/icon-toolbar/export-modal.js
+++ b/src/components/icon-toolbar/export-modal.js
@@ -3,8 +3,9 @@ import { connect } from 'react-redux';
 import Modal from '@quantumblack/kedro-ui/lib/components/modal';
 import Button from '@quantumblack/kedro-ui/lib/components/button';
 import { getGraphSize } from '../../selectors/layout';
-const downloadSvg = typeof window !== 'undefined' ? require('svg-crowbar') : {};
-const { downloadPng } = downloadSvg;
+const { default: downloadSvg, downloadPng } =
+  typeof window !== 'undefined' && require('svg-crowbar');
+
 /**
  * Handle onClick for the SVG/PNG download button
  * @param {Function} download SVG-crowbar function to download SVG or PNG

--- a/src/components/icon-toolbar/export-modal.js
+++ b/src/components/icon-toolbar/export-modal.js
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 import Modal from '@quantumblack/kedro-ui/lib/components/modal';
 import Button from '@quantumblack/kedro-ui/lib/components/button';
 import { getGraphSize } from '../../selectors/layout';
-import downloadSvg, { downloadPng } from 'svg-crowbar';
-
+const downloadSvg = typeof window !== 'undefined' ? require('svg-crowbar') : {};
+const { downloadPng } = downloadSvg;
 /**
  * Handle onClick for the SVG/PNG download button
  * @param {Function} download SVG-crowbar function to download SVG or PNG

--- a/src/config.js
+++ b/src/config.js
@@ -1,16 +1,22 @@
+const hasWindow = typeof window !== 'undefined';
+
 /**
  * Determine which data source to use
  * @return {string} Data source type key
  */
 const getDataSource = () => {
   let source;
-  const qs = window.location.search.match(/data=(\w+)/);
+  const qs = hasWindow && window.location.search.match(/data=(\w+)/);
   const { REACT_APP_DATA_SOURCE } = process.env;
+
   if (qs) {
     source = encodeURIComponent(qs[1]);
   } else if (REACT_APP_DATA_SOURCE) {
     source = REACT_APP_DATA_SOURCE;
-  } else if (window.location.host === 'quantumblacklabs.github.io') {
+  } else if (
+    hasWindow &&
+    window.location.host === 'quantumblacklabs.github.io'
+  ) {
     source = 'demo';
   }
   return validateDataSource(source);

--- a/src/store/helpers.js
+++ b/src/store/helpers.js
@@ -1,11 +1,16 @@
 import config from '../config';
 
+const noWindow = typeof window === 'undefined';
+
 /**
  * Retrieve state data from localStorage
  * @return {Object} State
  */
 export const loadState = () => {
   const { localStorageName } = config();
+  if (noWindow) {
+    return {};
+  }
   try {
     const serializedState = window.localStorage.getItem(localStorageName);
     if (serializedState === null) {
@@ -24,6 +29,9 @@ export const loadState = () => {
  */
 export const saveState = state => {
   const { localStorageName } = config();
+  if (noWindow) {
+    return;
+  }
   try {
     const newState = Object.assign(loadState(), state);
     const serializedState = JSON.stringify(newState);


### PR DESCRIPTION
## Description

Resolves #123

@WaylonWalker do you mind checking this PR to see if it fixes your issue?

## Development notes

I've temporarily set svg-crowbar to conditionally-load depending on whether the `window` object is defined, because it contains unguarded references. To do this I had to change it from an ES6 import to a `require`, because the former doesn't support synchronous conditional imports as far as I know. Ultimately I'd like to contact the maintainer and fix these references so that it can be changed back to an ES6 import.

## QA notes

Fixes server-side rendering builds. Otherwise, no changes

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
