### PR TITLE
(KED-1516) Stop kedro-viz from swallowing stacktraces

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,8 @@ Please follow the established format:
 - Drop support for Python 3.5 (#138)
 - Add logger configuration when loading pipeline from JSON (#133)
 - Move visibleNav/navWidth calculations into Redux store (#124)
-- Web browser will only be opened if the host corresponds to the localhost 
+- Web browser will only be opened if the host corresponds to the localhost (#136)
+- Print the stack trace when encountering a generic exception (#142)
 
 ## Thanks for supporting contributions
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -33,6 +33,7 @@ import json
 import logging
 import multiprocessing
 import socket
+import traceback
 import webbrowser
 from collections import defaultdict
 from contextlib import closing
@@ -305,6 +306,7 @@ def viz(host, port, browser, load_file, save_file, pipeline, env):
     except KedroCliError:
         raise
     except Exception as ex:
+        traceback.print_exc()
         raise KedroCliError(str(ex))
 
 

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -202,7 +202,9 @@ def test_no_browser_if_not_localhost(cli_runner):
     """Check that call to open browser is not performed when host
     is not the local host.
     """
-    result = cli_runner.invoke(server.commands, ["viz", "--browser", "--host", "123.1.2.3"])
+    result = cli_runner.invoke(
+        server.commands, ["viz", "--browser", "--host", "123.1.2.3"]
+    )
     assert result.exit_code == 0, result.output
     assert not server.webbrowser.open_new.called
     result = cli_runner.invoke(server.commands, ["viz", "--host", "123.1.2.3"])
@@ -383,6 +385,16 @@ def test_viz_kedro14_invalid(mocker, cli_runner):
     mocker.patch("kedro_viz.server.get_project_context", side_effect=KeyError)
     result = cli_runner.invoke(server.commands, "viz")
     assert "Could not find a Kedro project root." in result.output
+
+
+def test_viz_stacktrace(mocker, cli_runner):
+    """Test that in the case of a generic exception,
+    the stacktrace is printer."""
+    mocker.patch("kedro_viz.server._call_viz", side_effect=ValueError)
+    result = cli_runner.invoke(server.commands, "viz")
+
+    assert "Traceback (most recent call last):" in result.output
+    assert "ValueError" in result.output
 
 
 @pytest.fixture(autouse=True)

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -389,7 +389,7 @@ def test_viz_kedro14_invalid(mocker, cli_runner):
 
 def test_viz_stacktrace(mocker, cli_runner):
     """Test that in the case of a generic exception,
-    the stacktrace is printer."""
+    the stacktrace is printed."""
     mocker.patch("kedro_viz.server._call_viz", side_effect=ValueError)
     result = cli_runner.invoke(server.commands, "viz")
 


### PR DESCRIPTION
## Description

I'm a little uneasy about my approach here, so would welcome comments. Also, I guess this only prints stacktraces for generic exceptions and not for exceptions that are already `KedroCLIError`'s (from `_call_viz`) -- should I do it there too? 

When there's an underlying generic exception (e.g in your pipeline file, missing a comma or some syntax issue) kedro-viz silently prints something like `Error: invalid syntax (pipeline.py, line 64)` without the (sometimes helpful) stacktrace.

## Development notes

Use `traceback` to print the stacktrace before continuing with the `KedroCLIError`. Sadly the usual `raise a from b` trick doesn't work here because of the way `click` handles exceptions (and our custom `KedroCLIError` inherits from `click.Exception`).

## QA notes

Added a test that makes sure that the traceback is printed when `_call_viz` returns a `ValueError`.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
