### PR TITLE
Support semver versions in requirements.txt

### DIFF
--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -43,16 +43,23 @@ from typing import Dict, List, Set
 import click
 import kedro
 import requests
+import semver
 from flask import Flask, jsonify, send_from_directory
 from IPython.core.display import HTML, display
-from semver import VersionInfo
 from toposort import toposort_flatten
 
 from kedro_viz.utils import wait_for
 
-KEDRO_VERSION = VersionInfo.parse(kedro.__version__)
+KEDRO_VERSION = semver.VersionInfo.parse(kedro.__version__)
 
-if KEDRO_VERSION.match(">=0.16.0"):
+
+def _check_kedro_version_is(version: str):
+    if semver.match(semver.__version__, ">=2.10.0"):
+        return KEDRO_VERSION.match(version)
+    return semver.match(str(KEDRO_VERSION), version)
+
+
+if _check_kedro_version_is(">=0.16.0"):
     from kedro.framework.cli import get_project_context
     from kedro.framework.cli.utils import KedroCliError
 else:
@@ -168,7 +175,7 @@ def _load_from_file(load_file: str) -> dict:
 
 
 def _get_pipeline_from_context(context, pipeline_name):
-    if KEDRO_VERSION.match(">=0.15.2"):
+    if _check_kedro_version_is(">=0.15.2"):
         return context._get_pipeline(  # pylint: disable=protected-access
             name=pipeline_name
         )
@@ -475,9 +482,9 @@ def _call_viz(
 
         data = _load_from_file(load_file)
     else:
-        if KEDRO_VERSION.match(">=0.15.0"):
+        if _check_kedro_version_is(">=0.15.0"):
             # pylint: disable=import-outside-toplevel
-            if KEDRO_VERSION.match(">=0.16.0"):
+            if _check_kedro_version_is(">=0.16.0"):
                 from kedro.framework.context import KedroContextError
             else:
                 from kedro.context import KedroContextError


### PR DESCRIPTION
## Description

Hi team. I saw that `semver.VersionInfo.match` was being used to match kedro versions.

Unfortunately, [`semver.VersionInfo.match`](https://python-semver.readthedocs.io/en/2.9.1/api.html#semver.VersionInfo.isvalid) is [unsupported in `semver <= 2.9.1`](https://python-semver.readthedocs.io/en/2.9.1/api.html#semver.VersionInfo.major), but the [`requirements.txt`](https://github.com/quantumblacklabs/kedro-viz/blob/master/package/requirements.txt) only asks for `semver >=2.8.1`.

This pull requests adds a semver version check, to keep the code backwards compatible with `semver < 2.10.0`.

## Development notes

Uses `semver` to check itself for its own compatibility.

## QA notes

The tests `test_root_endpoint` and `test_call_twice_with_different_port` weren't working on `develop`, and still aren't working on my current PR.

## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [X] Added new entries to the `RELEASE.md` file
- [X] Added tests to cover my changes

## Legal notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
