### PR TITLE
[KED-1486] Proposal to make _call_viz a public function 

### DIFF
--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -110,7 +110,7 @@ def run_viz(port=None, line=None) -> None:
         _VIZ_PROCESSES[port].terminate()
 
     viz_process = multiprocessing.Process(
-        target=_call_viz, daemon=True, kwargs={"port": port}
+        target=call_viz, daemon=True, kwargs={"port": port}
     )
     viz_process.start()
     _VIZ_PROCESSES[port] = viz_process
@@ -300,7 +300,7 @@ def commands():
 def viz(host, port, browser, load_file, save_file, pipeline, env):
     """Visualize the pipeline using kedroviz."""
     try:
-        _call_viz(host, port, browser, load_file, save_file, pipeline, env)
+        call_viz(host, port, browser, load_file, save_file, pipeline, env)
     except KedroCliError:
         raise
     except Exception as ex:
@@ -308,7 +308,7 @@ def viz(host, port, browser, load_file, save_file, pipeline, env):
 
 
 # pylint: disable=too-many-arguments
-def _call_viz(
+def call_viz(
     host=None,
     port=None,
     browser=None,


### PR DESCRIPTION
## Description

I am wanting to use `call_viz` in a small library [kedro-static-viz](https://github.com/WaylonWalker/kedro-static-viz/blob/develop/kedro_static_viz/cli.py#L91), but am concerned about the direction of this function since it is currently private.


## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [ ] I acknowledge and agree that by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and/or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
- I am submitting this as my own thoughts.  This PR does not represent any company I work for.
