### PR TITLE
[KED-1833] Hook implementation for kedro-viz

### DIFF
--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -500,7 +500,7 @@ def _call_viz(
 
     enhanced_data = None
     if KEDRO_VERSION.match(">=0.16.0"):
-        enhanced_data = _get_context(project_path, env)._hook_manager\
+        enhanced_data = context._hook_manager\
             .hook.after_api_data_ready(api_data=data)  # pylint: disable=protected-access
 
     if save_file:

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -501,7 +501,7 @@ def _call_viz(
     enhanced_data = None
     if KEDRO_VERSION.match(">=0.16.0"):
         enhanced_data = _get_context(project_path, env)._hook_manager\
-            .hook.after_pipeline_formatted(formatted_pipeline=data)  # pylint: disable=protected-access
+            .hook.after_api_data_ready(api_data=data)  # pylint: disable=protected-access
 
     if save_file:
         if enhanced_data:

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -487,8 +487,9 @@ def _call_viz(
         data = _load_from_file(load_file)
     else:
         if KEDRO_VERSION.match(">=0.15.0"):
-            pipeline = _get_pipeline_from_context(_get_context(project_path, env), pipeline_name)
-            catalog = _get_context(project_path, env).catalog
+            context = _get_context(project_path, env)
+            pipeline = _get_pipeline_from_context(context, pipeline_name)
+            catalog = context.catalog
         else:
             # Kedro 0.14.*
             if pipeline_name:
@@ -497,8 +498,10 @@ def _call_viz(
 
         data = format_pipeline_data(pipeline, catalog)
 
-    enhanced_data = _get_context(project_path, env)._hook_manager\
-        .hook.after_pipeline_formatted(formatted_pipeline=data)  # pylint: disable=protected-access
+    enhanced_data = None
+    if KEDRO_VERSION.match(">=0.16.0"):
+        enhanced_data = _get_context(project_path, env)._hook_manager\
+            .hook.after_pipeline_formatted(formatted_pipeline=data)  # pylint: disable=protected-access
 
     if save_file:
         if enhanced_data:

--- a/package/kedro_viz/specs.py
+++ b/package/kedro_viz/specs.py
@@ -1,0 +1,54 @@
+# Copyright 2020 QuantumBlack Visual Analytics Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+# NONINFRINGEMENT. IN NO EVENT WILL THE LICENSOR OR OTHER CONTRIBUTORS
+# BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# The QuantumBlack Visual Analytics Limited ("QuantumBlack") name and logo
+# (either separately or in combination, "QuantumBlack Trademarks") are
+# trademarks of QuantumBlack. The License does not grant you any right or
+# license to the QuantumBlack Trademarks. You may not use the QuantumBlack
+# Trademarks or any confusingly similar mark as a trademark for your product,
+#     or use the QuantumBlack Trademarks in any other manner that might cause
+# confusion in the marketplace, including but not limited to in advertising,
+# on websites, or on software.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A module containing specifications for all callable hooks in the Kedro's execution timeline.
+For more information about these specifications, please visit
+[Pluggy's documentation](https://pluggy.readthedocs.io/en/stable/#specs)
+"""
+# pylint: disable=too-few-public-methods
+from typing import Any, Dict
+
+from kedro.framework.hooks.markers import hook_spec
+
+
+class VizSpecs:
+    """Namespace that defines all specifications for Kedro viz related hooks."""
+
+    @hook_spec
+    def after_pipeline_formatted(self, formatted_pipeline: Dict[str, Any]) -> Dict[str, Any]:
+        """Hook to be invoked after the Pipeline object has been formatted into a dictionary
+        that will be shown by Kedro Viz.
+
+        Args:
+            formatted_pipeline: the pipeline dictionary produces by format_pipeline_data.
+
+        Returns:
+            A dictionary containing the original pipeline data as well as any additional information
+            added by plugins using this hook.
+        """
+        pass

--- a/package/kedro_viz/specs.py
+++ b/package/kedro_viz/specs.py
@@ -40,12 +40,12 @@ class VizSpecs:
     """Namespace that defines all specifications for Kedro viz related hooks."""
 
     @hook_spec
-    def after_pipeline_formatted(self, formatted_pipeline: Dict[str, Any]) -> Dict[str, Any]:
+    def after_api_data_ready(self, api_data: Dict[str, Any]) -> Dict[str, Any]:
         """Hook to be invoked after the Pipeline object has been formatted into a dictionary
         that will be shown by Kedro Viz.
 
         Args:
-            formatted_pipeline: the pipeline dictionary produces by format_pipeline_data.
+            api_data: the pipeline dictionary produced by format_pipeline_data.
 
         Returns:
             A dictionary containing the original pipeline data as well as any additional information

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -163,7 +163,8 @@ def patched_get_project_context(mocker):
         mocked_context._get_pipeline = get_pipeline  # pylint: disable=protected-access
         mocked_context.catalog = mocker.MagicMock()
         mocked_context.pipeline = create_pipeline()
-        mocked_context._hook_manager.hook.after_pipeline_formatted = (lambda formatted_pipeline: None)
+        mocked_context._hook_manager.hook.after_pipeline_formatted = \
+            (lambda formatted_pipeline: None)
         return {
             "create_pipeline": create_pipeline,
             "create_catalog": lambda x: None,

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -236,6 +236,7 @@ def test_no_browser_if_not_localhost(cli_runner):
     assert result.exit_code == 0, result.output
     assert not server.webbrowser.open_new.call_count
 
+
 @pytest.mark.usefixtures("patched_get_project_context")
 def test_load_file_outside_kedro_project(cli_runner, tmp_path):
     """Check that running viz with `--load-file` flag works outside of a Kedro project.

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -163,6 +163,7 @@ def patched_get_project_context(mocker):
         mocked_context._get_pipeline = get_pipeline  # pylint: disable=protected-access
         mocked_context.catalog = mocker.MagicMock()
         mocked_context.pipeline = create_pipeline()
+        mocked_context._hook_manager.hook.after_pipeline_formatted = (lambda formatted_pipeline: None)
         return {
             "create_pipeline": create_pipeline,
             "create_catalog": lambda x: None,
@@ -234,7 +235,7 @@ def test_no_browser_if_not_localhost(cli_runner):
     assert result.exit_code == 0, result.output
     assert not server.webbrowser.open_new.call_count
 
-
+@pytest.mark.usefixtures("patched_get_project_context")
 def test_load_file_outside_kedro_project(cli_runner, tmp_path):
     """Check that running viz with `--load-file` flag works outside of a Kedro project.
     """

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -163,8 +163,8 @@ def patched_get_project_context(mocker):
         mocked_context._get_pipeline = get_pipeline  # pylint: disable=protected-access
         mocked_context.catalog = mocker.MagicMock()
         mocked_context.pipeline = create_pipeline()
-        mocked_context._hook_manager.hook.after_pipeline_formatted = \
-            (lambda formatted_pipeline: None)
+        mocked_context._hook_manager.hook.after_api_data_ready = \
+            (lambda api_data: None)
         return {
             "create_pipeline": create_pipeline,
             "create_catalog": lambda x: None,
@@ -284,8 +284,8 @@ def test_save_enhanced_file(cli_runner, tmp_path, mocker):
         mocked_context._get_pipeline = get_pipeline  # pylint: disable=protected-access
         mocked_context.catalog = mocker.MagicMock()
         mocked_context.pipeline = create_pipeline()
-        mocked_context._hook_manager.hook.after_pipeline_formatted = \
-            (lambda formatted_pipeline: enhanced_data)
+        mocked_context._hook_manager.hook.after_api_data_ready = \
+            (lambda api_data: enhanced_data)
         return {
             "create_pipeline": create_pipeline,
             "create_catalog": lambda x: None,

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -212,10 +212,12 @@ def test_no_browser(cli_runner):
 
 def test_viz_does_not_need_to_specify_project_path(cli_runner, patched_get_project_context):
     cli_runner.invoke(server.commands, ["viz", "--no-browser"])
-    patched_get_project_context.assert_called_once_with(
+    patched_get_project_context.assert_called_with(
         "context",
         env=None
     )
+
+    assert patched_get_project_context.call_count == 2
 
 
 @pytest.mark.usefixtures("patched_get_project_context")
@@ -450,19 +452,21 @@ class TestCallViz:
 
     def test_call_viz_without_project_path(self, patched_get_project_context):
         server._call_viz()
-        patched_get_project_context.assert_called_once_with(
+        patched_get_project_context.assert_called_with(
             "context",
             env=None
         )
+        assert patched_get_project_context.call_count == 2
 
     def test_call_viz_with_project_path(self, patched_get_project_context):
         mocked_project_path = Path("/tmp")
         server._call_viz(project_path=mocked_project_path)
-        patched_get_project_context.assert_called_once_with(
+        patched_get_project_context.assert_called_with(
             "context",
             project_path=mocked_project_path,
             env=None
         )
+        assert patched_get_project_context.call_count == 2
 
 
 class TestRunViz:

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -268,14 +268,14 @@ def test_save_enhanced_file(cli_runner, tmp_path, mocker):
     """Check that running with `--save-file` flag saves pipeline JSON file in a specified path.
     """
     enhanced_data = {
-            "name": "Enhanced",
-            "tags": ["bob"],
-            "id": "37316e3a",
-            "layer": None,
-            "full_name": "fred_out",
-            "type": "data",
-            "validation": "my_path.html"
-        }
+        "name": "Enhanced",
+        "tags": ["bob"],
+        "id": "37316e3a",
+        "layer": None,
+        "full_name": "fred_out",
+        "type": "data",
+        "validation": "my_path.html"
+    }
 
     def get_project_context(
             key: str = "context", **kwargs  # pylint: disable=bad-continuation


### PR DESCRIPTION
## Description
POC: Adding in an implementation for hooks, exactly like in Kedro, to allow plugins using the hook to add additional data to kedro-viz. Frontend changes to pick up this extra data and show it will follow.

This idea came from wanting to integrate kedro-ge with kedro-viz. Kedro-ge generates validation and profiling reports. It would be amazing to have those linked inside kedro-viz, so users don't have to spin up yet another UI for these results. See this PR on the kedro-ge side that shows how the hook is used: https://github.com/quantumblack/kedro-great-expectations/pull/76 

The hook spec is registered within the Kedro-GE mixin, so inside the kedro project the hook itself can just be added as any Kedro hook. 

`
hooks = (
        KedroGEVizHooks(),
    )
`
## Development notes
* Added `specs.py` to hold the kedro-viz hook specs.
* Refactored `_call_viz` inside `server.py` and added call to hook right after the Pipeline has been formatted.

## QA notes
I ran a toy kedro project to make sure the additional data shows up in `nodes.json` when running kedro viz. 

## Checklist

- [X] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
