### PR TITLE
[KED-1518] Wrap tooltip names & invert tooltip in top half of screen

### DIFF
--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -239,7 +239,6 @@ export class FlowChart extends Component {
   showTooltip(node) {
     this.setState({
       tooltip: {
-        chartSize: this.props.chartSize,
         targetRect: event.target.getBoundingClientRect(),
         text: node.fullName,
         visible: true
@@ -265,7 +264,8 @@ export class FlowChart extends Component {
    * Render React elements
    */
   render() {
-    const { outerWidth = 0, outerHeight = 0 } = this.props.chartSize;
+    const { chartSize } = this.props;
+    const { outerWidth = 0, outerHeight = 0 } = chartSize;
 
     return (
       <div
@@ -306,7 +306,7 @@ export class FlowChart extends Component {
           className="pipeline-flowchart__layer-names"
           ref={this.layerNamesRef}
         />
-        <Tooltip {...this.state.tooltip} />
+        <Tooltip chartSize={chartSize} {...this.state.tooltip} />
       </div>
     );
   }

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -19,6 +19,15 @@ import { getCentralNode, getLinkedNodes } from '../../selectors/linked-nodes';
 import draw from './draw';
 import './styles/flowchart.css';
 
+const zeroWidthSpace = String.fromCharCode(0x200b);
+/**
+ * Force tooltip text to break on special characters
+ * @param {string} text Any text with special characters
+ * @return {string} text
+ */
+const insertZeroWidthSpace = text =>
+  text.replace(/(\W)/g, `${zeroWidthSpace}$1${zeroWidthSpace}`);
+
 /**
  * Display a pipeline flowchart, mostly rendered with D3
  */
@@ -248,7 +257,7 @@ export class FlowChart extends Component {
     this.setState({
       tooltipVisible: true,
       tooltipIsRight: isRight,
-      tooltipText: node.fullName,
+      tooltipText: insertZeroWidthSpace(node.fullName),
       tooltipX: xOffset - left + eventOffset.width / 2,
       tooltipY: eventOffset.top - top
     });
@@ -318,12 +327,12 @@ export class FlowChart extends Component {
           ref={this.layerNamesRef}
         />
         <div
-          className={classnames('pipeline-flowchart__tooltip kedro', {
+          className={classnames('pipeline-flowchart__tooltip', {
             'tooltip--visible': tooltipVisible,
             'tooltip--right': tooltipIsRight
           })}
           style={{ transform: `translate(${tooltipX}px, ${tooltipY}px)` }}>
-          <span>{tooltipText}</span>
+          <div>{tooltipText}</div>
         </div>
       </div>
     );

--- a/src/components/flowchart/styles/_tooltip.scss
+++ b/src/components/flowchart/styles/_tooltip.scss
@@ -2,25 +2,14 @@
 
 .pipeline-flowchart__tooltip {
   position: absolute;
-  top: -60px;
+  top: -10px;
   left: -20px;
   z-index: 9;
-  padding: 12px 20px;
-  color: white;
+  width: 100vw;
   visibility: hidden;
   opacity: 0;
   transition: opacity ease 0.1s, visibility ease 0.1s;
   pointer-events: none;
-
-  .kui-theme--light & {
-    background: $tooltip-bg-light;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
-  }
-
-  .kui-theme--dark & {
-    background: $tooltip-bg-dark;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  }
 
   &.tooltip--visible {
     visibility: visible;
@@ -57,7 +46,29 @@
     }
   }
 
-  span {
+  div {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    max-width: 50vw;
+    padding: 12px 20px;
+    color: white;
     font-size: 1.5em;
+    overflow-wrap: break-word;
+
+    .kui-theme--light & {
+      background: $tooltip-bg-light;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    }
+
+    .kui-theme--dark & {
+      background: $tooltip-bg-dark;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+  }
+
+  &.tooltip--right div {
+    right: 0;
+    left: auto;
   }
 }

--- a/src/components/flowchart/styles/_variables.scss
+++ b/src/components/flowchart/styles/_variables.scss
@@ -29,10 +29,6 @@ $node-labeltext-fill-light-active: $color-text-light;
 
 $edge-light: mix($color-text-light, $color-bg-light, 75%);
 
-// Tooltip
-
-$tooltip-bg-light: rgba(darken($color-text-light, 5%), 0.9);
-
 //-------------- DARK --------------//
 
 // Icon
@@ -57,7 +53,3 @@ $node-labeltext-fill-dark-active: $color-text-dark;
 // Edge
 
 $edge-dark: mix($color-text-dark, $color-bg-dark, 85%);
-
-// Tooltip
-
-$tooltip-bg-dark: rgba(mix($color-bg-dark, #111, 50), 0.9);

--- a/src/components/flowchart/styles/flowchart.scss
+++ b/src/components/flowchart/styles/flowchart.scss
@@ -1,7 +1,6 @@
 @import './node';
 @import './edges';
 @import './layers';
-@import './tooltip';
 
 .pipeline-flowchart {
   height: 100%;

--- a/src/components/tooltip/index.js
+++ b/src/components/tooltip/index.js
@@ -20,17 +20,20 @@ const insertZeroWidthSpace = text =>
  * @param {string} text Tooltip display label
  */
 const Tooltip = ({ chartSize, targetRect, visible, text }) => {
-  const { left, top, width, outerWidth, sidebarWidth } = chartSize;
+  const { left, top, width, height, outerWidth, sidebarWidth } = chartSize;
   const isRight = targetRect.left - sidebarWidth > width / 2;
+  const isTop = targetRect.top < height / 2;
   const xOffset = isRight ? targetRect.left - outerWidth : targetRect.left;
+  const yOffset = isTop ? targetRect.top + targetRect.height : targetRect.top;
   const x = xOffset - left + targetRect.width / 2;
-  const y = targetRect.top - top;
+  const y = yOffset - top;
 
   return (
     <div
       className={classnames('pipeline-tooltip', {
         'pipeline-tooltip--visible': visible,
-        'pipeline-tooltip--right': isRight
+        'pipeline-tooltip--right': isRight,
+        'pipeline-tooltip--top': isTop
       })}
       style={{ transform: `translate(${x}px, ${y}px)` }}>
       <div className="pipeline-tooltip__text">{insertZeroWidthSpace(text)}</div>

--- a/src/components/tooltip/index.js
+++ b/src/components/tooltip/index.js
@@ -9,8 +9,8 @@ const zeroWidthSpace = String.fromCharCode(0x200b);
  * @param {string} text Any text with special characters
  * @return {string} text
  */
-const insertZeroWidthSpace = text =>
-  text.replace(/(\W)/g, `${zeroWidthSpace}$1${zeroWidthSpace}`);
+export const insertZeroWidthSpace = text =>
+  text.replace(/([^\w\s]|[_])/g, `${zeroWidthSpace}$1${zeroWidthSpace}`);
 
 /**
  * Display flowchart node tooltip

--- a/src/components/tooltip/index.js
+++ b/src/components/tooltip/index.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import classnames from 'classnames';
+import './tooltip.css';
+
+const zeroWidthSpace = String.fromCharCode(0x200b);
+
+/**
+ * Force tooltip text to break on special characters
+ * @param {string} text Any text with special characters
+ * @return {string} text
+ */
+const insertZeroWidthSpace = text =>
+  text.replace(/(\W)/g, `${zeroWidthSpace}$1${zeroWidthSpace}`);
+
+/**
+ * Display flowchart node tooltip
+ * @param {object} chartSize Chart dimensions in pixels
+ * @param {object} targetRect event.target.getBoundingClientRect()
+ * @param {boolean} visible Whether to show the tooltip
+ * @param {string} text Tooltip display label
+ */
+const Tooltip = ({ chartSize, targetRect, visible, text }) => {
+  const { left, top, width, outerWidth, sidebarWidth } = chartSize;
+  const isRight = targetRect.left - sidebarWidth > width / 2;
+  const xOffset = isRight ? targetRect.left - outerWidth : targetRect.left;
+  const x = xOffset - left + targetRect.width / 2;
+  const y = targetRect.top - top;
+
+  return (
+    <div
+      className={classnames('pipeline-tooltip', {
+        'pipeline-tooltip--visible': visible,
+        'pipeline-tooltip--right': isRight
+      })}
+      style={{ transform: `translate(${x}px, ${y}px)` }}>
+      <div className="pipeline-tooltip__text">{insertZeroWidthSpace(text)}</div>
+    </div>
+  );
+};
+
+Tooltip.defaultProps = {
+  chartSize: {},
+  targetRect: {},
+  visible: false,
+  text: ''
+};
+
+export default Tooltip;

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -1,6 +1,9 @@
-@import './variables';
+@import '../../styles/variables';
 
-.pipeline-flowchart__tooltip {
+$tooltip-bg-light: rgba(darken($color-text-light, 5%), 0.9);
+$tooltip-bg-dark: rgba(mix($color-bg-dark, #111, 50), 0.9);
+
+.pipeline-tooltip {
   position: absolute;
   top: -10px;
   left: -20px;
@@ -11,19 +14,14 @@
   transition: opacity ease 0.1s, visibility ease 0.1s;
   pointer-events: none;
 
-  &.tooltip--visible {
+  &--visible {
     visibility: visible;
     opacity: 1;
   }
 
-  &.tooltip--right {
+  &--right {
     right: -20px;
     left: auto;
-
-    &::before {
-      right: 10px;
-      left: auto;
-    }
   }
 
   &::before {
@@ -46,28 +44,33 @@
     }
   }
 
-  div {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    max-width: 50vw;
-    padding: 12px 20px;
-    color: white;
-    font-size: 1.5em;
-    overflow-wrap: break-word;
+  &--right::before {
+    right: 10px;
+    left: auto;
+  }
+}
 
-    .kui-theme--light & {
-      background: $tooltip-bg-light;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
-    }
+.pipeline-tooltip__text {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  max-width: 50vw;
+  padding: 12px 20px;
+  color: white;
+  font-size: 1.5em;
+  overflow-wrap: break-word;
 
-    .kui-theme--dark & {
-      background: $tooltip-bg-dark;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    }
+  .kui-theme--light & {
+    background: $tooltip-bg-light;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
   }
 
-  &.tooltip--right div {
+  .kui-theme--dark & {
+    background: $tooltip-bg-dark;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  }
+
+  .pipeline-tooltip--right & {
     right: 0;
     left: auto;
   }

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -76,7 +76,7 @@ $t: 10px;
   position: absolute;
   bottom: 0;
   left: 0;
-  max-width: 50vw;
+  max-width: calc(50vw - 150px);
   padding: 12px 20px;
   color: white;
   font-size: 1.5em;

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -2,11 +2,14 @@
 
 $tooltip-bg-light: rgba(darken($color-text-light, 5%), 0.9);
 $tooltip-bg-dark: rgba(mix($color-bg-dark, #111, 50), 0.9);
+$x: 20px;
+$y: 10px;
+$t: 10px;
 
 .pipeline-tooltip {
   position: absolute;
-  top: -10px;
-  left: -20px;
+  top: -$y;
+  left: -$x;
   z-index: 9;
   width: 100vw;
   visibility: hidden;
@@ -20,19 +23,23 @@ $tooltip-bg-dark: rgba(mix($color-bg-dark, #111, 50), 0.9);
   }
 
   &--right {
-    right: -20px;
+    right: -$x;
     left: auto;
+  }
+
+  &--top {
+    top: $y;
   }
 
   &::before {
     position: absolute;
-    bottom: -10px;
-    left: 10px;
+    bottom: -$y;
+    left: $x/2;
     width: 0;
     height: 0;
     border-color: transparent;
     border-style: solid;
-    border-width: 10px 10px 0 10px;
+    border-width: $t $t 0 $t;
     content: '';
 
     .kui-theme--light & {
@@ -45,8 +52,23 @@ $tooltip-bg-dark: rgba(mix($color-bg-dark, #111, 50), 0.9);
   }
 
   &--right::before {
-    right: 10px;
+    right: $x/2;
     left: auto;
+  }
+
+  &--top::before {
+    top: -$y;
+    bottom: auto;
+    border-width: 0 $t $t $t;
+    border-top-color: transparent;
+
+    .kui-theme--light & {
+      border-bottom-color: $tooltip-bg-light;
+    }
+
+    .kui-theme--dark & {
+      border-bottom-color: $tooltip-bg-dark;
+    }
   }
 }
 
@@ -73,5 +95,10 @@ $tooltip-bg-dark: rgba(mix($color-bg-dark, #111, 50), 0.9);
   .pipeline-tooltip--right & {
     right: 0;
     left: auto;
+  }
+
+  .pipeline-tooltip--top & {
+    top: 0;
+    bottom: auto;
   }
 }

--- a/src/components/tooltip/tooltip.test.js
+++ b/src/components/tooltip/tooltip.test.js
@@ -1,0 +1,98 @@
+import Tooltip, { insertZeroWidthSpace } from './index';
+import { setup } from '../../utils/state.mock';
+
+const mockProps = {
+  chartSize: {
+    height: 766,
+    left: 0,
+    outerHeight: 766,
+    outerWidth: 1198,
+    sidebarWidth: 300,
+    top: 0,
+    width: 898
+  },
+  targetRect: {
+    bottom: 341.05895,
+    height: 2.1011,
+    left: 856.19622,
+    right: 866.03076,
+    top: 338.95785,
+    width: 9.83453,
+    x: 856.19622,
+    y: 338.95785
+  },
+  text: 'lorem_ipsum-dolor: sit [amet]',
+  visible: true
+};
+
+describe('Tooltip', () => {
+  it('renders without crashing', () => {
+    const wrapper = setup.shallow(Tooltip);
+    const container = wrapper.find('.pipeline-tooltip');
+    expect(container.length).toBe(1);
+  });
+
+  it('should not add the top class when the tooltip is towards the bottom', () => {
+    const targetRect = {
+      ...mockProps.targetRect,
+      top: mockProps.chartSize.height - 10
+    };
+    const wrapper = setup.shallow(Tooltip, { ...mockProps, targetRect });
+    const container = wrapper.find('.pipeline-tooltip--top');
+    expect(container.length).toBe(0);
+  });
+
+  it('should not add the right class when the tooltip is towards the left', () => {
+    const targetRect = {
+      ...mockProps.targetRect,
+      left: 10
+    };
+    const wrapper = setup.shallow(Tooltip, { ...mockProps, targetRect });
+    const container = wrapper.find('.pipeline-tooltip--right');
+    expect(container.length).toBe(0);
+  });
+
+  it("should add the 'top' class when the tooltip is towards the top", () => {
+    const targetRect = {
+      ...mockProps.targetRect,
+      top: 10
+    };
+    const wrapper = setup.shallow(Tooltip, { ...mockProps, targetRect });
+    const container = wrapper.find('.pipeline-tooltip--top');
+    expect(container.length).toBe(1);
+  });
+
+  it("should add the 'right' class when the tooltip is towards the right", () => {
+    const targetRect = {
+      ...mockProps.targetRect,
+      left: mockProps.chartSize.width - 10
+    };
+    const wrapper = setup.shallow(Tooltip, { ...mockProps, targetRect });
+    const container = wrapper.find('.pipeline-tooltip--right');
+    expect(container.length).toBe(1);
+  });
+});
+
+describe('insertZeroWidthSpace', () => {
+  it('wraps special characters with zero-width spaces', () => {
+    expect(insertZeroWidthSpace('-').length).toBe(3);
+    expect(insertZeroWidthSpace('_').length).toBe(3);
+    expect(insertZeroWidthSpace('[').length).toBe(3);
+    expect(insertZeroWidthSpace(']').length).toBe(3);
+    expect(insertZeroWidthSpace('/').length).toBe(3);
+    expect(insertZeroWidthSpace(':').length).toBe(3);
+    expect(insertZeroWidthSpace('\\').length).toBe(3);
+  });
+
+  it('does not wrap alphanumeric characters', () => {
+    expect(insertZeroWidthSpace('a').length).toBe(1);
+    expect(insertZeroWidthSpace('aBc123').length).toBe(6);
+  });
+
+  it('does not wrap spaces', () => {
+    expect(insertZeroWidthSpace(' ').length).toBe(1);
+    expect(insertZeroWidthSpace('\t').length).toBe(1);
+    expect(insertZeroWidthSpace('a b').length).toBe(3);
+    expect(insertZeroWidthSpace(' a ').length).toBe(3);
+  });
+});

--- a/src/components/tooltip/tooltip.test.js
+++ b/src/components/tooltip/tooltip.test.js
@@ -74,25 +74,29 @@ describe('Tooltip', () => {
 });
 
 describe('insertZeroWidthSpace', () => {
-  it('wraps special characters with zero-width spaces', () => {
-    expect(insertZeroWidthSpace('-').length).toBe(3);
-    expect(insertZeroWidthSpace('_').length).toBe(3);
-    expect(insertZeroWidthSpace('[').length).toBe(3);
-    expect(insertZeroWidthSpace(']').length).toBe(3);
-    expect(insertZeroWidthSpace('/').length).toBe(3);
-    expect(insertZeroWidthSpace(':').length).toBe(3);
-    expect(insertZeroWidthSpace('\\').length).toBe(3);
+  describe('special characters', () => {
+    const z = String.fromCharCode(0x200b);
+    const wrap = text => z + text + z;
+    const characters = '-_[]/:\\!@£$%^&*()'.split('');
+    test.each(characters)('wraps %s with a zero-width space', d => {
+      expect(insertZeroWidthSpace(d)).toBe(wrap(d));
+      expect(insertZeroWidthSpace(d).length).toBe(3);
+    });
   });
 
-  it('does not wrap alphanumeric characters', () => {
-    expect(insertZeroWidthSpace('a').length).toBe(1);
-    expect(insertZeroWidthSpace('aBc123').length).toBe(6);
+  describe('alphanumeric characters', () => {
+    const characters = ['a', 'B', '123', 'aBc123', '0', ''];
+    test.each(characters)('does not wrap %s with a zero-width space', d => {
+      expect(insertZeroWidthSpace(d)).toBe(d);
+      expect(insertZeroWidthSpace(d).length).toBe(d.length);
+    });
   });
 
-  it('does not wrap spaces', () => {
-    expect(insertZeroWidthSpace(' ').length).toBe(1);
-    expect(insertZeroWidthSpace('\t').length).toBe(1);
-    expect(insertZeroWidthSpace('a b').length).toBe(3);
-    expect(insertZeroWidthSpace(' a ').length).toBe(3);
+  describe('spaces', () => {
+    const characters = [' ', '\t', '\n', 'a b', ' a '];
+    test.each(characters)('does not wrap %s with a zero-width space', d => {
+      expect(insertZeroWidthSpace(d)).toBe(d);
+      expect(insertZeroWidthSpace(d).length).toBe(d.length);
+    });
   });
 });


### PR DESCRIPTION
## Description

1. Refactor tooltips to turn it into a new standalone component
2. Wrap tooltip text for long node names, by injecting zero-width spaces around special characters, and adding `overflow-wrap: break-word;` as a backup.
<img src="https://user-images.githubusercontent.com/1155816/81170866-4fccae80-8f93-11ea-9b4c-d12bf9652d8d.png" width="500"/>

3. Make tooltips hang below their node in the top half of the screen, just as they do with inverting their positioning on the right side of the screen:
<img src="https://user-images.githubusercontent.com/1155816/81088147-7c7cb980-8ef2-11ea-9336-b5170104b843.png" width="350" />

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
