### PR TITLE
Make node-list group toggle button point right when collapsed

### DIFF
--- a/src/components/node-list/styles/_group.scss
+++ b/src/components/node-list/styles/_group.scss
@@ -83,6 +83,6 @@
   }
 
   &--alt {
-    transform: rotate(-180deg);
+    transform: rotate(-90deg);
   }
 }


### PR DESCRIPTION
## Description

Change node-list group toggle button direction from pointing up when closed, to pointing right
![image](https://user-images.githubusercontent.com/1155816/81716475-536ba400-9471-11ea-9155-e845ee722f65.png)

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
