### PR TITLE
[KED-1461] Fix bug where exported PNG was cut off

### DIFF
--- a/src/components/icon-toolbar/export-modal.js
+++ b/src/components/icon-toolbar/export-modal.js
@@ -11,17 +11,18 @@ const { default: downloadSvg, downloadPng } =
  * @param {Function} download SVG-crowbar function to download SVG or PNG
  * @param {string} format Must be 'svg' or 'png'
  * @param {string} theme light/dark theme
- * @param {number} param.width Graph width
- * @param {number} param.height Graph height
+ * @param {Object} graphSize Graph width/height/margin
  * @return {Function} onClick handler
  */
-export const exportGraph = (download, format, theme, { width, height }) => {
-  const svg = document.querySelector('#pipeline-graph');
+export const exportGraph = (download, format, theme, graphSize) => {
   // Create clone of graph SVG to avoid breaking the original
+  const svg = document.querySelector('#pipeline-graph');
   const clone = svg.parentNode.appendChild(svg.cloneNode(true));
   clone.classList.add('kedro', `kui-theme--${theme}`);
 
   // Reset zoom/translate
+  let width = graphSize.width + graphSize.marginx * 2;
+  let height = graphSize.height + graphSize.marginy * 2;
   clone.setAttribute('viewBox', `0 0 ${width} ${height}`);
   clone.querySelector('#zoom-wrapper').removeAttribute('transform');
 

--- a/src/components/icon-toolbar/export-modal.test.js
+++ b/src/components/icon-toolbar/export-modal.test.js
@@ -22,7 +22,12 @@ describe('IconToolbar', () => {
   });
 
   describe('exportGraph', () => {
-    const graphSize = { width: 1000, height: 500 };
+    const graphSize = {
+      width: 1000,
+      height: 500,
+      marginx: 40,
+      marginy: 40
+    };
 
     beforeEach(() => {
       document.body.innerHTML = `


### PR DESCRIPTION
## Description

One of our users reported that their exported PNGs are missing an edge line on the right side, that is being cut off:
<img src="https://user-images.githubusercontent.com/1155816/80397348-e3c0bb00-88ad-11ea-9768-18c506d2bffb.png" width="400" />

## Development notes

It turns out that the width/height values in graphSize did not include margin. Adding these to the overall w/h value solves the bug.

## QA notes

Steps to reproduce the error:

1. Download "viz2.json" attached on the JIRA ticket
2. `pip install kedro-viz==3.2.0`
3. `kedro viz --load-file=viz2.json`
4. Click "Download PNG" from the UI
5. Right part of the pipeline is not showing (see the attached screenshot)

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
