### PR TITLE
[KED-1645] Add node-list-count to node-list group headings

### DIFF
--- a/src/components/node-list/node-list-group.js
+++ b/src/components/node-list/node-list-group.js
@@ -7,10 +7,10 @@ import { toggleTypeDisabled } from '../../actions/node-type';
 
 export const NodeListGroup = ({
   children,
+  collapsed,
   onToggleTypeDisabled,
   onToggleCollapsed,
-  type,
-  collapsed
+  type
 }) => (
   <Flipped flipId={type.id}>
     <li>
@@ -20,7 +20,9 @@ export const NodeListGroup = ({
             <NodeListRow
               checked={!type.disabled}
               id={type.id}
-              label={type.name}
+              label={`${type.name} <i>(${type.nodeCount.visible}/${
+                type.nodeCount.total
+              })</i>`}
               name={type.name}
               onChange={e => {
                 onToggleTypeDisabled(type.id, !e.target.checked);

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -112,6 +112,13 @@
     font-weight: normal;
     opacity: 0.3;
   }
+
+  i {
+    display: inline-block;
+    margin-left: 1em;
+    font-style: normal;
+    opacity: 0.55;
+  }
 }
 
 .pipeline-nodelist__row__visibility {

--- a/src/selectors/node-types.js
+++ b/src/selectors/node-types.js
@@ -1,18 +1,42 @@
 import { createSelector } from 'reselect';
+import { getNodeDisabled } from './disabled';
+import { arrayToObject } from '../utils';
 
+const getNodeIDs = state => state.node.ids;
+const getNodeType = state => state.node.type;
 const getNodeTypeIDs = state => state.nodeType.ids;
 const getNodeTypeName = state => state.nodeType.name;
 const getNodeTypeDisabled = state => state.nodeType.disabled;
 
 /**
+ * Calculate the total number of nodes (and the number of visible nodes)
+ * for each node-type
+ */
+export const getTypeNodeCount = createSelector(
+  [getNodeTypeIDs, getNodeIDs, getNodeType, getNodeDisabled],
+  (types, nodeIDs, nodeType, nodeDisabled) =>
+    arrayToObject(types, type => {
+      const typeNodeIDs = nodeIDs.filter(nodeID => nodeType[nodeID] === type);
+      const visibleTypeNodeIDs = typeNodeIDs.filter(
+        nodeID => !nodeDisabled[nodeID]
+      );
+      return {
+        total: typeNodeIDs.length,
+        visible: visibleTypeNodeIDs.length
+      };
+    })
+);
+
+/**
  * Get formatted list of node type objects
  */
 export const getNodeTypes = createSelector(
-  [getNodeTypeIDs, getNodeTypeName, getNodeTypeDisabled],
-  (types, typeName, typeDisabled) =>
+  [getNodeTypeIDs, getNodeTypeName, getNodeTypeDisabled, getTypeNodeCount],
+  (types, typeName, typeDisabled, typeNodeCount) =>
     types.map(id => ({
       id,
       name: typeName[id],
-      disabled: Boolean(typeDisabled[id])
+      disabled: Boolean(typeDisabled[id]),
+      nodeCount: typeNodeCount[id]
     }))
 );


### PR DESCRIPTION
## Description

Add numerical counters to show the total number of nodes (and visible nodes) for each node-list group:
<img src="https://user-images.githubusercontent.com/1155816/81308414-a7454a00-9079-11ea-9d01-6d3ea64e1a9c.png" width="300"/>


## Development notes

This doesn't take into account search filtering:
<img src="https://user-images.githubusercontent.com/1155816/81308526-cb089000-9079-11ea-85f7-2235e416e07a.png" width=300 />

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
