### PR TITLE
Remove the need to transition layer height on zoom

### DIFF
--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -143,10 +143,12 @@ export class FlowChart extends Component {
       this.el.wrapper.attr('transform', event.transform);
 
       // Update layer label y positions
-      this.el.layerNames.style('transform', d => {
-        const ty = y + (d.y + d.height / 2) * scale;
-        return `translateY(${ty}px)`;
-      });
+      if (this.el.layerNames) {
+        this.el.layerNames.style('transform', d => {
+          const ty = y + (d.y + d.height / 2) * scale;
+          return `translateY(${ty}px)`;
+        });
+      }
 
       // Hide the tooltip so it doesn't get misaligned to its node
       this.hideTooltip();

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -143,12 +143,10 @@ export class FlowChart extends Component {
       this.el.wrapper.attr('transform', event.transform);
 
       // Update layer label y positions
-      this.el.layerNames
-        .style('height', d => `${d.height * scale}px`)
-        .style('transform', d => {
-          const ty = y + d.y * scale;
-          return `translateY(${ty}px)`;
-        });
+      this.el.layerNames.style('transform', d => {
+        const ty = y + (d.y + d.height / 2) * scale;
+        return `translateY(${ty}px)`;
+      });
 
       // Hide the tooltip so it doesn't get misaligned to its node
       this.hideTooltip();

--- a/src/components/flowchart/styles/_layers.scss
+++ b/src/components/flowchart/styles/_layers.scss
@@ -21,22 +21,12 @@
   position: absolute;
   top: 0;
   left: 0;
+  width: 130px;
+  height: 100%;
   margin: 0;
   padding: 0;
   list-style: none;
   pointer-events: none;
-}
-
-.layer-name {
-  position: absolute;
-  top: 0;
-  display: flex;
-  align-items: center;
-  width: 130px;
-  padding-left: 15px;
-  font-weight: bold;
-  font-size: 1.6em;
-  white-space: nowrap;
 
   .kui-theme--dark & {
     background: linear-gradient(to right, $color-bg-dark, transparent);
@@ -45,4 +35,16 @@
   .kui-theme--light & {
     background: linear-gradient(to right, $color-bg-light, transparent);
   }
+}
+
+.layer-name {
+  position: absolute;
+  top: -10px;
+  display: flex;
+  align-items: center;
+  height: 20px;
+  padding-left: 15px;
+  font-weight: bold;
+  font-size: 1.6em;
+  white-space: nowrap;
 }


### PR DESCRIPTION
## Description

Modifying DOM attributes is expensive. Transitioning height is also expensive. This PR removes a CSS height transition and a DOM update, because the height isn't strictly necessary for this effect. Now the label is centred, the gradient is on the container, and the translation is the only thing that gets animated, which should help performance a little.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
