### PR TITLE
Remove dateutil hardpinning in requirements.txt

### DIFF
--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,7 +1,3 @@
-python-dateutil==2.8.0 # explicit hard pin to resolve random pip dependency resolution failure,
-# in order to unblock release.
-# botocore requires <2.8.1, whereas pandas requires >=2.6.0. Pip dependency resolution ramdomly
-# picks either and sometimes fails. This pinning needs to be removed later.
 semver>=2.0.0,<3.0.0
 Flask>=1.0, <2.0
 kedro>=0.14.0


### PR DESCRIPTION
## Description

Since dateutil released 2.8.1 in https://github.com/dateutil/dateutil/releases, I'm removing the hardpinning that was done in https://github.com/quantumblacklabs/kedro-viz/commit/6f894073f531aedf22859de0716a8f3f20b3bd69

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
