### PR TITLE
Deselect nodes on Escape key, and when already selected

### DIFF
--- a/src/components/node-list/node-list-groups.js
+++ b/src/components/node-list/node-list-groups.js
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { Flipper } from 'react-flip-toolkit';
+import utils from '@quantumblack/kedro-ui/lib/utils';
 import { loadState, saveState } from '../../store/helpers';
 import { getNodeActive, getNodeSelected } from '../../selectors/nodes';
 import { getNodeTypes } from '../../selectors/node-types';
@@ -23,6 +24,17 @@ const NodeListGroups = ({
   nodeSelected,
   types
 }) => {
+  // Deselect node on Escape key
+  const handleKeyDown = event => {
+    utils.handleKeyEvent(event.keyCode, {
+      escape: () => onToggleNodeClicked(null)
+    });
+  };
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  });
+
   const [collapsed, setCollapsed] = useState(storedState.groupsCollapsed || {});
 
   const onToggleCollapsed = typeID => {

--- a/src/components/node-list/node-list-groups.js
+++ b/src/components/node-list/node-list-groups.js
@@ -37,12 +37,22 @@ const NodeListGroups = ({
 
   const [collapsed, setCollapsed] = useState(storedState.groupsCollapsed || {});
 
+  // Collapse/expand node group
   const onToggleCollapsed = typeID => {
     const groupsCollapsed = Object.assign({}, collapsed, {
       [typeID]: !collapsed[typeID]
     });
     setCollapsed(groupsCollapsed);
     saveState({ groupsCollapsed });
+  };
+
+  // Toggle node selection depending on whether it's already selected
+  const handleNodeSelection = nodeID => {
+    if (nodeSelected[nodeID]) {
+      onToggleNodeClicked(null);
+    } else {
+      onToggleNodeClicked(nodeID);
+    }
   };
 
   const renderTypeGroup = type => {
@@ -65,7 +75,7 @@ const NodeListGroups = ({
                 id={node.id}
                 label={node.highlightedLabel}
                 name={node.name}
-                onClick={() => onToggleNodeClicked(node.id)}
+                onClick={() => handleNodeSelection(node.id)}
                 onMouseEnter={() => onToggleNodeHovered(node.id)}
                 onMouseLeave={() => onToggleNodeHovered(null)}
                 onChange={e => {


### PR DESCRIPTION
## Description

1. Allow users to deselect a selected node with the escape key.
2. Allow users to deselect a selected node in the node-list by clicking  it again.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
