### PR TITLE
[KED-1859] Increase width of layer rects

### DIFF
--- a/src/selectors/layers.js
+++ b/src/selectors/layers.js
@@ -9,7 +9,7 @@ const getLayerName = state => state.layer.name;
  */
 export const getLayers = createSelector(
   [getLayoutNodes, getVisibleLayerIDs, getLayerName, getGraphSize],
-  (nodes, layerIDs, layerName, { width }) => {
+  (nodes, layerIDs, layerName, { width, height }) => {
     if (!nodes.length) {
       return [];
     }
@@ -44,13 +44,14 @@ export const getLayers = createSelector(
       ];
       const start = (prevBound[1] + currentBound[0]) / 2;
       const end = (currentBound[1] + nextBound[0]) / 2;
+      const rectWidth = Math.max(width, height) * 5;
 
       return {
         id,
         name: layerName[id],
-        x: -width / 2,
+        x: (rectWidth - width) / -2,
         y: start,
-        width: width * 2,
+        width: rectWidth,
         height: Math.max(end - start, 0)
       };
     });


### PR DESCRIPTION
## Description

This is to avoid the ends of the layer rects being visible on tall thin graphs, e.g.
http://localhost:4141/?data=random&seed=jZkSoKJvyzJVQjELcepsJfWRVEWcr5&newgraph
![image](https://user-images.githubusercontent.com/1155816/86613487-96498400-bfa9-11ea-9dda-89562cf7f3bb.png)

## Development notes

The ultimate fix would be to remove the layer rects from the scale/pan container and just change their y/height on zoom, while keeping their x/width consistent. This is what currently happens for the labels. However, this would require the DOM attributes to be updated on zoom tick, which might be worse for performance. So for now I reckon it's safer/better to just ensure that the widths are much wider than necessary.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
