### PR TITLE
[KED-1730] Improve rendering performance

### DIFF
--- a/src/actions/check-font-loaded.test.js
+++ b/src/actions/check-font-loaded.test.js
@@ -13,7 +13,8 @@ describe('checkFontLoaded', () => {
   };
 
   beforeEach(() => {
-    store = createStore(reducer, mockState.lorem);
+    const state = reducer(mockState.lorem, updateFontLoaded(false));
+    store = createStore(reducer, state);
     jest.resetModules();
     document.fonts = {
       check: () => false,

--- a/src/components/wrapper/index.js
+++ b/src/components/wrapper/index.js
@@ -9,20 +9,21 @@ import './wrapper.css';
 /**
  * Main app container. Handles showing/hiding the sidebar nav, and theme classes.
  */
-export const Wrapper = ({ fontLoaded, theme }) => (
+export const Wrapper = ({ theme }) => (
   <div
     className={classnames('kedro-pipeline', {
       'kui-theme--dark': theme === 'dark',
       'kui-theme--light': theme === 'light'
     })}>
     <Sidebar />
-    <div className="pipeline-wrapper">{fontLoaded && <FlowChart />}</div>
+    <div className="pipeline-wrapper">
+      <FlowChart />
+    </div>
     <ExportModal />
   </div>
 );
 
 export const mapStateToProps = state => ({
-  fontLoaded: state.fontLoaded,
   theme: state.theme
 });
 

--- a/src/components/wrapper/wrapper.test.js
+++ b/src/components/wrapper/wrapper.test.js
@@ -1,11 +1,9 @@
-import React from 'react';
 import { Wrapper, mapStateToProps } from './index';
 import { mockState, setup } from '../../utils/state.mock';
 
 const { theme } = mockState.lorem;
 const mockProps = {
-  theme,
-  fontLoaded: true
+  theme
 };
 
 describe('Wrapper', () => {
@@ -22,20 +20,9 @@ describe('Wrapper', () => {
     expect(container.hasClass(`kui-theme--dark`)).toBe(theme === 'dark');
   });
 
-  it("doesn't show the chart if fontLoaded is false", () => {
-    const wrapper = setup.mount(<Wrapper fontLoaded={false} />);
-    expect(wrapper.find('FlowChart').exists()).toBe(false);
-  });
-
-  it('only shows the chart if fontLoaded is true', () => {
-    const wrapper = setup.mount(<Wrapper fontLoaded={true} />);
-    expect(wrapper.find('FlowChart').exists()).toBe(true);
-  });
-
   it('maps state to props', () => {
     expect(mapStateToProps(mockState.lorem)).toEqual({
-      theme,
-      fontLoaded: false
+      theme
     });
   });
 });

--- a/src/selectors/layers.js
+++ b/src/selectors/layers.js
@@ -10,6 +10,10 @@ const getLayerName = state => state.layer.name;
 export const getLayers = createSelector(
   [getLayoutNodes, getVisibleLayerIDs, getLayerName, getGraphSize],
   (nodes, layerIDs, layerName, { width }) => {
+    if (!nodes.length) {
+      return [];
+    }
+
     // Get list of layer Y positions from nodes
     const layerY = nodes.reduce((layerY, node) => {
       if (!layerY[node.layer]) {

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -9,6 +9,7 @@ const getHasVisibleLayers = state =>
 const getNodeType = state => state.node.type;
 const getNodeLayer = state => state.node.layer;
 const getVisibleSidebar = state => state.visible.sidebar;
+const getFontLoaded = state => state.fontLoaded;
 
 /**
  * Calculate chart layout with Dagre.js.
@@ -17,9 +18,9 @@ const getVisibleSidebar = state => state.visible.sidebar;
  * which don't affect layout.
  */
 export const getGraph = createSelector(
-  [getVisibleNodes, getVisibleEdges, getHasVisibleLayers],
-  (nodes, edges, hasVisibleLayers) => {
-    if (!nodes.length || !edges.length) {
+  [getVisibleNodes, getVisibleEdges, getHasVisibleLayers, getFontLoaded],
+  (nodes, edges, hasVisibleLayers, fontLoaded) => {
+    if (!fontLoaded || !nodes.length || !edges.length) {
       return;
     }
 

--- a/src/selectors/nodes.js
+++ b/src/selectors/nodes.js
@@ -110,7 +110,10 @@ export const getGroupedNodes = createSelector(
  */
 export const getNodeTextWidth = createSelector(
   [getNodeIDs, getNodeName, getFontLoaded],
-  (nodeIDs, nodeName) => {
+  (nodeIDs, nodeName, fontLoaded) => {
+    if (!fontLoaded) {
+      return {};
+    }
     const svg = select(document.body)
       .append('svg')
       .attr('class', 'kedro pipeline-node');
@@ -147,9 +150,12 @@ export const getPadding = (showLabels, isTask) => {
  * Calculate node width/height and icon/text positioning
  */
 export const getNodeSize = createSelector(
-  [getNodeIDs, getNodeTextWidth, getTextLabels, getNodeType],
-  (nodeIDs, nodeTextWidth, textLabels, nodeType) =>
-    arrayToObject(nodeIDs, nodeID => {
+  [getNodeIDs, getNodeTextWidth, getTextLabels, getNodeType, getFontLoaded],
+  (nodeIDs, nodeTextWidth, textLabels, nodeType, fontLoaded) => {
+    if (!fontLoaded) {
+      return {};
+    }
+    return arrayToObject(nodeIDs, nodeID => {
       const iconSize = textLabels ? 24 : 28;
       const padding = getPadding(textLabels, nodeType[nodeID] === 'task');
       const textWidth = textLabels ? nodeTextWidth[nodeID] : 0;
@@ -162,7 +168,8 @@ export const getNodeSize = createSelector(
         iconOffset: -innerWidth / 2,
         iconSize
       };
-    })
+    });
+  }
 );
 
 /**
@@ -177,17 +184,29 @@ export const getVisibleNodes = createSelector(
     getNodeFullName,
     getNodeSize,
     getNodeLayer,
-    getNodeRank
+    getNodeRank,
+    getFontLoaded
   ],
-  (nodeIDs, nodeName, nodeType, nodeFullName, nodeSize, nodeLayer, nodeRank) =>
-    nodeIDs.map(id => ({
-      id,
-      name: nodeName[id],
-      label: nodeName[id],
-      fullName: nodeFullName[id],
-      type: nodeType[id],
-      layer: nodeLayer[id],
-      rank: nodeRank[id],
-      ...nodeSize[id]
-    }))
+  (
+    nodeIDs,
+    nodeName,
+    nodeType,
+    nodeFullName,
+    nodeSize,
+    nodeLayer,
+    nodeRank,
+    fontLoaded
+  ) =>
+    fontLoaded
+      ? nodeIDs.map(id => ({
+          id,
+          name: nodeName[id],
+          label: nodeName[id],
+          fullName: nodeFullName[id],
+          type: nodeType[id],
+          layer: nodeLayer[id],
+          rank: nodeRank[id],
+          ...nodeSize[id]
+        }))
+      : []
 );

--- a/src/selectors/nodes.js
+++ b/src/selectors/nodes.js
@@ -114,15 +114,20 @@ export const getNodeTextWidth = createSelector(
     if (!fontLoaded) {
       return {};
     }
+    const nodeTextWidth = {};
     const svg = select(document.body)
       .append('svg')
       .attr('class', 'kedro pipeline-node');
-    const nodeTextWidth = arrayToObject(nodeIDs, nodeID => {
-      const text = svg.append('text').text(nodeName[nodeID]);
-      const node = text.node();
-      const width = node.getBBox ? node.getBBox().width : 0;
-      return width;
-    });
+    svg
+      .selectAll('text')
+      .data(nodeIDs)
+      .enter()
+      .append('text')
+      .text(nodeID => nodeName[nodeID])
+      .each(function(nodeID) {
+        const width = this.getBBox ? this.getBBox().width : 0;
+        nodeTextWidth[nodeID] = width;
+      });
     svg.remove();
     return nodeTextWidth;
   }

--- a/src/utils/state.mock.js
+++ b/src/utils/state.mock.js
@@ -3,14 +3,25 @@ import { Provider } from 'react-redux';
 import { mount, shallow } from 'enzyme';
 import configureStore from '../store';
 import getInitialState from '../store/initial-state';
+import reducer from '../reducers';
+import { updateFontLoaded } from '../actions';
+
+/**
+ * Initialise state object, setting fontLoaded to true
+ * @param {Object} props
+ */
+const prepareState = (...props) => {
+  const state = getInitialState(...props);
+  return reducer(state, updateFontLoaded(true));
+};
 
 /**
  * Example state objects for use in tests of redux-enabled components
  */
 export const mockState = {
-  layers: getInitialState({ data: 'layers' }),
-  lorem: getInitialState({ data: 'lorem' }),
-  animals: getInitialState({ data: 'animals' })
+  layers: prepareState({ data: 'layers' }),
+  lorem: prepareState({ data: 'lorem' }),
+  animals: prepareState({ data: 'animals' })
 };
 
 /**
@@ -25,7 +36,7 @@ export const setup = {
   mount: (children, props = {}) => {
     const initialState = Object.assign(
       {},
-      getInitialState({ data: 'lorem', ...props }, props)
+      prepareState({ data: 'lorem', ...props }, props)
     );
     return mount(
       <Provider store={configureStore(initialState)}>{children}</Provider>


### PR DESCRIPTION
## Description

Kedro-Viz often runs very slowly on large pipelines. While there's only a limited amount that we can do to fix this (as the layout algorithm is intrinsically expensive), I have tried to find ways to reduce unnecessary overhead where possible.

## Development notes

1. Prevent layout calc from running twice on pageload: Though I had tried to avoid from being layout being called until after fontLoaded was ready, I missed that it was being called by the export-graph function, which meant that it was called twice on page load (i.e. on first load and then again when the font loads). I have changed this so that it now explicitly listens to fontLoaded, and won't return if fontLoaded is false. The same is now true for some of the more expensive node selectors.

2. Optimise getNodeTextWidth selector: This selector is a relatively expensive one, as it involves some hefty DOM operations. It turns out (from benchmarking tests) that using D3's selectAll approach is faster than the approach that I was using.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
