### PR TITLE
[KED-1807] Update SSH key fingerprint in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ utils:
 
   add_ssh_keys: &add_ssh_keys
     fingerprints:
-      - c0:c0:57:5c:f9:c0:ce:fb:56:d4:1c:52:50:47:df:c7
+      - 9a:fe:61:f4:d6:c2:c1:58:75:c9:72:56:6e:53:fd:8b
 
   deploy_gh_pages: &deploy_gh_pages
     name: Deploy to GitHub Pages


### PR DESCRIPTION
## Description

This is to fix the viz demo deployment step in the CircleCI build on master, which is currently broken because the fingerprint points to a public key on Github which no longer exists - I guess someone deleted it?
![image](https://user-images.githubusercontent.com/1155816/85392945-23212600-b544-11ea-9511-2e64b7edcdb7.png)
![image](https://user-images.githubusercontent.com/1155816/85392988-3207d880-b544-11ea-9b4d-0e7bb328db4a.png)


## Development notes

I've removed the old private key from CircleCI.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
