### PR TITLE
[KED-1586] Add node selected state, and improve node active/selected styling

### DIFF
--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -79,8 +79,8 @@ const drawNodes = function() {
     centralNode,
     linkedNodes,
     nodeActive,
+    nodeSelected,
     nodes,
-    selectedNode,
     textLabels
   } = this.props;
 
@@ -125,7 +125,7 @@ const drawNodes = function() {
     .classed('node--icon', !textLabels)
     .classed('node--text', textLabels)
     .classed('node--active', node => nodeActive[node.id])
-    .classed('node--selected', node => node.id === selectedNode)
+    .classed('node--selected', node => nodeSelected[node.id])
     .classed('node--highlight', node => centralNode && linkedNodes[node.id])
     .classed('node--faded', node => centralNode && !linkedNodes[node.id])
     .on('click', this.handleNodeClick)

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -76,10 +76,11 @@ const drawLayerNames = function() {
  */
 const drawNodes = function() {
   const {
-    nodes,
-    nodeActive,
     centralNode,
     linkedNodes,
+    nodeActive,
+    nodes,
+    selectedNode,
     textLabels
   } = this.props;
 
@@ -124,6 +125,7 @@ const drawNodes = function() {
     .classed('node--icon', !textLabels)
     .classed('node--text', textLabels)
     .classed('node--active', node => nodeActive[node.id])
+    .classed('node--selected', node => node.id === selectedNode)
     .classed('node--highlight', node => centralNode && linkedNodes[node.id])
     .classed('node--faded', node => centralNode && !linkedNodes[node.id])
     .on('click', this.handleNodeClick)

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -68,6 +68,7 @@ describe('FlowChart', () => {
       layers: expect.any(Array),
       linkedNodes: expect.any(Object),
       nodeActive: expect.any(Object),
+      nodeSelected: expect.any(Object),
       nodes: expect.any(Array),
       textLabels: expect.any(Boolean),
       visibleLayers: expect.any(Boolean),

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -339,6 +339,7 @@ export const mapStateToProps = state => ({
   linkedNodes: getLinkedNodes(state),
   nodes: getLayoutNodes(state),
   nodeActive: getNodeActive(state),
+  selectedNode: state.node.clicked,
   textLabels: state.textLabels,
   visibleLayers: state.visible.layers,
   visibleSidebar: state.visible.sidebar,

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -6,7 +6,7 @@ import { select, event } from 'd3-selection';
 import { zoom, zoomIdentity } from 'd3-zoom';
 import { updateChartSize } from '../../actions';
 import { toggleNodeClicked, toggleNodeHovered } from '../../actions/nodes';
-import { getNodeActive } from '../../selectors/nodes';
+import { getNodeActive, getNodeSelected } from '../../selectors/nodes';
 import {
   getChartSize,
   getGraphSize,
@@ -339,7 +339,7 @@ export const mapStateToProps = state => ({
   linkedNodes: getLinkedNodes(state),
   nodes: getLayoutNodes(state),
   nodeActive: getNodeActive(state),
-  selectedNode: state.node.clicked,
+  nodeSelected: getNodeSelected(state),
   textLabels: state.textLabels,
   visibleLayers: state.visible.layers,
   visibleSidebar: state.visible.sidebar,

--- a/src/components/flowchart/styles/_node.scss
+++ b/src/components/flowchart/styles/_node.scss
@@ -42,7 +42,9 @@
   }
 }
 
-.node--highlight {
+.node--highlight,
+.node--active,
+.node--selected {
   text {
     .kui-theme--light & {
       fill: $node-labeltext-fill-light-active;
@@ -52,8 +54,12 @@
       fill: $node-labeltext-fill-dark-active;
     }
   }
+}
 
+.node--active {
   rect {
+    stroke-width: 2px;
+
     .kui-theme--light & {
       fill: $node-fill-light-highlight;
       stroke: $node-stroke-light-highlight;
@@ -66,17 +72,7 @@
   }
 }
 
-.node--active {
-  text {
-    .kui-theme--light & {
-      fill: $node-labeltext-fill-light-active;
-    }
-
-    .kui-theme--dark & {
-      fill: $node-labeltext-fill-dark-active;
-    }
-  }
-
+.node--selected {
   rect {
     stroke-width: 3px;
 

--- a/src/components/node-list/node-list-group.js
+++ b/src/components/node-list/node-list-group.js
@@ -18,15 +18,10 @@ export const NodeListGroup = ({
         <div>
           <h3 className="pipeline-nodelist__heading">
             <NodeListRow
-              active={null}
               checked={!type.disabled}
-              disabled={null}
               id={type.id}
               label={type.name}
               name={type.name}
-              onClick={null}
-              onMouseEnter={null}
-              onMouseLeave={null}
               onChange={e => {
                 onToggleTypeDisabled(type.id, !e.target.checked);
               }}

--- a/src/components/node-list/node-list-groups.js
+++ b/src/components/node-list/node-list-groups.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { Flipper } from 'react-flip-toolkit';
 import { loadState, saveState } from '../../store/helpers';
-import { getNodeActive } from '../../selectors/nodes';
+import { getNodeActive, getNodeSelected } from '../../selectors/nodes';
 import { getNodeTypes } from '../../selectors/node-types';
 import NodeListGroup from './node-list-group';
 import NodeListRow from './node-list-row';
@@ -20,7 +20,7 @@ const NodeListGroups = ({
   onToggleNodeHovered,
   nodes,
   nodeActive,
-  selectedNode,
+  nodeSelected,
   types
 }) => {
   const [collapsed, setCollapsed] = useState(storedState.groupsCollapsed || {});
@@ -59,7 +59,7 @@ const NodeListGroups = ({
                 onChange={e => {
                   onToggleNodesDisabled([node.id], !e.target.checked);
                 }}
-                selected={node.id === selectedNode}
+                selected={nodeSelected[node.id]}
                 type={node.type}
               />
             </li>
@@ -78,7 +78,7 @@ const NodeListGroups = ({
 
 export const mapStateToProps = state => ({
   nodeActive: getNodeActive(state),
-  selectedNode: state.node.clicked,
+  nodeSelected: getNodeSelected(state),
   types: getNodeTypes(state)
 });
 

--- a/src/components/node-list/node-list-groups.js
+++ b/src/components/node-list/node-list-groups.js
@@ -20,6 +20,7 @@ const NodeListGroups = ({
   onToggleNodeHovered,
   nodes,
   nodeActive,
+  selectedNode,
   types
 }) => {
   const [collapsed, setCollapsed] = useState(storedState.groupsCollapsed || {});
@@ -58,6 +59,7 @@ const NodeListGroups = ({
                 onChange={e => {
                   onToggleNodesDisabled([node.id], !e.target.checked);
                 }}
+                selected={node.id === selectedNode}
                 type={node.type}
               />
             </li>
@@ -76,6 +78,7 @@ const NodeListGroups = ({
 
 export const mapStateToProps = state => ({
   nodeActive: getNodeActive(state),
+  selectedNode: state.node.clicked,
   types: getNodeTypes(state)
 });
 

--- a/src/components/node-list/node-list-groups.test.js
+++ b/src/components/node-list/node-list-groups.test.js
@@ -24,6 +24,7 @@ describe('NodeListGroups', () => {
   it('maps state to props', () => {
     const expectedResult = {
       nodeActive: expect.any(Object),
+      nodeSelected: expect.any(Object),
       types: expect.arrayContaining([
         expect.objectContaining({
           disabled: expect.any(Boolean),

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -24,6 +24,7 @@ const NodeListRow = ({
   return (
     <div
       className={classnames('pipeline-nodelist__row kedro', {
+        'pipeline-nodelist__row--button': Boolean(onClick),
         'pipeline-nodelist__row--active': active,
         'pipeline-nodelist__row--disabled': disabled
       })}

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -20,23 +20,24 @@ const NodeListRow = ({
   type
 }) => {
   const VisibilityIcon = checked ? VisibleIcon : InvisibleIcon;
-  const TextElement = onClick ? 'button' : 'div';
+  const useButton = Boolean(onClick && !disabled && checked);
+  const Text = useButton ? 'button' : 'div';
 
   return (
     <div
       className={classnames('pipeline-nodelist__row kedro', {
-        'pipeline-nodelist__row--button': Boolean(onClick),
+        'pipeline-nodelist__row--button': useButton,
         'pipeline-nodelist__row--active': active,
         'pipeline-nodelist__row--selected': selected,
         'pipeline-nodelist__row--disabled': disabled
       })}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}>
-      <TextElement
+      onMouseEnter={useButton ? onMouseEnter : null}
+      onMouseLeave={useButton ? onMouseLeave : null}>
+      <Text
         className="pipeline-nodelist__row__text"
-        onClick={onClick}
-        onFocus={onMouseEnter}
-        onBlur={onMouseLeave}
+        onClick={useButton ? onClick : null}
+        onFocus={useButton ? onMouseEnter : null}
+        onBlur={useButton ? onMouseLeave : null}
         disabled={disabled}
         title={children ? null : name}>
         <NodeIcon
@@ -55,7 +56,7 @@ const NodeListRow = ({
           })}
           dangerouslySetInnerHTML={{ __html: label }}
         />
-      </TextElement>
+      </Text>
       {children}
       <label htmlFor={id} className="pipeline-nodelist__row__visibility">
         <input

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -20,25 +20,24 @@ const NodeListRow = ({
   type
 }) => {
   const VisibilityIcon = checked ? VisibleIcon : InvisibleIcon;
-  const useButton = Boolean(onClick && !disabled && checked);
-  const Text = useButton ? 'button' : 'div';
+  const visible = Boolean(onClick && !disabled && checked);
 
   return (
     <div
       className={classnames('pipeline-nodelist__row kedro', {
-        'pipeline-nodelist__row--button': useButton,
+        'pipeline-nodelist__row--visible': visible,
         'pipeline-nodelist__row--active': active,
         'pipeline-nodelist__row--selected': selected,
         'pipeline-nodelist__row--disabled': disabled
       })}
-      onMouseEnter={useButton ? onMouseEnter : null}
-      onMouseLeave={useButton ? onMouseLeave : null}>
-      <Text
+      onMouseEnter={visible ? onMouseEnter : null}
+      onMouseLeave={visible ? onMouseLeave : null}>
+      <button
         className="pipeline-nodelist__row__text"
-        onClick={useButton ? onClick : null}
-        onFocus={useButton ? onMouseEnter : null}
-        onBlur={useButton ? onMouseLeave : null}
-        disabled={disabled}
+        onClick={onClick}
+        onFocus={onMouseEnter}
+        onBlur={onMouseLeave}
+        disabled={!visible}
         title={children ? null : name}>
         <NodeIcon
           className={classnames(
@@ -56,7 +55,7 @@ const NodeListRow = ({
           })}
           dangerouslySetInnerHTML={{ __html: label }}
         />
-      </Text>
+      </button>
       {children}
       <label htmlFor={id} className="pipeline-nodelist__row__visibility">
         <input

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -30,14 +30,11 @@ const NodeListRow = ({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}>
       <TextElement
+        className="pipeline-nodelist__row__text"
         onClick={onClick}
         onFocus={onMouseEnter}
         onBlur={onMouseLeave}
         disabled={disabled}
-        className={classnames('pipeline-nodelist__row__text', {
-          'pipeline-nodelist__row__text--active': active,
-          'pipeline-nodelist__row__text--unchecked': !checked
-        })}
         title={children ? null : name}>
         <NodeIcon
           className={classnames(

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -21,6 +21,7 @@ const NodeListRow = ({
 }) => {
   const VisibilityIcon = checked ? VisibleIcon : InvisibleIcon;
   const visible = Boolean(onClick && !disabled && checked);
+  const faded = disabled || !checked;
 
   return (
     <div
@@ -43,7 +44,7 @@ const NodeListRow = ({
           className={classnames(
             'pipeline-nodelist__row__type-icon pipeline-nodelist__row__icon',
             {
-              'pipeline-nodelist__row__type-icon--unchecked': !checked,
+              'pipeline-nodelist__row__type-icon--faded': faded,
               'pipeline-nodelist__row__type-icon--nested': !children
             }
           )}
@@ -51,7 +52,7 @@ const NodeListRow = ({
         />
         <span
           className={classnames('pipeline-nodelist__row__label', {
-            'pipeline-nodelist__row__label--faded': disabled || !checked
+            'pipeline-nodelist__row__label--faded': faded
           })}
           dangerouslySetInnerHTML={{ __html: label }}
         />

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -19,6 +19,7 @@ const NodeListRow = ({
   type
 }) => {
   const VisibilityIcon = checked ? VisibleIcon : InvisibleIcon;
+  const TextElement = onClick ? 'button' : 'div';
 
   return (
     <div
@@ -28,7 +29,7 @@ const NodeListRow = ({
       })}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}>
-      <button
+      <TextElement
         onClick={onClick}
         onFocus={onMouseEnter}
         onBlur={onMouseLeave}
@@ -56,7 +57,7 @@ const NodeListRow = ({
           })}
           dangerouslySetInnerHTML={{ __html: label }}
         />
-      </button>
+      </TextElement>
       {children}
       <label htmlFor={id} className="pipeline-nodelist__row__visibility">
         <input

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -16,6 +16,7 @@ const NodeListRow = ({
   onMouseLeave,
   onChange,
   onClick,
+  selected,
   type
 }) => {
   const VisibilityIcon = checked ? VisibleIcon : InvisibleIcon;
@@ -26,6 +27,7 @@ const NodeListRow = ({
       className={classnames('pipeline-nodelist__row kedro', {
         'pipeline-nodelist__row--button': Boolean(onClick),
         'pipeline-nodelist__row--active': active,
+        'pipeline-nodelist__row--selected': selected,
         'pipeline-nodelist__row--disabled': disabled
       })}
       onMouseEnter={onMouseEnter}

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -49,9 +49,7 @@ const NodeListRow = ({
         />
         <span
           className={classnames('pipeline-nodelist__row__label', {
-            'pipeline-nodelist__row__label--active': active,
-            'pipeline-nodelist__row__label--disabled': disabled,
-            'pipeline-nodelist__row__label--unchecked': !checked
+            'pipeline-nodelist__row__label--faded': disabled || !checked
           })}
           dangerouslySetInnerHTML={{ __html: label }}
         />

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -2,6 +2,7 @@
   position: relative;
   display: flex;
   align-items: center;
+  transition: background-color ease $row-transition;
 
   &--active,
   &--button:hover {
@@ -24,7 +25,7 @@
   flex-shrink: 0;
   width: $row-icon-size;
   height: $row-icon-size;
-  transition: opacity ease 0.1s;
+  transition: opacity ease $row-transition;
 
   .kui-theme--light & {
     fill: $color-text-light;
@@ -66,7 +67,7 @@
   border: none;
   border-radius: 0;
   box-shadow: none;
-  transition: opacity ease 0.1s;
+  transition: opacity ease $row-transition;
 
   &:focus {
     outline: 4px solid $color-link;
@@ -86,6 +87,7 @@
   font-size: 1.6em;
   white-space: nowrap;
   text-overflow: ellipsis;
+  transition: opacity ease $row-transition;
 
   &--faded {
     opacity: 0.55;
@@ -109,7 +111,6 @@
   padding: $visibility-icon-padding;
   border-radius: 50%;
   opacity: 0;
-  transition: opacity ease 0.2s;
 
   &--unchecked,
   .pipeline-nodelist__row__text:focus + label &,
@@ -123,7 +124,6 @@
 
   .pipeline-nodelist__row__checkbox:focus + & {
     outline: none;
-    transition: box-shadow ease 0.2s;
 
     [data-whatintent='keyboard'] & {
       box-shadow: 0 0 0 3px $color-link inset;

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -6,13 +6,25 @@
 
   &--active,
   &--visible:hover {
-    background: rgba(#fff, 0.05);
+    .kui-theme--light & {
+      background-color: darken($color-bg-light-alt2, 4%);
+    }
+
+    .kui-theme--dark & {
+      background-color: lighten($color-bg-dark-alt2, 4%);
+    }
   }
 
   &--selected,
   // additional selector required to increase specificity to override previous rule:
   &--visible#{&}--selected {
-    background: rgba(#fff, 0.12);
+    .kui-theme--light & {
+      background-color: darken($color-bg-light-alt2, 10%);
+    }
+
+    .kui-theme--dark & {
+      background-color: lighten($color-bg-dark-alt2, 10%);
+    }
   }
 
   &--disabled {

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -84,8 +84,7 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 
-  &--disabled,
-  &--unchecked {
+  &--faded {
     opacity: 0.55;
   }
 

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -49,7 +49,7 @@
   [data-whatintent='keyboard'] .pipeline-nodelist__row__text:focus & {
     opacity: 1;
 
-    &--unchecked {
+    &--faded {
       opacity: 0.55;
     }
   }

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -62,6 +62,8 @@
   padding: $row-padding-y $row-offset-right $row-padding-y $row-offset-left;
   color: inherit;
   font-size: inherit;
+  font-family: inherit;
+  letter-spacing: inherit;
   text-align: inherit;
   background: none;
   border: none;

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -8,9 +8,10 @@
     background: rgba(#fff, 0.05);
   }
 
-  &--active,
-  &--active:hover {
-    background: rgba(#fff, 0.1);
+  &--selected,
+  // additional selector required to increase specificity to override previous rule:
+  &--button#{&}--selected {
+    background: rgba(#fff, 0.12);
   }
 
   &--disabled {
@@ -42,6 +43,8 @@
   }
 
   .pipeline-nodelist__row:hover &,
+  .pipeline-nodelist__row--active &,
+  .pipeline-nodelist__row--selected &,
   [data-whatintent='keyboard'] .pipeline-nodelist__row__text:focus & {
     opacity: 1;
 

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -67,6 +67,7 @@
   border: none;
   border-radius: 0;
   box-shadow: none;
+  cursor: default;
   transition: opacity ease $row-transition;
 
   &:focus {

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -3,7 +3,8 @@
   display: flex;
   align-items: center;
 
-  &:hover {
+  &--active,
+  &--button:hover {
     background: rgba(#fff, 0.05);
   }
 

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -5,13 +5,13 @@
   transition: background-color ease $row-transition;
 
   &--active,
-  &--button:hover {
+  &--visible:hover {
     background: rgba(#fff, 0.05);
   }
 
   &--selected,
   // additional selector required to increase specificity to override previous rule:
-  &--button#{&}--selected {
+  &--visible#{&}--selected {
     background: rgba(#fff, 0.12);
   }
 

--- a/src/components/node-list/styles/_variables.scss
+++ b/src/components/node-list/styles/_variables.scss
@@ -1,5 +1,6 @@
 $toggle-size: 2.4em;
 $toggle-margin-right: 0.8em;
+$row-transition: 0.1s;
 $row-padding-y: 0.8em;
 $row-padding-x: 1.2em;
 $row-icon-margin: 0.5em;

--- a/src/reducers/nodes.js
+++ b/src/reducers/nodes.js
@@ -16,6 +16,9 @@ function nodeReducer(nodeState = {}, action) {
 
     case TOGGLE_NODES_DISABLED: {
       return updateState({
+        clicked: action.nodeIDs.includes(nodeState.clicked)
+          ? null
+          : nodeState.clicked,
         disabled: action.nodeIDs.reduce(
           (disabled, id) =>
             Object.assign({}, disabled, {

--- a/src/reducers/reducers.test.js
+++ b/src/reducers/reducers.test.js
@@ -75,6 +75,23 @@ describe('Reducer', () => {
       });
       expect(newState.node.disabled).toEqual({ '123': true, abc: true });
     });
+
+    it('should set nodeClicked to null if the selected node is being disabled', () => {
+      const nodeID = 'abc123';
+      const clickNodeAction = {
+        type: TOGGLE_NODE_CLICKED,
+        nodeClicked: nodeID
+      };
+      const clickedState = reducer(mockState.lorem, clickNodeAction);
+      expect(clickedState.node.clicked).toEqual(nodeID);
+      const disableNodeAction = {
+        type: TOGGLE_NODES_DISABLED,
+        nodeIDs: [nodeID],
+        isDisabled: true
+      };
+      const disabledState = reducer(clickedState, disableNodeAction);
+      expect(disabledState.node.clicked).toEqual(null);
+    });
   });
 
   describe('TOGGLE_TEXT_LABELS', () => {

--- a/src/selectors/nodes.js
+++ b/src/selectors/nodes.js
@@ -6,7 +6,6 @@ import {
   getNodeDisabledTag,
   getVisibleNodeIDs
 } from './disabled';
-import { getCentralNode } from './linked-nodes';
 import { getNodeRank } from './ranks';
 
 const getNodeIDs = state => state.node.ids;
@@ -16,6 +15,7 @@ const getNodeDisabledNode = state => state.node.disabled;
 const getNodeTags = state => state.node.tags;
 const getNodeType = state => state.node.type;
 const getNodeLayer = state => state.node.layer;
+const getHoveredNode = state => state.node.hovered;
 const getTagActive = state => state.tag.active;
 const getTextLabels = state => state.textLabels;
 const getFontLoaded = state => state.fontLoaded;
@@ -26,10 +26,10 @@ const getNodeTypeDisabled = state => state.nodeType.disabled;
  * @return {Boolean} True if active
  */
 export const getNodeActive = createSelector(
-  [getNodeIDs, getCentralNode, getNodeTags, getTagActive],
-  (nodeIDs, centralNode, nodeTags, tagActive) =>
+  [getNodeIDs, getHoveredNode, getNodeTags, getTagActive],
+  (nodeIDs, hoveredNode, nodeTags, tagActive) =>
     arrayToObject(nodeIDs, nodeID => {
-      if (nodeID === centralNode) {
+      if (nodeID === hoveredNode) {
         return true;
       }
       const activeViaTag = nodeTags[nodeID].some(tag => tagActive[tag]);

--- a/src/selectors/nodes.js
+++ b/src/selectors/nodes.js
@@ -16,6 +16,7 @@ const getNodeTags = state => state.node.tags;
 const getNodeType = state => state.node.type;
 const getNodeLayer = state => state.node.layer;
 const getHoveredNode = state => state.node.hovered;
+const getClickedNode = state => state.node.clicked;
 const getTagActive = state => state.tag.active;
 const getTextLabels = state => state.textLabels;
 const getFontLoaded = state => state.fontLoaded;
@@ -23,7 +24,6 @@ const getNodeTypeDisabled = state => state.nodeType.disabled;
 
 /**
  * Set active status if the node is specifically highlighted, and/or via an associated tag
- * @return {Boolean} True if active
  */
 export const getNodeActive = createSelector(
   [getNodeIDs, getHoveredNode, getNodeTags, getTagActive],
@@ -35,6 +35,18 @@ export const getNodeActive = createSelector(
       const activeViaTag = nodeTags[nodeID].some(tag => tagActive[tag]);
       return Boolean(activeViaTag);
     })
+);
+
+/**
+ * Set selected status if the node is clicked
+ */
+export const getNodeSelected = createSelector(
+  [getNodeIDs, getClickedNode, getNodeDisabled],
+  (nodeIDs, clickedNode, nodeDisabled) =>
+    arrayToObject(
+      nodeIDs,
+      nodeID => nodeID === clickedNode && !nodeDisabled[nodeID]
+    )
 );
 
 /**

--- a/src/selectors/nodes.test.js
+++ b/src/selectors/nodes.test.js
@@ -1,6 +1,7 @@
 import { mockState } from '../utils/state.mock';
 import {
   getNodeActive,
+  getNodeSelected,
   getNodeData,
   getNodeTextWidth,
   getPadding,
@@ -20,32 +21,20 @@ const getNodeName = state => state.node.name;
 
 describe('Selectors', () => {
   describe('getNodeActive', () => {
+    const nodeActive = getNodeActive(mockState.lorem);
+
     it('returns an object', () => {
-      expect(getNodeActive(mockState.lorem)).toEqual(expect.any(Object));
+      expect(nodeActive).toEqual(expect.any(Object));
     });
 
     it("returns an object whose keys match the current pipeline's nodes", () => {
-      expect(Object.keys(getNodeActive(mockState.lorem))).toEqual(
-        getNodeIDs(mockState.lorem)
-      );
+      expect(Object.keys(nodeActive)).toEqual(getNodeIDs(mockState.lorem));
     });
 
     it('returns an object whose values are all Booleans', () => {
-      expect(
-        Object.values(getNodeActive(mockState.lorem)).every(
-          value => typeof value === 'boolean'
-        )
-      ).toBe(true);
-    });
-
-    it('returns true when a given node is clicked', () => {
-      const nodes = getNodeIDs(mockState.lorem);
-      const nodeID = nodes[0];
-      const inactiveNodes = nodes.filter(id => id !== nodeID);
-      const newMockState = reducer(mockState.lorem, toggleNodeClicked(nodeID));
-      const nodeActive = getNodeActive(newMockState);
-      expect(nodeActive[nodeID]).toEqual(true);
-      expect(inactiveNodes.every(id => nodeActive[id] === false)).toEqual(true);
+      expect(Object.values(nodeActive)).toEqual(
+        expect.arrayContaining([expect.any(Boolean)])
+      );
     });
 
     it('returns true when a given node is hovered', () => {
@@ -54,6 +43,34 @@ describe('Selectors', () => {
       const inactiveNodes = nodes.filter(id => id !== nodeID);
       const newMockState = reducer(mockState.lorem, toggleNodeHovered(nodeID));
       const nodeActive = getNodeActive(newMockState);
+      expect(nodeActive[nodeID]).toEqual(true);
+      expect(inactiveNodes.every(id => nodeActive[id] === false)).toEqual(true);
+    });
+  });
+
+  describe('getNodeSelected', () => {
+    const nodeSelected = getNodeSelected(mockState.lorem);
+
+    it('returns an object', () => {
+      expect(nodeSelected).toEqual(expect.any(Object));
+    });
+
+    it("returns an object whose keys match the current pipeline's nodes", () => {
+      expect(Object.keys(nodeSelected)).toEqual(getNodeIDs(mockState.lorem));
+    });
+
+    it('returns an object whose values are all Booleans', () => {
+      expect(Object.values(nodeSelected)).toEqual(
+        expect.arrayContaining([expect.any(Boolean)])
+      );
+    });
+
+    it('returns true when a given node is clicked', () => {
+      const nodes = getNodeIDs(mockState.lorem);
+      const nodeID = nodes[0];
+      const inactiveNodes = nodes.filter(id => id !== nodeID);
+      const newMockState = reducer(mockState.lorem, toggleNodeClicked(nodeID));
+      const nodeActive = getNodeSelected(newMockState);
       expect(nodeActive[nodeID]).toEqual(true);
       expect(inactiveNodes.every(id => nodeActive[id] === false)).toEqual(true);
     });


### PR DESCRIPTION
## Description

Previously, Kedro-Viz would use a node's 'active' state to refer to multiple things:
1. When a node is hovered, or focused
2. When a node's tag is hovered
3. When a node has been clicked, and it is kept open (with the forthcoming meta panel)

I felt that we should style the 3rd case differently from the other two, as hovering is different from having the node selected, and the UI should reflect that. So in addition to 'active', I've added a new 'selected' visual UI state, that corresponds to the 'clicked' node store state as 'active' corresponds to 'hovered' node/tag states.

This PR also fixes a bunch of outstanding minor issues arising from the new node-list styling in #144. See commit comments for details.

## QA notes

Nde hover/focus/highlight/selected states have changed in both the graph and node-list.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
