### PR TITLE
[KED-1493] Limit zoom scale/translate extent

### DIFF
--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -64,6 +64,7 @@ describe('FlowChart', () => {
       centralNode: null,
       chartSize: expect.any(Object),
       edges: expect.any(Array),
+      graphSize: expect.any(Object),
       linkedNodes: expect.any(Object),
       nodes: expect.any(Array),
       textLabels: expect.any(Boolean),

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -8,6 +8,7 @@ import { updateChartSize } from '../../actions';
 import { toggleNodeClicked, toggleNodeHovered } from '../../actions/nodes';
 import {
   getChartSize,
+  getGraphSize,
   getLayoutNodes,
   getLayoutEdges,
   getZoomPosition
@@ -123,7 +124,23 @@ export class FlowChart extends Component {
    */
   initZoomBehaviour() {
     this.zoomBehaviour = zoom().on('zoom', () => {
+      const { k: scale } = event.transform;
+      const { sidebarWidth } = this.props.chartSize;
+      const { width, height } = this.props.graphSize;
+
+      // Limit zoom translate extent: This needs to be recalculated on zoom
+      // as it needs access to the current scale to correctly multiply the
+      // sidebarWidth by the scale to offset it properly
+      const margin = 200;
+      this.zoomBehaviour.translateExtent([
+        [-sidebarWidth / scale - margin, -margin],
+        [width + margin, height + margin]
+      ]);
+
+      // Transform the <g> that wraps the chart
       this.el.wrapper.attr('transform', event.transform);
+
+      // Hide the tooltip so it doesn't get misaligned to its node
       this.hideTooltip();
     });
     this.el.svg.call(this.zoomBehaviour);
@@ -134,6 +151,11 @@ export class FlowChart extends Component {
    */
   zoomChart() {
     const { scale = 1, translateX = 0, translateY = 0 } = this.props.zoom;
+
+    // Limit zoom scale extent
+    this.zoomBehaviour.scaleExtent([scale * 0.8, 1]);
+
+    // Auto zoom to fit the chart nicely on the page
     this.el.svg
       .transition()
       .duration(this.DURATION)
@@ -292,6 +314,7 @@ export class FlowChart extends Component {
 export const mapStateToProps = state => ({
   centralNode: getCentralNode(state),
   chartSize: getChartSize(state),
+  graphSize: getGraphSize(state),
   edges: getLayoutEdges(state),
   linkedNodes: getLinkedNodes(state),
   nodes: getLayoutNodes(state),

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -314,8 +314,8 @@ export class FlowChart extends Component {
 export const mapStateToProps = state => ({
   centralNode: getCentralNode(state),
   chartSize: getChartSize(state),
-  graphSize: getGraphSize(state),
   edges: getLayoutEdges(state),
+  graphSize: getGraphSize(state),
   linkedNodes: getLinkedNodes(state),
   nodes: getLayoutNodes(state),
   textLabels: state.textLabels,


### PR DESCRIPTION
# Description

Prevent users from zooming too far in/out and panning too far up/down/left/right.

This will help a lot with the upcoming layers feature in #129 - I originally implemented it in that PR, but have split it out into its own PR to help make the review a little smaller.

## Development notes

Unfortunately, the translation extent needs to be recalculated on every zoom tick as it needs access to the current scale integer, to correctly multiply the sidebarWidth by the scale to offset it properly

## QA notes

Zoom in/out and pan up/down/left/right

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
