### PR TITLE
[KED-1745] Autoformat viz python code using black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ e2e-tests: build
 
 pylint:
 	cd package && isort
+	black package/kedro_viz package/tests package/features
 	pylint -j 0 --disable=bad-continuation,unnecessary-pass package/kedro_viz
 	pylint -j 0 --disable=bad-continuation,missing-docstring,redefined-outer-name,no-self-use,invalid-name,too-few-public-methods,no-member package/tests
 	pylint -j 0 --disable=missing-docstring,no-name-in-module package/features

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ e2e-tests: build
 
 pylint:
 	cd package && isort
-	black package/kedro_viz package/tests package/features
 	pylint -j 0 --disable=bad-continuation,unnecessary-pass package/kedro_viz
 	pylint -j 0 --disable=bad-continuation,missing-docstring,redefined-outer-name,no-self-use,invalid-name,too-few-public-methods,no-member package/tests
 	pylint -j 0 --disable=missing-docstring,no-name-in-module package/features

--- a/package/.isort.cfg
+++ b/package/.isort.cfg
@@ -1,4 +1,3 @@
-
 # copied from black
 
 [settings]

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -74,7 +74,7 @@ def create_project_from_config_file(context):
     res = run(
         [context.kedro, "new", "-c", str(context.config_file)],
         env=context.env,
-        cwd=str(context.temp_dir)
+        cwd=str(context.temp_dir),
     )
     assert res.returncode == OK_EXIT_CODE
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -479,7 +479,7 @@ def _call_viz(
     save_file=None,
     pipeline_name=None,
     env=None,
-    project_path=None
+    project_path=None,
 ):
     global data  # pylint: disable=global-statement,invalid-name
 
@@ -499,7 +499,9 @@ def _call_viz(
 
             try:
                 if project_path is not None:
-                    context = get_project_context("context", project_path=project_path, env=env)
+                    context = get_project_context(
+                        "context", project_path=project_path, env=env
+                    )
                 else:
                     context = get_project_context("context", env=env)
                 pipeline = _get_pipeline_from_context(context, pipeline_name)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -190,7 +190,9 @@ def _get_pipeline_catalog_from_kedro14(env):
         raise KedroCliError(ERROR_PROJECT_ROOT)
 
 
-def _sort_layers(nodes: Dict[str, Dict], dependencies: Dict[str, Set[str]]) -> List[str]:
+def _sort_layers(
+    nodes: Dict[str, Dict], dependencies: Dict[str, Set[str]]
+) -> List[str]:
     """Given a DAG represented by a dictionary of nodes, some of which have a `layer` attribute,
     along with their dependencies, return the list of all layers sorted according to
     the nodes' topological order, i.e. a layer should appear before another layer in the list
@@ -286,11 +288,13 @@ def _sort_layers(nodes: Dict[str, Dict], dependencies: Dict[str, Set[str]]) -> L
 def _construct_layer_mapping(catalog):
     if hasattr(catalog, "layers"):  # kedro>=0.16.0
         if catalog.layers is None:
-            return {ds_name: None for ds_name in catalog._data_sets}   # pylint: disable=protected-access
+            return {ds_name: None for ds_name in getattr(catalog, "_data_sets")}
 
         dataset_to_layer = {}
         for layer, dataset_names in catalog.layers.items():
-            dataset_to_layer.update({dataset_name: layer for dataset_name in dataset_names})
+            dataset_to_layer.update(
+                {dataset_name: layer for dataset_name in dataset_names}
+            )
     else:
         dataset_to_layer = {
             ds_name: getattr(ds_obj, "_layer", None)
@@ -382,7 +386,7 @@ def format_pipeline_data(pipeline, catalog):
         "nodes": sorted_nodes,
         "edges": edges,
         "tags": sorted_tags,
-        "layers": sorted_layers
+        "layers": sorted_layers,
     }
 
 

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 bandit>=1.6.2, < 2.0
+black==19.10b0
 psutil==5.6.6  # same as Kedro for now
 pytest>=4.4.2, <5.0
 pytest-cov>=2.7.1, <3.0

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -5,7 +5,7 @@ pytest>=4.4.2, <5.0
 pytest-cov>=2.7.1, <3.0
 pytest-coverage
 behave>=1.2.6, <2.0
-pylint>=2.4.4, <2.5.0 # due to a regression in 2.5.0: https://github.com/PyCQA/pylint/issues/3524
+pylint>=2.4.4, <3.0
 pytest-mock>=1.7.1,<2.0
 requests-mock>=1.6.0, <2.0
 flake8>=3.5, <3.8.0

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -5,7 +5,7 @@ pytest>=4.4.2, <5.0
 pytest-cov>=2.7.1, <3.0
 pytest-coverage
 behave>=1.2.6, <2.0
-pylint>=2.4.4, <3.0
+pylint>=2.4.4, <2.5.0 # due to a regression in 2.5.0: https://github.com/PyCQA/pylint/issues/3524
 pytest-mock>=1.7.1,<2.0
 requests-mock>=1.6.0, <2.0
 flake8>=3.5, <3.8.0

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 bandit>=1.6.2, < 2.0
-black==19.10b0
 psutil==5.6.6  # same as Kedro for now
 pytest>=4.4.2, <5.0
 pytest-cov>=2.7.1, <3.0

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -169,7 +169,9 @@ def patched_get_project_context(mocker):
             "context": mocked_context,
         }[key]
 
-    return mocker.patch("kedro_viz.server.get_project_context", side_effect=get_project_context)
+    return mocker.patch(
+        "kedro_viz.server.get_project_context", side_effect=get_project_context
+    )
 
 
 @pytest.fixture
@@ -210,12 +212,11 @@ def test_no_browser(cli_runner):
     assert server.webbrowser.open_new.call_count == 1
 
 
-def test_viz_does_not_need_to_specify_project_path(cli_runner, patched_get_project_context):
+def test_viz_does_not_need_to_specify_project_path(
+    cli_runner, patched_get_project_context
+):
     cli_runner.invoke(server.commands, ["viz", "--no-browser"])
-    patched_get_project_context.assert_called_once_with(
-        "context",
-        env=None
-    )
+    patched_get_project_context.assert_called_once_with("context", env=None)
 
 
 @pytest.mark.usefixtures("patched_get_project_context")
@@ -447,21 +448,15 @@ def mocked_process(mocker):
 
 
 class TestCallViz:
-
     def test_call_viz_without_project_path(self, patched_get_project_context):
         server._call_viz()
-        patched_get_project_context.assert_called_once_with(
-            "context",
-            env=None
-        )
+        patched_get_project_context.assert_called_once_with("context", env=None)
 
     def test_call_viz_with_project_path(self, patched_get_project_context):
         mocked_project_path = Path("/tmp")
         server._call_viz(project_path=mocked_project_path)
         patched_get_project_context.assert_called_once_with(
-            "context",
-            project_path=mocked_project_path,
-            env=None
+            "context", project_path=mocked_project_path, env=None
         )
 
 
@@ -515,13 +510,17 @@ class TestRunViz:
 
         # we can't use assert_called_once_with because it doesn't work with functools.partial
         # so we are comparing the call args one by one
-        assert len(mocked_process.mock_calls) == 2  # 1 for the constructor, 1 to start the process
+        assert (
+            len(mocked_process.mock_calls) == 2
+        )  # 1 for the constructor, 1 to start the process
         mocked_call_kwargs = mocked_process.call_args_list[0][1]
 
         expected_target = partial(server._call_viz, project_path=mocked_project_path)
-        assert mocked_call_kwargs["target"].func == expected_target.func \
-            and mocked_call_kwargs["target"].args == expected_target.args \
+        assert (
+            mocked_call_kwargs["target"].func == expected_target.func
+            and mocked_call_kwargs["target"].args == expected_target.args
             and mocked_call_kwargs["target"].keywords == expected_target.keywords
+        )
         assert mocked_call_kwargs["daemon"] is True
 
 

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -615,88 +615,145 @@ def test_format_pipeline_data_no_layers(pipeline, new_catalog_with_layers):
     assert result["layers"] == []
 
 
-@pytest.mark.parametrize("graph_schema,nodes,node_dependencies,expected", [
-    (
-        # direct dependency
-        "node_1(layer=raw) -> node_2(layer=int)",
-        {"node_1": {"id": "node_1", "layer": "raw"}, "node_2": {"id": "node_2", "layer": "int"}},
-        {"node_1": {"node_2"}, "node_2": set()},
-        ["raw", "int"]
-    ),
-    (
-        # more than 1 node in a layer
-        "node_1 -> node_2(layer=raw) -> node_3(layer=raw) -> node_4(layer=int)",
-        {"node_1": {"id": "node_1"}, "node_2": {"id": "node_2", "layer": "raw"},
-         "node_3": {"id": "node_3", "layer": "raw"}, "node_4": {"id": "node_4", "layer": "int"}},
-        {"node_1": {"node_2"}, "node_2": {"node_3"}, "node_3": {"node_4"}, "node_4": set()},
-        ["raw", "int"]
-    ),
-    (
-        # indirect dependency
-        "node_1(layer=raw) -> node_2 -> node_3(layer=int)",
-        {"node_1": {"id": "node_1", "layer": "raw"}, "node_2": {"id": "node_2"},
-         "node_3": {"id": "node_3", "layer": "int"}},
-        {"node_1": {"node_2"}, "node_2": {"node_3"}, "node_3": set()},
-        ["raw", "int"]
-    ),
-    (
-        # fan-in dependency
-        """
+@pytest.mark.parametrize(
+    "graph_schema,nodes,node_dependencies,expected",
+    [
+        (
+            # direct dependency
+            "node_1(layer=raw) -> node_2(layer=int)",
+            {
+                "node_1": {"id": "node_1", "layer": "raw"},
+                "node_2": {"id": "node_2", "layer": "int"},
+            },
+            {"node_1": {"node_2"}, "node_2": set()},
+            ["raw", "int"],
+        ),
+        (
+            # more than 1 node in a layer
+            "node_1 -> node_2(layer=raw) -> node_3(layer=raw) -> node_4(layer=int)",
+            {
+                "node_1": {"id": "node_1"},
+                "node_2": {"id": "node_2", "layer": "raw"},
+                "node_3": {"id": "node_3", "layer": "raw"},
+                "node_4": {"id": "node_4", "layer": "int"},
+            },
+            {
+                "node_1": {"node_2"},
+                "node_2": {"node_3"},
+                "node_3": {"node_4"},
+                "node_4": set(),
+            },
+            ["raw", "int"],
+        ),
+        (
+            # indirect dependency
+            "node_1(layer=raw) -> node_2 -> node_3(layer=int)",
+            {
+                "node_1": {"id": "node_1", "layer": "raw"},
+                "node_2": {"id": "node_2"},
+                "node_3": {"id": "node_3", "layer": "int"},
+            },
+            {"node_1": {"node_2"}, "node_2": {"node_3"}, "node_3": set()},
+            ["raw", "int"],
+        ),
+        (
+            # fan-in dependency
+            """
         node_1(layer=raw) -> node_2 -> node_3(layer=int) -> node_6(layer=feature)
         node_4(layer=int) -> node_5 -----------------------------^
         """,
-        {"node_1": {"id": "node_1", "layer": "raw"}, "node_2": {"id": "node_2"},
-         "node_3": {"id": "node_3", "layer": "int"}, "node_4": {"id": "node_4", "layer": "int"},
-         "node_5": {"id": "node_5"}, "node_6": {"id": "node_6", "layer": "feature"}},
-        {"node_1": {"node_2"}, "node_2": {"node_3"}, "node_3": {"node_6"}, "node_4": {"node_5"},
-         "node_5": {"node_6"}, "node_6": set()},
-        ["raw", "int", "feature"]
-    ),
-    (
-        # fan-out dependency: note that model_input comes after feature here based on
-        # alphabetical order since they have no dependency relationship.
-        """
+            {
+                "node_1": {"id": "node_1", "layer": "raw"},
+                "node_2": {"id": "node_2"},
+                "node_3": {"id": "node_3", "layer": "int"},
+                "node_4": {"id": "node_4", "layer": "int"},
+                "node_5": {"id": "node_5"},
+                "node_6": {"id": "node_6", "layer": "feature"},
+            },
+            {
+                "node_1": {"node_2"},
+                "node_2": {"node_3"},
+                "node_3": {"node_6"},
+                "node_4": {"node_5"},
+                "node_5": {"node_6"},
+                "node_6": set(),
+            },
+            ["raw", "int", "feature"],
+        ),
+        (
+            # fan-out dependency: note that model_input comes after feature here based on
+            # alphabetical order since they have no dependency relationship.
+            """
         node_1(layer=raw) -> node_2 -> node_3(layer=int) -> node_6 -> node_7(layer=feature)
                 |----------> node_4(layer=int) -> node_5(layer=model_input)
         """,
-        {"node_1": {"id": "node_1", "layer": "raw"}, "node_2": {"id": "node_2"},
-         "node_3": {"id": "node_3", "layer": "int"}, "node_4": {"id": "node_4", "layer": "int"},
-         "node_5": {"id": "node_5", "layer": "model_input"},
-         "node_6": {"id": "node_6"}, "node_7": {"id": "node_7", "layer": "feature"}},
-        {"node_1": {"node_2"}, "node_2": {"node_3"}, "node_3": {"node_6"},
-         "node_4": {"node_5"}, "node_5": set(), "node_6": {"node_7"}, "node_7": set()},
-        ["raw", "int", "feature", "model_input"]
-    ),
-    (
-        # fan-out-fan-in dependency
-        """
+            {
+                "node_1": {"id": "node_1", "layer": "raw"},
+                "node_2": {"id": "node_2"},
+                "node_3": {"id": "node_3", "layer": "int"},
+                "node_4": {"id": "node_4", "layer": "int"},
+                "node_5": {"id": "node_5", "layer": "model_input"},
+                "node_6": {"id": "node_6"},
+                "node_7": {"id": "node_7", "layer": "feature"},
+            },
+            {
+                "node_1": {"node_2"},
+                "node_2": {"node_3"},
+                "node_3": {"node_6"},
+                "node_4": {"node_5"},
+                "node_5": set(),
+                "node_6": {"node_7"},
+                "node_7": set(),
+            },
+            ["raw", "int", "feature", "model_input"],
+        ),
+        (
+            # fan-out-fan-in dependency
+            """
         node_1(layer=raw) -> node_2 -> node_3(layer=int) -> node_6 -> node_7(layer=feature)
                 |----------> node_4(layer=int) -> node_5(layer=model_input) --^
         """,
-        {"node_1": {"id": "node_1", "layer": "raw"}, "node_2": {"id": "node_2"},
-         "node_3": {"id": "node_3", "layer": "int"}, "node_4": {"id": "node_4", "layer": "int"},
-         "node_5": {"id": "node_5", "layer": "model_input"},
-         "node_6": {"id": "node_6"},
-         "node_7": {"id": "node_7", "layer": "feature"}},
-        {"node_1": {"node_2"}, "node_2": {"node_3"}, "node_3": {"node_6"},
-         "node_4": {"node_5"}, "node_5": {"node_7"}, "node_6": {"node_7"}, "node_7": set()},
-        ["raw", "int", "model_input", "feature"]
-    ),
-    (
-        # disjoint dependency: when two groups of layers have no direct dependencies,
-        # their order is determined by topological order first and alphabetical order second,
-        # which is the default of the toposort library. In the example below, toposort the layers
-        # will give [{c, d}, {b, a}], so it will be come [c, d, a, b] when flattened.
-        """
+            {
+                "node_1": {"id": "node_1", "layer": "raw"},
+                "node_2": {"id": "node_2"},
+                "node_3": {"id": "node_3", "layer": "int"},
+                "node_4": {"id": "node_4", "layer": "int"},
+                "node_5": {"id": "node_5", "layer": "model_input"},
+                "node_6": {"id": "node_6"},
+                "node_7": {"id": "node_7", "layer": "feature"},
+            },
+            {
+                "node_1": {"node_2"},
+                "node_2": {"node_3"},
+                "node_3": {"node_6"},
+                "node_4": {"node_5"},
+                "node_5": {"node_7"},
+                "node_6": {"node_7"},
+                "node_7": set(),
+            },
+            ["raw", "int", "model_input", "feature"],
+        ),
+        (
+            # disjoint dependency: when two groups of layers have no direct
+            # dependencies,their order is determined by topological order first and
+            # alphabetical order second, which is the default of the toposort library.
+            # In the example below, toposort the layers will give [{c, d}, {b, a}],
+            # so it will become [c, d, a, b] when flattened.
+            """
         node_1(layer=c) -> node_2(layer=a)
         node_3(layer=d) -> node_4(layer=b)
         """,
-        {"node_1": {"id": "node_1", "layer": "c"}, "node_2": {"id": "node_2", "layer": "a"},
-         "node_3": {"id": "node_3", "layer": "d"}, "node_4": {"id": "node_4", "layer": "b"}},
-        {"node_1": {"node_2"}, "node_2": {}, "node_3": {"node_4"}, "node_4": {}},
-        ["c", "d", "a", "b"]
-    )
-])
+            {
+                "node_1": {"id": "node_1", "layer": "c"},
+                "node_2": {"id": "node_2", "layer": "a"},
+                "node_3": {"id": "node_3", "layer": "d"},
+                "node_4": {"id": "node_4", "layer": "b"},
+            },
+            {"node_1": {"node_2"}, "node_2": {}, "node_3": {"node_4"}, "node_4": {}},
+            ["c", "d", "a", "b"],
+        ),
+    ],
+)
 def test_sort_layers(graph_schema, nodes, node_dependencies, expected):
     assert _sort_layers(nodes, node_dependencies) == expected, graph_schema
 
@@ -711,6 +768,6 @@ def test_sort_layers_should_raise_on_cyclic_layers():
     node_dependencies = {"node_1": {"node_2"}, "node_2": {"node_3"}, "node_3": set()}
     with pytest.raises(
         CircularDependencyError,
-        match="Circular dependencies exist among these items: {'int':{'raw'}, 'raw':{'int'}}"
+        match="Circular dependencies exist among these items: {'int':{'raw'}, 'raw':{'int'}}",
     ):
         _sort_layers(nodes, node_dependencies)


### PR DESCRIPTION
## Description

Make sure `viz` has consistent code formatting standards as the other `kedro` products.

## Development notes

Added `black` step to `make pylint`, `black`ing `package/kedro_viz`, `package/features` and `package/tests`, then ran `make pylint` and let the autoformatting happen. Only edited the code in 3 places, which I've highlighted below

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
