### PR TITLE
[KED-1487] Only open browser on localhost

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,8 @@ Please follow the established format:
 
 <!-- Add release notes for the upcoming release here -->
 - Move visibleNav/navWidth calculations into Redux store (#124)
-- `kedro viz --load-file=XX` stopped emitting log files 
+- `kedro viz --load-file=XX` stopped emitting log files
+- Web browser will only be opened if the host corresponds to the localhost 
 
 ## Thanks for supporting contributions
 [Ana Potje](https://github.com/ANA-POTJE)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,6 @@ Please follow the established format:
 - Drop support for Python 3.5 (#138)
 - Add logger configuration when loading pipeline from JSON (#133)
 - Move visibleNav/navWidth calculations into Redux store (#124)
-- `kedro viz --load-file=XX` stopped emitting log files
 - Web browser will only be opened if the host corresponds to the localhost 
 
 ## Thanks for supporting contributions

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -349,6 +349,7 @@ def _call_viz(
     if save_file:
         Path(save_file).write_text(json.dumps(data, indent=4, sort_keys=True))
     else:
-        if browser:
-            webbrowser.open_new("http://127.0.0.1:{:d}/".format(port))
+        is_localhost = host == "127.0.0.1"
+        if browser and is_localhost:
+            webbrowser.open_new("http://{}:{:d}/".format(host, port))
         app.run(host=host, port=port)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -267,7 +267,7 @@ def commands():
     "--browser/--no-browser",
     default=True,
     help="Whether to open viz interface in the default browser or not. "
-    "Defaults to True.",
+    "Browser will only be opened if host is localhost. Defaults to True.",
 )
 @click.option(
     "--load-file",

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -349,7 +349,7 @@ def _call_viz(
     if save_file:
         Path(save_file).write_text(json.dumps(data, indent=4, sort_keys=True))
     else:
-        is_localhost = host == "127.0.0.1"
+        is_localhost = host in ("127.0.0.1", "localhost", "0.0.0.0")
         if browser and is_localhost:
             webbrowser.open_new("http://{}:{:d}/".format(host, port))
         app.run(host=host, port=port)

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -197,6 +197,19 @@ def test_no_browser(cli_runner):
     assert server.webbrowser.open_new.called
 
 
+@pytest.mark.usefixtures("patched_get_project_context")
+def test_no_browser_if_not_localhost(cli_runner):
+    """Check that call to open browser is not performed when host
+    is not the local host.
+    """
+    result = cli_runner.invoke(server.commands, ["viz", "--browser", "--host", "123.1.2.3"])
+    assert result.exit_code == 0, result.output
+    assert not server.webbrowser.open_new.called
+    result = cli_runner.invoke(server.commands, ["viz", "--host", "123.1.2.3"])
+    assert result.exit_code == 0, result.output
+    assert not server.webbrowser.open_new.called
+
+
 def test_load_file_outside_kedro_project(cli_runner, tmp_path):
     """Check that running viz with `--load-file` flag works outside of a Kedro project.
     """

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -172,7 +172,7 @@ def test_set_port(cli_runner,):
     result = cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
     assert result.exit_code == 0, result.output
     server.app.run.assert_called_with(host="127.0.0.1", port=8000)
-    assert server.webbrowser.open_new.called_with("http://127.0.0.1:8000/")
+    server.webbrowser.open_new.assert_called_with("http://127.0.0.1:8000/")
 
 
 @pytest.mark.usefixtures("patched_get_project_context")
@@ -181,7 +181,7 @@ def test_set_ip(cli_runner):
     result = cli_runner.invoke(server.commands, ["viz", "--host", "0.0.0.0"])
     assert result.exit_code == 0, result.output
     server.app.run.assert_called_with(host="0.0.0.0", port=4141)
-    assert server.webbrowser.open_new.called_with("http://127.0.0.1:4141/")
+    server.webbrowser.open_new.assert_called_with("http://0.0.0.0:4141/")
 
 
 @pytest.mark.usefixtures("patched_get_project_context")
@@ -194,7 +194,7 @@ def test_no_browser(cli_runner):
     assert not server.webbrowser.open_new.called
     result = cli_runner.invoke(server.commands, ["viz"])
     assert result.exit_code == 0, result.output
-    assert server.webbrowser.open_new.called
+    assert server.webbrowser.open_new.call_count == 1
 
 
 @pytest.mark.usefixtures("patched_get_project_context")
@@ -207,7 +207,7 @@ def test_no_browser_if_not_localhost(cli_runner):
     assert not server.webbrowser.open_new.called
     result = cli_runner.invoke(server.commands, ["viz", "--host", "123.1.2.3"])
     assert result.exit_code == 0, result.output
-    assert not server.webbrowser.open_new.called
+    assert not server.webbrowser.open_new.call_count
 
 
 def test_load_file_outside_kedro_project(cli_runner, tmp_path):


### PR DESCRIPTION
## Description

<!-- Why was this PR created? -->
Resolve https://github.com/quantumblacklabs/kedro-viz/issues/131
Reported issue is actually intended behaviour, but it's not entirely clear from the way the code is currently written. We should make this decision more explicit/transparent.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->
We intentionally only open Viz in a browser on localhost. Given a scenario where server is running remotely, we don't want to open web browser on that server.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
