### PR TITLE
[KED-1564] Make dataPath relative again

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -53,7 +53,7 @@ const validateDataSource = source => {
  * Generate a configuration object for use across the application
  */
 const config = () => ({
-  dataPath: '/api/nodes.json',
+  dataPath: './api/nodes.json',
   dataSource: getDataSource(),
   localStorageName: 'KedroViz'
 });

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -21,6 +21,10 @@ describe('config', () => {
     });
   });
 
+  it('should return a relative dataPath', () => {
+    expect(config().dataPath.substr(0, 2)).toEqual('./');
+  });
+
   it('should return "json" as the datasource if undefined', () => {
     expect(config().dataSource).toBe('json');
   });

--- a/src/store/load-data.js
+++ b/src/store/load-data.js
@@ -6,9 +6,11 @@ import config from '../config';
  */
 const loadJsonData = () => {
   const { dataPath } = config();
+  const fullPath = `/public${dataPath.substr(1)}`;
+
   return json(dataPath).catch(() => {
     throw new Error(
-      `Unable to load pipeline data from ${dataPath}. If you're running Kedro-Viz as a standalone (e.g. for JavaScript development), please check that you have placed a data file at /public${dataPath}.`
+      `Unable to load pipeline data from ${dataPath}. If you're running Kedro-Viz as a standalone (e.g. for JavaScript development), please check that you have placed a data file at ${fullPath}.`
     );
   });
 };


### PR DESCRIPTION
## Description

Raised by @gbraccialli-qb:
> "Last year, I requested Viz to work on relative paths, it's helpful to use it on jupyter hub proxy and publish it to users that don't have kedro installed locally. It was added in [the old internal version of Viz], but it doesn't work on latest version of kedro-viz. Is it possible to add it back?"

## Development notes

I've added a new test to ensure that I don't break this again 🙈

## QA notes

n/a

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
