### PR TITLE
Protect URL constructor/searchParams where browser support is limited.

### DIFF
--- a/src/utils/flags.js
+++ b/src/utils/flags.js
@@ -35,7 +35,13 @@ export const Flags = {
  * @returns {object} An object with flags and their values
  */
 export const getFlagsFromUrl = url => {
-  const urlParams = new URL(url || document.location).searchParams;
+  let urlParams;
+  try {
+    urlParams = new URL(url || document.location.href).searchParams;
+  } catch (e) {
+    console.warn('Feature flags are not supported in this browser');
+    return;
+  }
   const flags = {};
 
   [...urlParams].forEach(([name, value]) =>

--- a/src/utils/flags.js
+++ b/src/utils/flags.js
@@ -35,14 +35,15 @@ export const Flags = {
  * @returns {object} An object with flags and their values
  */
 export const getFlagsFromUrl = url => {
+  const flags = {};
+
   let urlParams;
   try {
     urlParams = new URL(url || document.location.href).searchParams;
   } catch (e) {
     console.warn('Feature flags are not supported in this browser');
-    return;
+    return flags;
   }
-  const flags = {};
 
   [...urlParams].forEach(([name, value]) =>
     Flags.isDefined(name)

--- a/src/utils/random-utils.js
+++ b/src/utils/random-utils.js
@@ -27,8 +27,15 @@ export const getSeedFromURL = () => {
   if (typeof window === 'undefined') {
     return;
   }
-  const url = new URL(window.location);
-  let seed = url.searchParams.get('seed');
+  let url;
+  let seed;
+  try {
+    url = new URL(window.location.href);
+    seed = url.searchParams.get('seed');
+  } catch (e) {
+    console.warn('Random data seeding is not supported in this browser');
+    return;
+  }
   if (!seed) {
     seed = generateHash(30);
     url.searchParams.set('seed', seed);


### PR DESCRIPTION
## Description

The [URL constructor](https://caniuse.com/#feat=url) and [URL.searchParams](https://caniuse.com/#search=URLSearchParams) have good but imperfect browser support. The functionality that uses them (random seeding) is not essential for most users, so it's better to just disable it in browsers that don't support it, rather than add a polyfill.

## Development notes

I initially added a check for `typeof URL !== 'function'` (as in IE11 `typeof URL === 'object'`). But seeing as I'd also need to check `typeof new URL(window.location.href).searchParams`, I decided to just wrap both in a try/catch statement for simplicity's sake.

## QA notes

This should only affect certain slightly older browsers

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
