### PR TITLE
Fix e2e tests

### DIFF
--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -79,14 +79,8 @@ def before_scenario(context, feature):  # pylint: disable=unused-argument
     # Activate environment
     context.env["PATH"] = path_sep.join(path)
 
-    # install this plugin by resolving the requirements using pip-compile
-    # from pip-tools due to this bug in pip: https://github.com/pypa/pip/issues/988
-    call([context.python, "-m", "pip", "install", "-U", "pip", "pip-tools"])
-    pip_compile = str(bin_dir / "pip-compile")
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        compiled_reqs = Path(tmpdirname) / "compiled_requirements.txt"
-        call([pip_compile, "--output-file", str(compiled_reqs), "requirements.txt"])
-        call([context.pip, "install", "-r", str(compiled_reqs)])
+    call([context.python, "-m", "pip", "install", "-U", "pip"])
+    call([context.pip, "install", "-r", str("requirements.txt")])
 
     for wheel_path in glob.glob("dist/*.whl"):
         os.remove(wheel_path)

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -79,8 +79,14 @@ def before_scenario(context, feature):  # pylint: disable=unused-argument
     # Activate environment
     context.env["PATH"] = path_sep.join(path)
 
-    call([context.python, "-m", "pip", "install", "-U", "pip"])
-    call([context.pip, "install", "-r", str("requirements.txt")])
+    # install this plugin by resolving the requirements using pip-compile
+    # from pip-tools due to this bug in pip: https://github.com/pypa/pip/issues/988
+    call([context.python, "-m", "pip", "install", "-U", "pip", "pip-tools"])
+    pip_compile = str(bin_dir / "pip-compile")
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        compiled_reqs = Path(tmpdirname) / "compiled_requirements.txt"
+        call([pip_compile, "--output-file", str(compiled_reqs), "requirements.txt"])
+        call([context.pip, "install", "-r", str(compiled_reqs)])
 
     for wheel_path in glob.glob("dist/*.whl"):
         os.remove(wheel_path)

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -147,6 +147,7 @@ def check_kedroviz_up(context):
         expected_result=None,
         print_error=False,
         context=context,
+        timeout_=30,
     )
 
 

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -71,7 +71,11 @@ def create_config_file_with_example(context):
 def create_project_from_config_file(context):
     """Behave step to run kedro new given the config I previously created.
     """
-    res = run([context.kedro, "new", "-c", str(context.config_file)], env=context.env)
+    res = run(
+        [context.kedro, "new", "-c", str(context.config_file)],
+        env=context.env,
+        cwd=str(context.temp_dir)
+    )
     assert res.returncode == OK_EXIT_CODE
 
 

--- a/package/features/viz.feature
+++ b/package/features/viz.feature
@@ -34,21 +34,18 @@ Feature: Viz plugin in new project
     Scenario: Execute viz with Kedro 0.14.0
         Given I have installed kedro version "0.14.0"
         And I have run a non-interactive kedro new
-        And I have executed the kedro command "install"
         When I execute the kedro viz command "viz"
         Then kedro-viz should start successfully
 
     Scenario: Execute viz with Kedro 0.14.3
         Given I have installed kedro version "0.14.3"
         And I have run a non-interactive kedro new
-        And I have executed the kedro command "install"
         When I execute the kedro viz command "viz"
         Then kedro-viz should start successfully
 
     Scenario: Execute viz with Kedro 0.15.0
         Given I have installed kedro version "0.15.0"
         And I have run a non-interactive kedro new
-        And I have executed the kedro command "install"
         When I execute the kedro viz command "viz"
         Then kedro-viz should start successfully
 
@@ -56,6 +53,5 @@ Feature: Viz plugin in new project
         Given I have installed kedro version "latest"
         And I have run a non-interactive kedro new
         And I have executed the kedro command "install"
-        # otherwise try pip install -r src/requirements.txt
         When I execute the kedro viz command "viz"
         Then kedro-viz should start successfully

--- a/package/features/viz.feature
+++ b/package/features/viz.feature
@@ -30,27 +30,29 @@
 Feature: Viz plugin in new project
     Background:
         Given I have prepared a config file with example code
-
-    Scenario: Execute viz with Kedro 0.14.0
-        Given I have installed kedro version "0.14.0"
-        And I have run a non-interactive kedro new
-        When I execute the kedro viz command "viz"
-        Then kedro-viz should start successfully
-
-    Scenario: Execute viz with Kedro 0.14.3
-        Given I have installed kedro version "0.14.3"
-        And I have run a non-interactive kedro new
-        When I execute the kedro viz command "viz"
-        Then kedro-viz should start successfully
-
-    Scenario: Execute viz with Kedro 0.15.0
-        Given I have installed kedro version "0.15.0"
-        And I have run a non-interactive kedro new
-        When I execute the kedro viz command "viz"
-        Then kedro-viz should start successfully
+#
+#    Scenario: Execute viz with Kedro 0.14.0
+#        Given I have installed kedro version "0.14.0"
+#        And I have run a non-interactive kedro new
+#        When I execute the kedro viz command "viz"
+#        Then kedro-viz should start successfully
+#
+#    Scenario: Execute viz with Kedro 0.14.3
+#        Given I have installed kedro version "0.14.3"
+#        And I have run a non-interactive kedro new
+#        When I execute the kedro viz command "viz"
+#        Then kedro-viz should start successfully
+#
+#    Scenario: Execute viz with Kedro 0.15.0
+#        Given I have installed kedro version "0.15.0"
+#        And I have run a non-interactive kedro new
+#        When I execute the kedro viz command "viz"
+#        Then kedro-viz should start successfully
 
     Scenario: Execute viz with latest Kedro
         Given I have installed kedro version "latest"
         And I have run a non-interactive kedro new
+        And I have executed the kedro command "install"
+        # otherwise try pip install -r src/requirements.txt
         When I execute the kedro viz command "viz"
         Then kedro-viz should start successfully

--- a/package/features/viz.feature
+++ b/package/features/viz.feature
@@ -30,24 +30,27 @@
 Feature: Viz plugin in new project
     Background:
         Given I have prepared a config file with example code
-#
-#    Scenario: Execute viz with Kedro 0.14.0
-#        Given I have installed kedro version "0.14.0"
-#        And I have run a non-interactive kedro new
-#        When I execute the kedro viz command "viz"
-#        Then kedro-viz should start successfully
-#
-#    Scenario: Execute viz with Kedro 0.14.3
-#        Given I have installed kedro version "0.14.3"
-#        And I have run a non-interactive kedro new
-#        When I execute the kedro viz command "viz"
-#        Then kedro-viz should start successfully
-#
-#    Scenario: Execute viz with Kedro 0.15.0
-#        Given I have installed kedro version "0.15.0"
-#        And I have run a non-interactive kedro new
-#        When I execute the kedro viz command "viz"
-#        Then kedro-viz should start successfully
+
+    Scenario: Execute viz with Kedro 0.14.0
+        Given I have installed kedro version "0.14.0"
+        And I have run a non-interactive kedro new
+        And I have executed the kedro command "install"
+        When I execute the kedro viz command "viz"
+        Then kedro-viz should start successfully
+
+    Scenario: Execute viz with Kedro 0.14.3
+        Given I have installed kedro version "0.14.3"
+        And I have run a non-interactive kedro new
+        And I have executed the kedro command "install"
+        When I execute the kedro viz command "viz"
+        Then kedro-viz should start successfully
+
+    Scenario: Execute viz with Kedro 0.15.0
+        Given I have installed kedro version "0.15.0"
+        And I have run a non-interactive kedro new
+        And I have executed the kedro command "install"
+        When I execute the kedro viz command "viz"
+        Then kedro-viz should start successfully
 
     Scenario: Execute viz with latest Kedro
         Given I have installed kedro version "latest"


### PR DESCRIPTION
## Description

<!-- Why was this PR created? -->
Last scenario in `viz.feature` fails, which I was able to reproduce manually in a clean environment. It is actually expected behaviour, we should update our tests.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->
We don't run `kedro install` after creating a Kedro project in e2e tests, which is an incomplete workflow.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->
Somehow this failed on my machine with a weird error (https://stackoverflow.com/questions/54093020/no-module-named-pandas-libs-tslib/54539768) complaining about `pandas` already being installed, so checking if this is reproduced on CI. If yes, it's sth weird we're doing in behave setup.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
