### PR TITLE
Fix tooltip triangle styling issues

### DIFF
--- a/src/components/easter-egg/easter-egg.scss
+++ b/src/components/easter-egg/easter-egg.scss
@@ -1,3 +1,7 @@
+.easter-theme .pipeline-flowchart {
+  animation: spin3d 4s infinite alternate linear;
+}
+
 .easter-theme {
   overflow: hidden;
 
@@ -73,6 +77,15 @@
     // beat: 188 bpm. speed obtained by (120/188)*2
     animation: brody 1.27659574468s linear 0s infinite;
     pointer-events: none;
+  }
+}
+
+@keyframes spin3d {
+  0% {
+    transform: perspective(400px) rotateY(20deg) rotateX(10deg);
+  }
+  100% {
+    transform: perspective(400px) rotateY(-20deg) rotateX(10deg);
   }
 }
 

--- a/src/components/icon-toolbar/icon-toolbar.scss
+++ b/src/components/icon-toolbar/icon-toolbar.scss
@@ -81,7 +81,7 @@
 
     position: absolute;
     top: calc(50% - #{$triangle-size});
-    left: -$triangle-size;
+    left: -$triangle-size + 0.5;
     width: 0;
     height: 0;
     border-color: transparent;

--- a/src/components/icon-toolbar/icon-toolbar.scss
+++ b/src/components/icon-toolbar/icon-toolbar.scss
@@ -44,7 +44,10 @@
 
   &:disabled {
     cursor: not-allowed;
-    opacity: 0.2;
+
+    svg {
+      opacity: 0.2;
+    }
   }
 
   svg {

--- a/src/components/icon-toolbar/icon-toolbar.scss
+++ b/src/components/icon-toolbar/icon-toolbar.scss
@@ -76,7 +76,7 @@
     opacity: 1;
   }
 
-  &::before {
+  &::after {
     $triangle-size: 7px;
 
     position: absolute;

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -30,7 +30,7 @@ $triangle-size: 10px;
     top: $y-offset;
   }
 
-  &::before {
+  &::after {
     position: absolute;
     bottom: -$y-offset + 0.5;
     left: $x-offset / 2;
@@ -50,12 +50,12 @@ $triangle-size: 10px;
     }
   }
 
-  &--right::before {
+  &--right::after {
     right: $x-offset / 2;
     left: auto;
   }
 
-  &--top::before {
+  &--top::after {
     top: -$y-offset + 0.5;
     bottom: auto;
     border-width: 0 $triangle-size $triangle-size $triangle-size;

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -32,7 +32,7 @@ $triangle-size: 10px;
 
   &::before {
     position: absolute;
-    bottom: -$y-offset;
+    bottom: -$y-offset + 0.5;
     left: $x-offset / 2;
     width: 0;
     height: 0;
@@ -56,7 +56,7 @@ $triangle-size: 10px;
   }
 
   &--top::before {
-    top: -$y-offset;
+    top: -$y-offset + 0.5;
     bottom: auto;
     border-width: 0 $triangle-size $triangle-size $triangle-size;
     border-top-color: transparent;


### PR DESCRIPTION
## Description

- Fix sub-pixel aliasing gaps on retina screens
    - For some reason, there is often a 0.5px gap between the triangle and the tooltip box on retina screens. Adding/subtracting 0.5px fixes the problem.
- Fix tooltip drop-shadow overlapping triangle
    - Place the triangle after the text box rather than before, in order to change the z-index and avoid the box-shadow overlapping the triangle
- Don't fade out icon button tooltip when disabled
    - Disabled icon-toolbar buttons are faded out to 20% opacity. This change prevents the on-hover tooltip from being similarly faded out on hover, as it just makes them harder to read and the transparency looks weird

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
