### PR TITLE
Break D3 draw function into multiple functions

### DIFF
--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -5,66 +5,15 @@ import { curveBasis, line } from 'd3-shape';
 import icon from './icon';
 
 /**
- * Render chart to the DOM with D3
+ * Render node icons and name labels
  */
-const draw = function() {
-  const { nodes, edges, centralNode, linkedNodes, textLabels } = this.props;
-
-  // Create selections
-  this.el.edges = this.el.edgeGroup
-    .selectAll('.edge')
-    .data(edges, edge => edge.id);
+const drawNodes = function() {
+  const { nodes, centralNode, linkedNodes, textLabels } = this.props;
 
   this.el.nodes = this.el.nodeGroup
     .selectAll('.node')
     .data(nodes, node => node.id);
 
-  // Set up line shape function
-  const lineShape = line()
-    .x(d => d.x)
-    .y(d => d.y)
-    .curve(curveBasis);
-
-  // Create edges
-  const enterEdges = this.el.edges
-    .enter()
-    .append('g')
-    .attr('class', 'edge')
-    .attr('opacity', 0);
-
-  enterEdges.append('path').attr('marker-end', d => `url(#arrowhead)`);
-
-  this.el.edges
-    .exit()
-    .transition('exit-edges')
-    .duration(this.DURATION)
-    .attr('opacity', 0)
-    .remove();
-
-  this.el.edges = this.el.edges.merge(enterEdges);
-
-  this.el.edges
-    .attr('data-id', edge => edge.id)
-    .classed(
-      'edge--faded',
-      ({ source, target }) =>
-        centralNode && (!linkedNodes[source] || !linkedNodes[target])
-    )
-    .transition('show-edges')
-    .duration(this.DURATION)
-    .attr('opacity', 1);
-
-  this.el.edges
-    .select('path')
-    .transition('update-edges')
-    .duration(this.DURATION)
-    .attrTween('d', function(edge) {
-      const current = edge.points && lineShape(edge.points);
-      const previous = select(this).attr('d') || current;
-      return interpolatePath(previous, current);
-    });
-
-  // Create nodes
   const enterNodes = this.el.nodes
     .enter()
     .append('g')
@@ -139,6 +88,70 @@ const draw = function() {
     .attr('height', node => node.iconSize)
     .attr('x', node => node.iconOffset)
     .attr('y', node => node.iconSize / -2);
+};
+
+/**
+ * Render edge lines
+ */
+const drawEdges = function() {
+  const { edges, centralNode, linkedNodes } = this.props;
+
+  this.el.edges = this.el.edgeGroup
+    .selectAll('.edge')
+    .data(edges, edge => edge.id);
+
+  // Set up line shape function
+  const lineShape = line()
+    .x(d => d.x)
+    .y(d => d.y)
+    .curve(curveBasis);
+
+  // Create edges
+  const enterEdges = this.el.edges
+    .enter()
+    .append('g')
+    .attr('class', 'edge')
+    .attr('opacity', 0);
+
+  enterEdges.append('path').attr('marker-end', d => `url(#arrowhead)`);
+
+  this.el.edges
+    .exit()
+    .transition('exit-edges')
+    .duration(this.DURATION)
+    .attr('opacity', 0)
+    .remove();
+
+  this.el.edges = this.el.edges.merge(enterEdges);
+
+  this.el.edges
+    .attr('data-id', edge => edge.id)
+    .classed(
+      'edge--faded',
+      ({ source, target }) =>
+        centralNode && (!linkedNodes[source] || !linkedNodes[target])
+    )
+    .transition('show-edges')
+    .duration(this.DURATION)
+    .attr('opacity', 1);
+
+  this.el.edges
+    .select('path')
+    .transition('update-edges')
+    .duration(this.DURATION)
+    .attrTween('d', function(edge) {
+      const current = edge.points && lineShape(edge.points);
+      const previous = select(this).attr('d') || current;
+      return interpolatePath(previous, current);
+    });
+};
+
+/**
+ * Render chart to the DOM with D3
+ */
+const draw = function() {
+  drawEdges.call(this);
+  drawNodes.call(this);
 };
 
 export default draw;


### PR DESCRIPTION
## Description

Simplify the code and make it easier to follow.

## Development notes

This PR is broken out of #129, to ultimately make that PR smaller. The layers PR will add two more draw functions (drawLayers and drawLayerNames), which is why this is necessary.

## QA notes

No functionality changes

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
