### PR TITLE
Fix deprecation warnings when running kedro viz from Kedro 0.16

### DIFF
--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -43,14 +43,14 @@ from typing import Dict, List, Set
 import click
 import kedro
 import requests
-import semver
 from flask import Flask, jsonify, send_from_directory
 from IPython.core.display import HTML, display
+from semver import VersionInfo
 from toposort import toposort_flatten
 
 from kedro_viz.utils import wait_for
 
-KEDRO_VERSION = semver.VersionInfo.parse(kedro.__version__)
+KEDRO_VERSION = VersionInfo.parse(kedro.__version__)
 
 if KEDRO_VERSION.match(">=0.16.0"):
     from kedro.framework.cli import get_project_context

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -57,7 +57,7 @@ if KEDRO_VERSION.match(">=0.16.0"):
     from kedro.framework.cli.utils import KedroCliError
 else:
     from kedro.cli import get_project_context  # pragma: no cover
-    from kedro.cli.utils import KedroCliError  # pragmaL no cover
+    from kedro.cli.utils import KedroCliError  # pragma: no cover
 
 
 _VIZ_PROCESSES = {}  # type: Dict[int, multiprocessing.Process]

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -56,8 +56,8 @@ if KEDRO_VERSION.match(">=0.16.0"):
     from kedro.framework.cli import get_project_context
     from kedro.framework.cli.utils import KedroCliError
 else:
-    from kedro.cli import get_project_context
-    from kedro.cli.utils import KedroCliError
+    from kedro.cli import get_project_context  # pragma: no cover
+    from kedro.cli.utils import KedroCliError  # pragmaL no cover
 
 
 _VIZ_PROCESSES = {}  # type: Dict[int, multiprocessing.Process]

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -43,14 +43,22 @@ from typing import Dict, List, Set
 import click
 import kedro
 import requests
+import semver
 from flask import Flask, jsonify, send_from_directory
 from IPython.core.display import HTML, display
-from kedro.cli import get_project_context  # pylint: disable=ungrouped-imports
-from kedro.cli.utils import KedroCliError  # pylint: disable=ungrouped-imports
-from semver import match
 from toposort import toposort_flatten
 
 from kedro_viz.utils import wait_for
+
+KEDRO_VERSION = semver.VersionInfo.parse(kedro.__version__)
+
+if KEDRO_VERSION.match(">=0.16.0"):
+    from kedro.framework.cli import get_project_context
+    from kedro.framework.cli.utils import KedroCliError
+else:
+    from kedro.cli import get_project_context
+    from kedro.cli.utils import KedroCliError
+
 
 _VIZ_PROCESSES = {}  # type: Dict[int, multiprocessing.Process]
 
@@ -160,7 +168,7 @@ def _load_from_file(load_file: str) -> dict:
 
 
 def _get_pipeline_from_context(context, pipeline_name):
-    if match(kedro.__version__, ">=0.15.2"):
+    if KEDRO_VERSION.match(">=0.15.2"):
         return context._get_pipeline(  # pylint: disable=protected-access
             name=pipeline_name
         )
@@ -467,9 +475,12 @@ def _call_viz(
 
         data = _load_from_file(load_file)
     else:
-        if match(kedro.__version__, ">=0.15.0"):
+        if KEDRO_VERSION.match(">=0.15.0"):
             # pylint: disable=import-outside-toplevel
-            from kedro.context import KedroContextError
+            if KEDRO_VERSION.match(">=0.16.0"):
+                from kedro.framework.context import KedroContextError
+            else:
+                from kedro.context import KedroContextError
 
             try:
                 context = get_project_context("context", env=env)

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,4 +1,4 @@
-semver>=2.0.0,<3.0.0
+semver>=2.8.1, <3.0.0 # Needs to be at least 2.8.1 to get VersionInfo.parse
 Flask>=1.0, <2.0
 kedro>=0.14.0
 ipython>=7.0.0, <8.0

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -34,10 +34,11 @@ import re
 from pathlib import Path
 
 import pytest
+from kedro.context import KedroContextError
 from kedro.extras.datasets.pickle import PickleDataSet
-from kedro.framework.context import KedroContextError
 from kedro.io import DataCatalog, MemoryDataSet
 from kedro.pipeline import Pipeline, node
+from semver import VersionInfo
 from toposort import CircularDependencyError
 
 from kedro_viz import server
@@ -303,7 +304,7 @@ def test_pipeline_flag_non_existent(cli_runner):
 
 def test_viz_kedro15(mocker, cli_runner):
     """Test that running viz in Kedro 0.15.0."""
-    mocker.patch("kedro.__version__", "0.15.0")
+    mocker.patch("kedro_viz.server.KEDRO_VERSION", VersionInfo.parse("0.15.0"))
 
     def get_project_context(
         key: str = "context", **kwargs  # pylint: disable=bad-continuation
@@ -319,7 +320,7 @@ def test_viz_kedro15(mocker, cli_runner):
 
 def test_viz_kedro15_pipeline_flag(mocker, cli_runner):
     """Test that running viz with `--pipeline` flag in Kedro 0.15.0."""
-    mocker.patch("kedro.__version__", "0.15.0")
+    mocker.patch("kedro_viz.server.KEDRO_VERSION", VersionInfo.parse("0.15.0"))
 
     def get_project_context(
         key: str = "context", **kwargs  # pylint: disable=bad-continuation
@@ -334,7 +335,7 @@ def test_viz_kedro15_pipeline_flag(mocker, cli_runner):
 def test_viz_kedro15_invalid(mocker, cli_runner):
     """Test that running viz in Kedro 0.15.0,
     and it is outside of a Kedro project root."""
-    mocker.patch("kedro.__version__", "0.15.0")
+    mocker.patch("kedro_viz.server.KEDRO_VERSION", VersionInfo.parse("0.15.0"))
     mocker.patch("kedro_viz.server.get_project_context", side_effect=KedroContextError)
     result = cli_runner.invoke(server.commands, "viz")
     assert "Could not find a Kedro project root." in result.output
@@ -342,7 +343,7 @@ def test_viz_kedro15_invalid(mocker, cli_runner):
 
 def test_viz_kedro14(mocker, cli_runner):
     """Test that running viz in Kedro 0.14.0."""
-    mocker.patch("kedro.__version__", "0.14.0")
+    mocker.patch("kedro_viz.server.KEDRO_VERSION", VersionInfo.parse("0.14.0"))
 
     def create_catalog(config):  # pylint: disable=unused-argument,bad-continuation
         return mocker.MagicMock()
@@ -366,7 +367,7 @@ def test_viz_kedro14(mocker, cli_runner):
 
 def test_viz_kedro14_pipeline_flag(mocker, cli_runner):
     """Test that running viz with `--pipeline` flag in Kedro 0.14.0 is not supported."""
-    mocker.patch("kedro.__version__", "0.14.0")
+    mocker.patch("kedro_viz.server.KEDRO_VERSION", VersionInfo.parse("0.14.0"))
 
     def create_catalog(config):  # pylint: disable=unused-argument,bad-continuation
         return lambda x: None
@@ -391,7 +392,7 @@ def test_viz_kedro14_pipeline_flag(mocker, cli_runner):
 def test_viz_kedro14_invalid(mocker, cli_runner):
     """Test that running viz in Kedro 0.14.0,
     while outside of a Kedro project is not supported."""
-    mocker.patch("kedro.__version__", "0.14.0")
+    mocker.patch("kedro_viz.server.KEDRO_VERSION", VersionInfo.parse("0.14.0"))
     mocker.patch("kedro_viz.server.get_project_context", side_effect=KeyError)
     result = cli_runner.invoke(server.commands, "viz")
     assert "Could not find a Kedro project root." in result.output

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -34,8 +34,8 @@ import re
 from pathlib import Path
 
 import pytest
-from kedro.context import KedroContextError
 from kedro.extras.datasets.pickle import PickleDataSet
+from kedro.framework.context import KedroContextError
 from kedro.io import DataCatalog, MemoryDataSet
 from kedro.pipeline import Pipeline, node
 from toposort import CircularDependencyError


### PR DESCRIPTION
## Description

Does conditional imports to make sure the deprecation warnings don't appear when using the latest version of `viz` with the latest version of `kedro`, whilst still working with older versions of `kedro`.

## Development notes

* Updated the `semver.match` to `semver.VersionInfo.match` everywhere to get rid of that deprecation warning
* Bump required version of `semver` in `requirements.txt`
* Conditional imports for `kedro.cli` and `kedro.context` in `server.py` with `pragma: no cover` to get test coverage passing.
* Fixed mocking the kedro version in `test_server` to match the `semver` changes.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
