### PR TITLE
[KED-1735] Parameterise run_viz with project_path

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,7 @@ Please follow the established format:
 
 ## Bug fixes and other changes
 
-<!-- Add release notes for the upcoming release here -->
+* Fix `%run_viz` line magic to display kedro viz inside Jupyter notebook. Note that the fix needs `kedro>=0.16.2` to take effect.
 
 # Release 3.3.0:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,7 @@ Please follow the established format:
 
 ## Bug fixes and other changes
 
-* Fix `%run_viz` line magic to display kedro viz inside Jupyter notebook. Note that the fix needs `kedro>=0.16.2` to take effect.
+* Fix `%run_viz` line magic to display kedro viz inside Jupyter notebook, previously broken for kedro 0.16.0/0.16.1. Note that the fix needs `kedro>=0.16.2` to take effect.
 
 # Release 3.3.0:
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -125,15 +125,13 @@ def run_viz(port=None, line=None, local_ns=None) -> None:
         _VIZ_PROCESSES[port].terminate()
 
     if local_ns is not None and 'project_path' in local_ns:
-        viz_process = multiprocessing.Process(
-            target=partial(_call_viz, project_path=local_ns['project_path']),
-            daemon=True,
-            kwargs={"port": port}
-        )
+        target = partial(_call_viz, project_path=local_ns['project_path'])
     else:
-        viz_process = multiprocessing.Process(
-            target=_call_viz, daemon=True, kwargs={"port": port}
-        )
+        target = _call_viz
+
+    viz_process = multiprocessing.Process(
+        target=target, daemon=True, kwargs={"port": port}
+    )
 
     viz_process.start()
     _VIZ_PROCESSES[port] = viz_process

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -124,8 +124,8 @@ def run_viz(port=None, line=None, local_ns=None) -> None:
     if port in _VIZ_PROCESSES and _VIZ_PROCESSES[port].is_alive():
         _VIZ_PROCESSES[port].terminate()
 
-    if local_ns is not None and 'project_path' in local_ns:
-        target = partial(_call_viz, project_path=local_ns['project_path'])
+    if local_ns is not None and "project_path" in local_ns:
+        target = partial(_call_viz, project_path=local_ns["project_path"])
     else:
         target = _call_viz
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -37,17 +37,18 @@ import traceback
 import webbrowser
 from collections import defaultdict
 from contextlib import closing
+from functools import partial
 from pathlib import Path
 from typing import Dict, List, Set
 
 import click
-import kedro
 import requests
 from flask import Flask, jsonify, send_from_directory
 from IPython.core.display import HTML, display
 from semver import VersionInfo
 from toposort import toposort_flatten
 
+import kedro
 from kedro_viz.utils import wait_for
 
 KEDRO_VERSION = VersionInfo.parse(kedro.__version__)
@@ -104,7 +105,7 @@ def _check_viz_up(port):
 
 
 # pylint: disable=unused-argument
-def run_viz(port=None, line=None) -> None:
+def run_viz(port=None, line=None, local_ns=None) -> None:
     """
     Line magic function to start kedro viz. It calls a kedro viz in a process and display it in
     the Jupyter notebook environment.
@@ -112,6 +113,9 @@ def run_viz(port=None, line=None) -> None:
     Args:
         port: TCP port that viz will listen to. Defaults to 4141.
         line: line required by line magic interface.
+        local_ns: Local namespace with local variables of the scope where the line magic is invoked.
+            For more details, please visit:
+            https://ipython.readthedocs.io/en/stable/config/custommagics.html
 
     """
     port = port or 4141  # Default argument doesn't work in Jupyter line magic
@@ -120,9 +124,17 @@ def run_viz(port=None, line=None) -> None:
     if port in _VIZ_PROCESSES and _VIZ_PROCESSES[port].is_alive():
         _VIZ_PROCESSES[port].terminate()
 
-    viz_process = multiprocessing.Process(
-        target=_call_viz, daemon=True, kwargs={"port": port}
-    )
+    if local_ns is not None and 'project_path' in local_ns:
+        viz_process = multiprocessing.Process(
+            target=partial(_call_viz, project_path=local_ns['project_path']),
+            daemon=True,
+            kwargs={"port": port}
+        )
+    else:
+        viz_process = multiprocessing.Process(
+            target=_call_viz, daemon=True, kwargs={"port": port}
+        )
+
     viz_process.start()
     _VIZ_PROCESSES[port] = viz_process
 
@@ -456,7 +468,7 @@ def viz(host, port, browser, load_file, save_file, pipeline, env):
         raise KedroCliError(str(ex))
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,too-many-branches
 def _call_viz(
     host=None,
     port=None,
@@ -465,6 +477,7 @@ def _call_viz(
     save_file=None,
     pipeline_name=None,
     env=None,
+    project_path=None
 ):
     global data  # pylint: disable=global-statement,invalid-name
 
@@ -483,7 +496,13 @@ def _call_viz(
                 from kedro.context import KedroContextError
 
             try:
-                context = get_project_context("context", env=env)
+                if project_path is not None:
+                    context = get_project_context("context", project_path=project_path, env=env)
+                else:
+                    print(">>>>>>> GET HERE")
+                    print(get_project_context)
+                    context = get_project_context("context", env=env)
+                print(context)
                 pipeline = _get_pipeline_from_context(context, pipeline_name)
             except KedroContextError:
                 raise KedroCliError(ERROR_PROJECT_ROOT)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -499,10 +499,7 @@ def _call_viz(
                 if project_path is not None:
                     context = get_project_context("context", project_path=project_path, env=env)
                 else:
-                    print(">>>>>>> GET HERE")
-                    print(get_project_context)
                     context = get_project_context("context", env=env)
-                print(context)
                 pipeline = _get_pipeline_from_context(context, pipeline_name)
             except KedroContextError:
                 raise KedroCliError(ERROR_PROJECT_ROOT)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -42,13 +42,13 @@ from pathlib import Path
 from typing import Dict, List, Set
 
 import click
+import kedro
 import requests
 from flask import Flask, jsonify, send_from_directory
 from IPython.core.display import HTML, display
 from semver import VersionInfo
 from toposort import toposort_flatten
 
-import kedro
 from kedro_viz.utils import wait_for
 
 KEDRO_VERSION = VersionInfo.parse(kedro.__version__)

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -25,22 +25,24 @@
 #
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pylint: disable=protected-access
 """
 Tests for Kedro-Viz server
 """
 
 import json
 import re
+from functools import partial
 from pathlib import Path
 
 import pytest
+from semver import VersionInfo
+from toposort import CircularDependencyError
+
 from kedro.context import KedroContextError
 from kedro.extras.datasets.pickle import PickleDataSet
 from kedro.io import DataCatalog, MemoryDataSet
 from kedro.pipeline import Pipeline, node
-from semver import VersionInfo
-from toposort import CircularDependencyError
-
 from kedro_viz import server
 from kedro_viz.server import _allocate_port, _sort_layers, format_pipeline_data
 from kedro_viz.utils import WaitForException
@@ -167,7 +169,7 @@ def patched_get_project_context(mocker):
             "context": mocked_context,
         }[key]
 
-    mocker.patch("kedro_viz.server.get_project_context", new=get_project_context)
+    return mocker.patch("kedro_viz.server.get_project_context", side_effect=get_project_context)
 
 
 @pytest.fixture
@@ -206,6 +208,14 @@ def test_no_browser(cli_runner):
     result = cli_runner.invoke(server.commands, ["viz"])
     assert result.exit_code == 0, result.output
     assert server.webbrowser.open_new.call_count == 1
+
+
+def test_viz_does_not_need_to_specify_project_path(cli_runner, patched_get_project_context):
+    cli_runner.invoke(server.commands, ["viz", "--no-browser"])
+    patched_get_project_context.assert_called_once_with(
+        "context",
+        env=None
+    )
 
 
 @pytest.mark.usefixtures("patched_get_project_context")
@@ -410,7 +420,6 @@ def test_viz_stacktrace(mocker, cli_runner):
 
 @pytest.fixture(autouse=True)
 def clean_up():
-    # pylint: disable=protected-access
     server._VIZ_PROCESSES.clear()
 
 
@@ -437,13 +446,31 @@ def mocked_process(mocker):
     return mocker.patch("kedro_viz.server.multiprocessing.Process")
 
 
+class TestCallViz:
+
+    def test_call_viz_without_project_path(self, patched_get_project_context):
+        server._call_viz()
+        patched_get_project_context.assert_called_once_with(
+            "context",
+            env=None
+        )
+
+    def test_call_viz_with_project_path(self, patched_get_project_context):
+        mocked_project_path = Path("/tmp")
+        server._call_viz(project_path=mocked_project_path)
+        patched_get_project_context.assert_called_once_with(
+            "context",
+            project_path=mocked_project_path,
+            env=None
+        )
+
+
 class TestRunViz:
     default_port = 4141
 
     def test_call_once(self, mocked_process):
         """Test inline magic function"""
         server.run_viz()
-        # pylint: disable=protected-access
         mocked_process.assert_called_once_with(
             target=server._call_viz, kwargs={"port": self.default_port}, daemon=True
         )
@@ -452,7 +479,6 @@ class TestRunViz:
         """Running run_viz with the same port should trigger another process."""
         server.run_viz()
         server.run_viz()
-        # pylint: disable=protected-access
         mocked_process.assert_called_with(
             target=server._call_viz, kwargs={"port": self.default_port}, daemon=True
         )
@@ -461,12 +487,10 @@ class TestRunViz:
     def test_call_twice_with_different_port(self, mocked_process):
         """Running run_viz with a different port should start another process."""
         server.run_viz()
-        # pylint: disable=protected-access
         mocked_process.assert_called_with(
             target=server._call_viz, kwargs={"port": self.default_port}, daemon=True
         )
         server.run_viz(port=8000)
-        # pylint: disable=protected-access
         mocked_process.assert_called_with(
             target=server._call_viz, kwargs={"port": 8000}, daemon=True
         )
@@ -477,11 +501,28 @@ class TestRunViz:
         requests_mock.get(
             "http://127.0.0.1:8000/", content=b"some output", status_code=200
         )
-        assert server._check_viz_up(8000)  # pylint: disable=protected-access
+        assert server._check_viz_up(8000)
 
     def test_check_viz_up_invalid(self):
         """Test should catch the request connection error and returns False."""
-        assert not server._check_viz_up(8888)  # pylint: disable=protected-access
+        assert not server._check_viz_up(8888)
+
+    def test_call_with_local_ns(self, mocked_process):
+        mocked_project_path = Path("/tmp")
+        mocked_local_ns = {"project_path": mocked_project_path}
+
+        server.run_viz(local_ns=mocked_local_ns)
+
+        # we can't use assert_called_once_with because it doesn't work with functools.partial
+        # so we are comparing the call args one by one
+        assert len(mocked_process.mock_calls) == 2  # 1 for the constructor, 1 to start the process
+        mocked_call_kwargs = mocked_process.call_args_list[0][1]
+
+        expected_target = partial(server._call_viz, project_path=mocked_project_path)
+        assert mocked_call_kwargs["target"].func == expected_target.func \
+            and mocked_call_kwargs["target"].args == expected_target.args \
+            and mocked_call_kwargs["target"].keywords == expected_target.keywords
+        assert mocked_call_kwargs["daemon"] is True
 
 
 class TestAllocatePort:

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -36,13 +36,13 @@ from functools import partial
 from pathlib import Path
 
 import pytest
-from semver import VersionInfo
-from toposort import CircularDependencyError
-
 from kedro.context import KedroContextError
 from kedro.extras.datasets.pickle import PickleDataSet
 from kedro.io import DataCatalog, MemoryDataSet
 from kedro.pipeline import Pipeline, node
+from semver import VersionInfo
+from toposort import CircularDependencyError
+
 from kedro_viz import server
 from kedro_viz.server import _allocate_port, _sort_layers, format_pipeline_data
 from kedro_viz.utils import WaitForException


### PR DESCRIPTION
## Description

This is the first part of the fix for KED-1735.

A summary of the problem and the fix:

* After we release Kedro 0.16.1, the `run_viz` line magic has stopped working because we stop changing user's working directory directly, so the line magic isn't being called with the correct `project_path`.
* To fix this problem, this PR adds a backward-compatible way to call `run_viz` and subsequently `_call_viz` with a `project_path` parameter. For `run_viz`, this parameter is provided via the `local_ns` parameter, which is provided by IPython line magic's local scope functionality.
* Another follow-up PR in Kedro will make sure that the line magic has the correct local scope, which contains the `project_path` value, as well as parameterise `get_project_context` to use it.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
