### PR TITLE
[KED-1424] Update svg-crowbar to reduce exported SVG filesize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19237,21 +19237,6 @@
         }
       }
     },
-    "stylelint-config-recommended": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
-      "integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
-      "dev": true
-    },
-    "stylelint-config-standard": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-19.0.0.tgz",
-      "integrity": "sha512-VvcODsL1PryzpYteWZo2YaA5vU/pWfjqBpOvmeA8iB2MteZ/ZhI1O4hnrWMidsS4vmEJpKtjdhLdfGJmmZm6Cg==",
-      "dev": true,
-      "requires": {
-        "stylelint-config-recommended": "^3.0.0"
-      }
-    },
     "stylelint-order": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-4.0.0.tgz",
@@ -19328,9 +19313,9 @@
       }
     },
     "svg-crowbar": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/svg-crowbar/-/svg-crowbar-0.2.4.tgz",
-      "integrity": "sha512-3zVrUJi4zOi6Q4m0RCWQoSxHLurPaYsf0nyYIdIBaY9n0EM2EHyuYBWB6aaRcrU3+4y32FvQBBwg1lRPAnG2Cg=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/svg-crowbar/-/svg-crowbar-0.3.1.tgz",
+      "integrity": "sha512-kr6kILbwUyeFPltIFn8ZcHp/8vkyjYYjYfVX6/y0NxWvMmFaA2jCAyu+Xuiqz8DXwU8lTY6kgmX/B0eA3zh4wA=="
     },
     "svg-parser": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "redux": "^4.0.1",
     "reselect": "^4.0.0",
     "snyk": "^1.290.1",
-    "svg-crowbar": "^0.2.4",
+    "svg-crowbar": "^0.3.1",
     "what-input": "^5.2.3"
   },
   "peerDependencies": {

--- a/src/components/icon-toolbar/export-modal.js
+++ b/src/components/icon-toolbar/export-modal.js
@@ -9,14 +9,16 @@ import downloadSvg, { downloadPng } from 'svg-crowbar';
  * Handle onClick for the SVG/PNG download button
  * @param {Function} download SVG-crowbar function to download SVG or PNG
  * @param {string} format Must be 'svg' or 'png'
+ * @param {string} theme light/dark theme
  * @param {number} param.width Graph width
  * @param {number} param.height Graph height
  * @return {Function} onClick handler
  */
-export const exportGraph = (download, format, { width, height }) => {
+export const exportGraph = (download, format, theme, { width, height }) => {
   const svg = document.querySelector('#pipeline-graph');
   // Create clone of graph SVG to avoid breaking the original
   const clone = svg.parentNode.appendChild(svg.cloneNode(true));
+  clone.classList.add('kedro', `kui-theme--${theme}`);
 
   // Reset zoom/translate
   clone.setAttribute('viewBox', `0 0 ${width} ${height}`);
@@ -46,7 +48,7 @@ export const exportGraph = (download, format, { width, height }) => {
   clone.prepend(style);
 
   // Download SVG/PNG
-  download(clone, 'kedro-pipeline');
+  download(clone, 'kedro-pipeline', { css: 'internal' });
 
   // Delete cloned SVG
   svg.parentNode.removeChild(clone);
@@ -65,7 +67,7 @@ const ExportModal = ({ graphSize, theme, toggleModal, visible }) => (
       <Button
         theme={theme}
         onClick={() => {
-          exportGraph(downloadPng, 'png', graphSize);
+          exportGraph(downloadPng, 'png', theme, graphSize);
           toggleModal(false);
         }}>
         Download PNG
@@ -73,7 +75,7 @@ const ExportModal = ({ graphSize, theme, toggleModal, visible }) => (
       <Button
         theme={theme}
         onClick={() => {
-          exportGraph(downloadSvg, 'svg', graphSize);
+          exportGraph(downloadSvg, 'svg', theme, graphSize);
           toggleModal(false);
         }}>
         Download SVG

--- a/src/components/icon-toolbar/export-modal.test.js
+++ b/src/components/icon-toolbar/export-modal.test.js
@@ -34,13 +34,13 @@ describe('IconToolbar', () => {
 
     it('downloads an SVG', () => {
       const downloadFn = jest.fn();
-      exportGraph(downloadFn, 'svg', graphSize);
+      exportGraph(downloadFn, 'svg', 'dark', graphSize);
       expect(downloadFn.mock.calls.length).toBe(1);
     });
 
     it('downloads a PNG', () => {
       const downloadFn = jest.fn();
-      exportGraph(downloadFn, 'png', graphSize);
+      exportGraph(downloadFn, 'png', 'dark', graphSize);
       expect(downloadFn.mock.calls.length).toBe(1);
     });
 


### PR DESCRIPTION
## Description

See https://github.com/cy6erskunk/svg-crowbar/pull/87

When exporting large SVGs with many elements, the volume of inline styles can make the resulting file extremely large. For instance, the ones I'm exporting regularly exceed 3MB.

This PR adds the new `internal` css feature, which can reduce SVG file sizes by a factor of 10.

## Development notes

minimal

## QA notes

Exported SVGs have slightly increased risk of breaking in different browsers, but should be much smaller now.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
