### PR TITLE
[KED-1874] Move data loader into standalone-app entry point

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,8 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 <!-- Add release notes for the upcoming release here -->
+- Move data source loading into standalone-app entry point (#215)
+- Allow an argument to be passed to loadJsonData (#215)
 
 # Release 3.4.0
 

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -86,7 +86,7 @@ class App extends React.Component {
 
 App.propTypes = {
   data: PropTypes.oneOfType([
-    PropTypes.oneOf(['random', 'animals', 'demo', 'json']),
+    PropTypes.oneOf(['json']),
     PropTypes.shape({
       schema_id: PropTypes.string,
       edges: PropTypes.array.isRequired,
@@ -109,13 +109,10 @@ App.propTypes = {
 App.defaultProps = {
   /**
    * Determines what pipeline data will be displayed on the chart.
-   * You can supply one of the following strings:
-     - 'random': Use randomly-generated data
-     - 'animals': Use data from the 'animals' test dataset
-     - 'demo': Use data from the 'demo' test dataset
-     - 'json': Load data from a local json file (in /public/api/nodes.json)
-   * Alternatively, you can supply an object containing lists of edges, nodes, tags.
+   * You can supply an object containing lists of edges, nodes, tags -
    * See /src/utils/data for examples of the expected data format.
+   * Alternatively, uou can supply the string 'json', which loads data
+   * from a local json file (in /public/api/nodes.json)
    */
   data: null,
   /**

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -6,7 +6,6 @@ import { resetData, updateFontLoaded } from '../../actions';
 import checkFontLoaded from '../../actions/check-font-loaded';
 import Wrapper from '../wrapper';
 import getInitialState from '../../store/initial-state';
-import loadData from '../../store/load-data';
 import normalizeData from '../../store/normalize-data';
 import { getFlagsMessage } from '../../utils/flags';
 import '@quantumblack/kedro-ui/lib/styles/app.css';
@@ -24,12 +23,11 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    this.asyncLoadJsonData();
     this.checkWebFontLoading();
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.data.schema_id !== this.props.data.schema_id) {
+    if (prevProps.data !== this.props.data) {
       this.updatePipelineData();
     }
   }
@@ -42,19 +40,6 @@ class App extends React.Component {
 
     if (message && typeof jest === 'undefined') {
       console.info(message);
-    }
-  }
-
-  /**
-   * Load data asynchronously from a JSON file then update the store
-   */
-  asyncLoadJsonData() {
-    if (this.props.data === 'json') {
-      loadData()
-        .then(normalizeData)
-        .then(data => {
-          this.store.dispatch(resetData(data));
-        });
     }
   }
 
@@ -111,8 +96,8 @@ App.defaultProps = {
    * Determines what pipeline data will be displayed on the chart.
    * You can supply an object containing lists of edges, nodes, tags -
    * See /src/utils/data for examples of the expected data format.
-   * Alternatively, uou can supply the string 'json', which loads data
-   * from a local json file (in /public/api/nodes.json)
+   * Alternatively, the string 'json' indicates that data is being
+   * loaded asynchronously from /public/api/nodes.json
    */
   data: null,
   /**

--- a/src/components/export-modal/export-graph.js
+++ b/src/components/export-modal/export-graph.js
@@ -1,5 +1,4 @@
-const { default: downloadSvg, downloadPng } =
-  typeof window !== 'undefined' && require('svg-crowbar');
+import downloadSvg, { downloadPng } from 'svg-crowbar';
 
 /**
  * Handle onClick for the SVG/PNG download button

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 export const dataPath = './api/nodes.json';
+export const fullDataPath = `/public${dataPath.substr(1)}`;
 
 export const localStorageName = 'KedroViz';
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,26 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import 'what-input';
 import App from './components/app';
 import EasterEgg from './components/easter-egg';
-import getDataSource from './utils/data-source';
+import getPipelineData from './utils/data-source';
+import loadData from './store/load-data';
 import './styles/index.css';
 
-ReactDOM.render(
-  <>
-    <App data={getDataSource()} />
-    <EasterEgg />
-  </>,
-  document.getElementById('root')
-);
+const KedroViz = () => {
+  const [data, updateData] = useState(getPipelineData());
+  useEffect(() => {
+    if (data === 'json') {
+      loadData().then(updateData);
+    }
+  }, [data]);
+
+  return (
+    <>
+      <App data={data} />
+      <EasterEgg />
+    </>
+  );
+};
+
+ReactDOM.render(<KedroViz />, document.getElementById('root'));

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -1,38 +1,6 @@
 import { loadState } from './helpers';
 import normalizeData from './normalize-data';
-import animals from '../utils/data/animals.mock';
-import demo from '../utils/data/demo.mock';
 import { getFlagsFromUrl, Flags } from '../utils/flags';
-
-/**
- * Determine where data should be loaded from (i.e. async from JSON,
- * or randomly-generated, or directly via props), then retrieve & format it.
- * @param {string|Array} data Either raw data itself, or a string
- * @return {Object} Normalized data
- */
-export const getPipelineData = data => {
-  switch (data) {
-    case 'animals':
-      // Use data from the 'animals' test dataset
-      return animals;
-    case 'demo':
-      // Use data from the 'demo' test dataset
-      return demo;
-    case 'json':
-      // Return empty state, as data will be loaded asynchronously later
-      return null;
-    case 'random':
-      throw new Error(
-        "The random data should already have replaced the 'random' string in 'data-source.js', so if you see this error then something has gone horribly wrong."
-      );
-    case null:
-    case undefined:
-      throw new Error('No data was provided to App component via props');
-    default:
-      // Use data provided via component prop
-      return data;
-  }
-};
 
 /**
  * Generate a new default pipeline state instance
@@ -84,7 +52,10 @@ export const getInitialPipelineState = () => ({
  * @return {Object} Initial state
  */
 const getInitialState = (props = {}) => {
-  const pipelineData = normalizeData(getPipelineData(props.data));
+  if (!props.data) {
+    throw new Error('No data provided');
+  }
+  const pipelineData = normalizeData(props.data);
 
   // Load properties from localStorage if defined, else use defaults
   const localStorageState = loadState();

--- a/src/store/initial-state.test.js
+++ b/src/store/initial-state.test.js
@@ -1,36 +1,13 @@
-import getInitialState, { getPipelineData } from './initial-state';
+import getInitialState from './initial-state';
 import { saveState } from './helpers';
-import getRandomPipeline from '../utils/random-data';
 import animals from '../utils/data/animals.mock';
-import demo from '../utils/data/demo.mock';
-
-describe('getPipelineData', () => {
-  it('returns the correct dataset when passed a dataset string', () => {
-    expect(getPipelineData('animals')).toEqual(animals);
-    expect(getPipelineData('demo')).toEqual(demo);
-  });
-
-  it("returns null when passed 'json'", () => {
-    expect(getPipelineData('json')).toEqual(null);
-  });
-
-  it('returns original data', () => {
-    const randomPipeline = getRandomPipeline();
-    expect(getPipelineData(randomPipeline)).toEqual(randomPipeline);
-  });
-
-  it('throws an error when passed random', () => {
-    expect(() => getPipelineData('random')).toThrow();
-  });
-
-  it('throws an error when passed null or undefined', () => {
-    expect(() => getPipelineData(null)).toThrow();
-    expect(() => getPipelineData(undefined)).toThrow();
-  });
-});
 
 describe('getInitialState', () => {
-  const props = { data: 'animals' };
+  const props = { data: animals };
+
+  it('throws an error when data prop is empty', () => {
+    expect(() => getInitialState({})).toThrow();
+  });
 
   it('returns an object', () => {
     expect(getInitialState(props)).toEqual(expect.any(Object));

--- a/src/store/load-data.js
+++ b/src/store/load-data.js
@@ -1,17 +1,18 @@
 import { json } from 'd3-fetch';
-import { dataPath } from '../config';
+import { dataPath, fullDataPath } from '../config';
 
 /**
- * Asynchronously load, parse and format data from json file using D3
+ * Asynchronously load and parse data from json file using d3-fetch
+ * @param {string} path JSON data file location. Defaults to dataPath from config.js
+ * @return {function} A promise that will return when the file is loaded and parsed
  */
-const loadJsonData = () => {
-  const fullPath = `/public${dataPath.substr(1)}`;
-
-  return json(dataPath).catch(() => {
+const loadJsonData = path =>
+  json(path || dataPath).catch(() => {
     throw new Error(
-      `Unable to load pipeline data from ${dataPath}. If you're running Kedro-Viz as a standalone (e.g. for JavaScript development), please check that you have placed a data file at ${fullPath}.`
+      `Unable to load pipeline data from ${path ||
+        dataPath}. If you're running Kedro-Viz as a standalone (e.g. for JavaScript development), please check that you have placed a data file at ${path ||
+        fullDataPath}.`
     );
   });
-};
 
 export default loadJsonData;

--- a/src/utils/data-source.js
+++ b/src/utils/data-source.js
@@ -2,9 +2,6 @@ import getRandomPipeline from './random-data';
 import animals from './data/animals.mock';
 import demo from './data/demo.mock';
 
-// Avoid errors when running in a non-browser environment
-const hasWindow = typeof window !== 'undefined';
-
 /**
  * Determine the data source ID from the URL query string, or an environment
  * variable from the CLI, or from the URL host, else return undefined.
@@ -16,10 +13,9 @@ const hasWindow = typeof window !== 'undefined';
  * @return {string} Data source identifier
  */
 export const getSourceID = () => {
-  const qs = hasWindow && window.location.search.match(/data=(\w+)/);
+  const qs = document.location.search.match(/data=(\w+)/);
   const { REACT_APP_DATA_SOURCE } = process.env;
-  const isDemo =
-    hasWindow && window.location.host === 'quantumblacklabs.github.io';
+  const isDemo = document.location.host === 'quantumblacklabs.github.io';
 
   if (qs) {
     return encodeURIComponent(qs[1]);

--- a/src/utils/data-source.js
+++ b/src/utils/data-source.js
@@ -1,52 +1,69 @@
 import getRandomPipeline from './random-data';
+import animals from './data/animals.mock';
+import demo from './data/demo.mock';
 
 // Avoid errors when running in a non-browser environment
 const hasWindow = typeof window !== 'undefined';
 
 /**
- * Validate against expected results
- * @param {string} source Input type key
- * @return {string} Data source type key
+ * Determine the data source ID from the URL query string, or an environment
+ * variable from the CLI, or from the URL host, else return undefined.
+ * You can supply one of the following strings:
+   - 'random': Use randomly-generated data
+   - 'animals': Use data from the 'animals' test dataset
+   - 'demo': Use data from the 'demo' test dataset
+   - 'json': Load data from a local json file (in /public/api/nodes.json)
+ * @return {string} Data source identifier
  */
-const validateDataSource = source => {
-  const expectedInput = ['animals', 'demo', 'json', 'random'];
-  if (expectedInput.includes(source)) {
-    // If random, supply random data instead. We're doing this here to avoid
-    // including this file unnecessarily in the exported npm package
-    if (source === 'random') {
-      return getRandomPipeline();
-    }
-    return source;
-  }
-  if (source) {
-    throw new Error(
-      `Unexpected data source value '${source}'. Your input should be one of the following values: ${expectedInput.join(
-        ', '
-      )}.`
-    );
-  }
-  return 'json';
-};
-
-/**
- * Determine which data source to use
- * @return {string} Data source type key
- */
-const getDataSource = () => {
-  let source;
+export const getSourceID = () => {
   const qs = hasWindow && window.location.search.match(/data=(\w+)/);
   const { REACT_APP_DATA_SOURCE } = process.env;
   const isDemo =
     hasWindow && window.location.host === 'quantumblacklabs.github.io';
 
   if (qs) {
-    source = encodeURIComponent(qs[1]);
-  } else if (REACT_APP_DATA_SOURCE) {
-    source = REACT_APP_DATA_SOURCE;
-  } else if (isDemo) {
-    source = 'demo';
+    return encodeURIComponent(qs[1]);
   }
-  return validateDataSource(source);
+  if (REACT_APP_DATA_SOURCE) {
+    return REACT_APP_DATA_SOURCE;
+  }
+  if (isDemo) {
+    return 'demo';
+  }
+  return 'json';
 };
 
-export default getDataSource;
+/**
+ * Either load synchronous pipeline data, or else indicate with a string
+ * that json data should be loaded asynchronously later on.
+ * @param {string} source Data source identifier
+ * @return {object|string} Either raw data itself, or 'json'
+ */
+export const getDataValue = source => {
+  switch (source) {
+    case 'animals':
+      // Use data from the 'animals' test dataset
+      return animals;
+    case 'demo':
+      // Use data from the 'demo' test dataset
+      return demo;
+    case 'random':
+      // Use procedurally-generated data
+      return getRandomPipeline();
+    case 'json':
+      // Load data asynchronously later
+      return source;
+    default:
+      throw new Error(
+        `Unexpected data source value '${source}'. Your input should be one of the following values: 'animals', 'demo', 'json', or 'random'`
+      );
+  }
+};
+
+/**
+ * Determine which data source to use, and return it
+ * @return {object|string} Pipeline data, or 'json'
+ */
+const getPipelineData = () => getDataValue(getSourceID());
+
+export default getPipelineData;

--- a/src/utils/data-source.test.js
+++ b/src/utils/data-source.test.js
@@ -37,7 +37,7 @@ describe('getDataValue', () => {
     expect(getDataValue('json')).toEqual('json');
   });
 
-  it("should return random data when passed 'random'", () => {
+  it("should return a dataset object when passed 'random'", () => {
     expect(getDataValue('random')).toEqual(
       expect.objectContaining({
         edges: expect.any(Array),

--- a/src/utils/data-source.test.js
+++ b/src/utils/data-source.test.js
@@ -1,6 +1,61 @@
-import getDataSource from './data-source';
+import getPipelineData, { getSourceID, getDataValue } from './data-source';
+import animals from './data/animals.mock';
+import demo from './data/demo.mock';
 
-describe('getDataSource', () => {
+describe('getSourceID', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    delete process.env.REACT_APP_DATA_SOURCE;
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it("should return 'json' by default if no source is supplied", () => {
+    expect(getSourceID()).toBe('json');
+  });
+
+  it('should return the given datasource if set via environment variable', () => {
+    process.env.REACT_APP_DATA_SOURCE = 'animals';
+    expect(getSourceID()).toEqual('animals');
+    process.env.REACT_APP_DATA_SOURCE = 'demo';
+    expect(getSourceID()).toEqual('demo');
+  });
+});
+
+describe('getDataValue', () => {
+  it('should return the correct dataset when passed a dataset string', () => {
+    expect(getDataValue('animals')).toEqual(animals);
+    expect(getDataValue('demo')).toEqual(demo);
+  });
+
+  it("should return the string 'json' when passed 'json'", () => {
+    expect(getDataValue('json')).toEqual('json');
+  });
+
+  it("should return random data when passed 'random'", () => {
+    expect(getDataValue('random')).toEqual(
+      expect.objectContaining({
+        edges: expect.any(Array),
+        nodes: expect.any(Array),
+        tags: expect.any(Array),
+        layers: expect.any(Array)
+      })
+    );
+  });
+
+  it('should throw an error if the given source is unknown', () => {
+    expect(() => getDataValue('qwertyuiop')).toThrow();
+    expect(() => getDataValue(null)).toThrow();
+    expect(() => getDataValue(undefined)).toThrow();
+  });
+});
+
+describe('getPipelineData', () => {
   const OLD_ENV = process.env;
 
   beforeEach(() => {
@@ -14,23 +69,21 @@ describe('getDataSource', () => {
   });
 
   it('should return "json" as the datasource if undefined', () => {
-    expect(getDataSource()).toBe('json');
+    expect(getPipelineData()).toBe('json');
   });
 
   it('should throw an error if the given source is unknown', () => {
     process.env.REACT_APP_DATA_SOURCE = 'qwertyuiop';
-    expect(() => {
-      getDataSource();
-    }).toThrow();
+    expect(() => getPipelineData()).toThrow();
   });
 
   it('should return the given datasource if set', () => {
     process.env.REACT_APP_DATA_SOURCE = 'animals';
-    expect(getDataSource()).toBe('animals');
+    expect(getPipelineData()).toEqual(animals);
   });
 
   it('should return random data if requested', () => {
     process.env.REACT_APP_DATA_SOURCE = 'random';
-    expect(getDataSource()).toEqual(expect.objectContaining({}));
+    expect(getPipelineData()).toEqual(expect.objectContaining({}));
   });
 });

--- a/src/utils/random-utils.js
+++ b/src/utils/random-utils.js
@@ -24,13 +24,10 @@ export const generateHash = length => {
  * else create a new one, and make it available via the console.
  */
 export const getSeedFromURL = () => {
-  if (typeof window === 'undefined') {
-    return;
-  }
   let url;
   let seed;
   try {
-    url = new URL(window.location.href);
+    url = new URL(document.location.href);
     seed = url.searchParams.get('seed');
   } catch (e) {
     console.warn('Random data seeding is not supported in this browser');

--- a/src/utils/state.mock.js
+++ b/src/utils/state.mock.js
@@ -3,6 +3,8 @@ import { Provider } from 'react-redux';
 import { mount, shallow } from 'enzyme';
 import configureStore from '../store';
 import getInitialState from '../store/initial-state';
+import animals from './data/animals.mock';
+import demo from './data/demo.mock';
 import reducer from '../reducers';
 import { updateFontLoaded } from '../actions';
 
@@ -19,8 +21,8 @@ const prepareState = (...props) => {
  * Example state objects for use in tests of redux-enabled components
  */
 export const mockState = {
-  demo: prepareState({ data: 'demo' }),
-  animals: prepareState({ data: 'animals' })
+  demo: prepareState({ data: demo }),
+  animals: prepareState({ data: animals })
 };
 
 /**
@@ -35,7 +37,7 @@ export const setup = {
   mount: (children, props = {}) => {
     const initialState = Object.assign(
       {},
-      prepareState({ data: 'animals', ...props }, props)
+      prepareState({ data: animals, ...props }, props)
     );
     return mount(
       <Provider store={configureStore(initialState)}>{children}</Provider>


### PR DESCRIPTION
## Description

- **Move data-source logic from initial-state:** The test datasets aren't necessary in the exported component lib, and are only required when running the full app. So I've moved the data source loading functionality out of the App/initial-state logic
- **Replace window.location with document.location:** This allows us to remove the typeof window checks, as document is available in build while window isn't.
- **Remove conditional window checks on svg-crowbar:** These are no longer necessary as of [svg-crowbar v0.4.0](https://github.com/cy6erskunk/svg-crowbar/releases/tag/v0.4.0), updated in #208
- **Load json in src/index.js instead of App component:** This simplifies the App component and moves unnecessary logic out of the exported library component
- **Allow an argument to be passed to loadJsonData:** This will allow external users to load and run it if they wish. e.g.
```JSX
import KedroViz from '@quantumblack/kedro-viz`;
import loadData from '@quantumblack/kedro-viz/lib/store/load-data';

loadData('/path/to/data.json').then(data => {
  ReactDOM.render(<KedroViz data={data} />, document.getElementById('root'));
});
```

## QA notes

I've changed the `componentDidUpdate` check to not pay attention to the schema_id. Hopefully this won't change anything. Not sure why I didn't do this before.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
