### PR TITLE
[KED-1491] Drop Python 3.5 support in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,12 +118,12 @@ utils:
       git push origin master:gh-pages --force
 
 jobs:
-  build_35: &DEFAULT
+  build_36: &DEFAULT
     docker:
       - image: circleci/node:10.15
     working_directory: ~/repo
     environment:
-      CONDA_ENV_PY_VERSION: '3.5'
+      CONDA_ENV_PY_VERSION: "3.6"
     steps:
       - checkout
       - restore_cache: *restore_cache
@@ -146,15 +146,10 @@ jobs:
       - run: *package_app
       - run: *check_legal_compliance
 
-  build_36:
-    <<: *DEFAULT
-    environment:
-      CONDA_ENV_PY_VERSION: '3.6'
-
   build_37:
     <<: *DEFAULT
     environment:
-      CONDA_ENV_PY_VERSION: '3.7'
+      CONDA_ENV_PY_VERSION: "3.7"
 
   deploy_demo:
     <<: *DEFAULT
@@ -170,12 +165,10 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_35
       - build_36
       - build_37
       - deploy_demo:
           requires:
-            - build_35
             - build_36
             - build_37
           filters:
@@ -184,13 +177,12 @@ workflows:
   daily:
     triggers:
       - schedule:
-          cron: '0 1 * * *'
+          cron: "0 1 * * *"
           filters:
             branches:
               only:
                 - develop
                 - master
     jobs:
-      - build_35
       - build_36
       - build_37

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Working on your first pull request? You can learn how from these resources:
 
 - Aim for cross-platform compatibility on Windows, macOS and Linux, and support recent versions of major browsers
 - We use [SemVer](https://semver.org/) for versioning
-- Our code is designed to be compatible with Python 3.5 onwards
+- Our code is designed to be compatible with Python 3.6 onwards
 - We use [Anaconda](https://www.anaconda.com/distribution/) as a preferred virtual environment
 - We use [PEP 8 conventions](https://www.python.org/dev/peps/pep-0008/) for all Python code
 - We use [Google docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) for code comments

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm version](https://img.shields.io/npm/v/@quantumblack/kedro-viz.svg?color=cc3534)](https://badge.fury.io/js/%40quantumblack%2Fkedro-viz)
 [![PyPI version](https://img.shields.io/pypi/v/kedro-viz.svg?color=yellow)](https://pypi.org/project/kedro-viz/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-3da639.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Python Version](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7-blue.svg)](https://pypi.org/project/kedro-viz/)
+[![Python Version](https://img.shields.io/badge/python-3.6%20%7C%203.7-blue.svg)](https://pypi.org/project/kedro-viz/)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 Kedro-Viz shows you how your [Kedro](https://github.com/quantumblacklabs/kedro) data pipelines are structured.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 <!-- Add release notes for the upcoming release here -->
-- Remove Python 3.5 CI (#138)
+- Drop support for Python 3.5 CI (#138)
 - Add logger configuration when loading pipeline from JSON (#133)
 - Move visibleNav/navWidth calculations into Redux store (#124)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 <!-- Add release notes for the upcoming release here -->
-- Drop support for Python 3.5 CI (#138)
+- Drop support for Python 3.5 (#138)
 - Add logger configuration when loading pipeline from JSON (#133)
 - Move visibleNav/navWidth calculations into Redux store (#124)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,10 +16,12 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 <!-- Add release notes for the upcoming release here -->
+- Remove Python 3.5 CI (#138)
+- Add logger configuration when loading pipeline from JSON (#133)
 - Move visibleNav/navWidth calculations into Redux store (#124)
-- `kedro viz --load-file=XX` stopped emitting log files 
 
 ## Thanks for supporting contributions
+
 [Ana Potje](https://github.com/ANA-POTJE)
 
 # Release 3.2.0:

--- a/package/setup.py
+++ b/package/setup.py
@@ -69,7 +69,7 @@ setup(
     long_description_content_type="text/markdown",
     license="Apache Software License (Apache 2.0)",
     url="https://github.com/quantumblacklabs/kedro-viz",
-    python_requires=">=3.5, <3.8",
+    python_requires=">=3.6, <3.8",
     install_requires=requires,
     tests_require=test_requires,
     keywords="pipelines, machine learning, data pipelines, data science, data engineering, visualisation",


### PR DESCRIPTION
## Description

Kedro has stopped supporting Python 3.5, and this has broken the CI builds in Kedro plugins

## Development notes

Remove Python 3.5 job in CI

## QA notes

N/A

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
