### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,11 @@ jobs:
     environment:
       CONDA_ENV_PY_VERSION: "3.7"
 
+  build_38:
+    <<: *DEFAULT
+    environment:
+      CONDA_ENV_PY_VERSION: "3.8"
+
   deploy_demo:
     <<: *DEFAULT
     steps:
@@ -167,10 +172,12 @@ workflows:
     jobs:
       - build_36
       - build_37
+      - build_38
       - deploy_demo:
           requires:
             - build_36
             - build_37
+            - build_38
           filters:
             branches:
               only: master
@@ -186,3 +193,4 @@ workflows:
     jobs:
       - build_36
       - build_37
+      - build_38

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm version](https://img.shields.io/npm/v/@quantumblack/kedro-viz.svg?color=cc3534)](https://badge.fury.io/js/%40quantumblack%2Fkedro-viz)
 [![PyPI version](https://img.shields.io/pypi/v/kedro-viz.svg?color=yellow)](https://pypi.org/project/kedro-viz/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-3da639.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Python Version](https://img.shields.io/badge/python-3.6%20%7C%203.7-blue.svg)](https://pypi.org/project/kedro-viz/)
+[![Python Version](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8-blue.svg)](https://pypi.org/project/kedro-viz/)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 Kedro-Viz shows you how your [Kedro](https://github.com/quantumblacklabs/kedro) data pipelines are structured.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@ Please follow the established format:
 ## Major features and improvements
 
 <!-- Add release notes for the upcoming release here -->
-- Add support for Python 3.8 (#XXX)
+- Add support for Python 3.8 (#173)
 ## Bug fixes and other changes
 
 <!-- Add release notes for the upcoming release here -->

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@ Please follow the established format:
 ## Major features and improvements
 
 <!-- Add release notes for the upcoming release here -->
-
+- Add support for Python 3.8 (#XXX)
 ## Bug fixes and other changes
 
 <!-- Add release notes for the upcoming release here -->

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -32,6 +32,7 @@ import glob
 import os
 import shutil
 import stat
+import sys
 import tempfile
 from pathlib import Path
 
@@ -39,10 +40,21 @@ from features.steps.sh_run import run
 from features.steps.util import create_new_venv
 
 
-def before_scenario(context, feature):  # pylint: disable=unused-argument
+def should_exclude_scenario(scenario):
+    # -- RUNTIME DECISION LOGIC: Will exclude
+    #  * Scenario: Alice
+    #  * Scenario: Alice in Wonderland
+    #  * Scenario: Bob and Alice2
+    pre_16_scenario = any(key in scenario.name for key in ["0.14", "0.15"])
+    return sys.version_info == (3.8) and pre_16_scenario
+
+
+def before_scenario(context, feature, scenario):  # pylint: disable=unused-argument
     """Environment preparation before other cli tests are run.
     Installs kedro by running pip in the top level directory.
     """
+    if should_exclude_scenario(scenario):
+        scenario.skip()
 
     def call(cmd, verbose=False):
         res = run(cmd, env=context.env)

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -40,11 +40,7 @@ from features.steps.sh_run import run
 from features.steps.util import create_new_venv
 
 
-def should_exclude_scenario(scenario):
-    # -- RUNTIME DECISION LOGIC: Will exclude
-    #  * Scenario: Alice
-    #  * Scenario: Alice in Wonderland
-    #  * Scenario: Bob and Alice2
+def _should_exclude_scenario(scenario):
     pre_16_scenario = any(key in scenario.name for key in ["0.14", "0.15"])
     return sys.version_info >= (3, 8) and pre_16_scenario
 
@@ -53,7 +49,7 @@ def before_scenario(context, scenario):  # pylint: disable=unused-argument
     """Environment preparation before other cli tests are run.
     Installs kedro by running pip in the top level directory.
     """
-    if should_exclude_scenario(scenario):
+    if _should_exclude_scenario(scenario):
         scenario.skip()
 
     def call(cmd, verbose=False):

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -46,7 +46,7 @@ def should_exclude_scenario(scenario):
     #  * Scenario: Alice in Wonderland
     #  * Scenario: Bob and Alice2
     pre_16_scenario = any(key in scenario.name for key in ["0.14", "0.15"])
-    return sys.version_info > (3.7) and pre_16_scenario
+    return sys.version_info >= (3, 8) and pre_16_scenario
 
 
 def before_scenario(context, scenario):  # pylint: disable=unused-argument

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -49,7 +49,7 @@ def should_exclude_scenario(scenario):
     return sys.version_info >= (3.8) and pre_16_scenario
 
 
-def before_scenario(context, feature, scenario):  # pylint: disable=unused-argument
+def before_scenario(context, scenario, feature):  # pylint: disable=unused-argument
     """Environment preparation before other cli tests are run.
     Installs kedro by running pip in the top level directory.
     """

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -46,7 +46,7 @@ def should_exclude_scenario(scenario):
     #  * Scenario: Alice in Wonderland
     #  * Scenario: Bob and Alice2
     pre_16_scenario = any(key in scenario.name for key in ["0.14", "0.15"])
-    return sys.version_info >= (3.8) and pre_16_scenario
+    return sys.version_info > (3.7) and pre_16_scenario
 
 
 def before_scenario(context, scenario):  # pylint: disable=unused-argument
@@ -108,7 +108,7 @@ def before_scenario(context, scenario):  # pylint: disable=unused-argument
     context.temp_dir = Path(tempfile.mkdtemp())
 
 
-def after_scenario(context):
+def after_scenario(context, scenario):
     # pylint: disable=unused-argument
     rmtree(str(context.temp_dir))
     if "E2E_VENV" not in os.environ:

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -46,7 +46,7 @@ def should_exclude_scenario(scenario):
     #  * Scenario: Alice in Wonderland
     #  * Scenario: Bob and Alice2
     pre_16_scenario = any(key in scenario.name for key in ["0.14", "0.15"])
-    return sys.version_info == (3.8) and pre_16_scenario
+    return sys.version_info >= (3.8) and pre_16_scenario
 
 
 def before_scenario(context, feature, scenario):  # pylint: disable=unused-argument

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -49,7 +49,7 @@ def should_exclude_scenario(scenario):
     return sys.version_info >= (3.8) and pre_16_scenario
 
 
-def before_scenario(context, scenario, feature):  # pylint: disable=unused-argument
+def before_scenario(context, scenario):  # pylint: disable=unused-argument
     """Environment preparation before other cli tests are run.
     Installs kedro by running pip in the top level directory.
     """
@@ -108,7 +108,7 @@ def before_scenario(context, scenario, feature):  # pylint: disable=unused-argum
     context.temp_dir = Path(tempfile.mkdtemp())
 
 
-def after_scenario(context, feature):
+def after_scenario(context):
     # pylint: disable=unused-argument
     rmtree(str(context.temp_dir))
     if "E2E_VENV" not in os.environ:

--- a/package/features/viz.feature
+++ b/package/features/viz.feature
@@ -49,6 +49,12 @@ Feature: Viz plugin in new project
         When I execute the kedro viz command "viz"
         Then kedro-viz should start successfully
 
+    Scenario: Execute viz with Kedro 0.16.1
+        Given I have installed kedro version "0.16.1"
+        And I have run a non-interactive kedro new
+        When I execute the kedro viz command "viz"
+        Then kedro-viz should start successfully
+
     Scenario: Execute viz with latest Kedro
         Given I have installed kedro version "latest"
         And I have run a non-interactive kedro new

--- a/package/features/viz.feature
+++ b/package/features/viz.feature
@@ -52,6 +52,7 @@ Feature: Viz plugin in new project
     Scenario: Execute viz with Kedro 0.16.1
         Given I have installed kedro version "0.16.1"
         And I have run a non-interactive kedro new
+        And I have executed the kedro command "install"
         When I execute the kedro viz command "viz"
         Then kedro-viz should start successfully
 

--- a/package/setup.py
+++ b/package/setup.py
@@ -69,7 +69,7 @@ setup(
     long_description_content_type="text/markdown",
     license="Apache Software License (Apache 2.0)",
     url="https://github.com/quantumblacklabs/kedro-viz",
-    python_requires=">=3.6, <3.8",
+    python_requires=">=3.6, <3.9",
     install_requires=requires,
     tests_require=test_requires,
     keywords="pipelines, machine learning, data pipelines, data science, data engineering, visualisation",


### PR DESCRIPTION
## Description

Kedro 0.16.* has been released, which supports Python 3.8. So we are also supporting Python 3.8 for Kedro-Viz plugins. 

## Development notes
Modified the e2e tests 

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
