### PR TITLE
[KED-1830] Add support for multiple pipelines to app state

### DIFF
--- a/src/actions/actions.test.js
+++ b/src/actions/actions.test.js
@@ -7,6 +7,7 @@ import {
   TOGGLE_SIDEBAR,
   TOGGLE_TEXT_LABELS,
   TOGGLE_THEME,
+  UPDATE_ACTIVE_PIPELINE,
   UPDATE_CHART_SIZE,
   UPDATE_FONT_LOADED,
   changeFlag,
@@ -16,6 +17,7 @@ import {
   toggleSidebar,
   toggleTextLabels,
   toggleTheme,
+  updateActivePipeline,
   updateChartSize,
   updateFontLoaded
 } from '../actions';
@@ -149,6 +151,15 @@ describe('actions', () => {
       disabled
     };
     expect(toggleTypeDisabled(typeID, disabled)).toEqual(expectedAction);
+  });
+
+  it('should create an action to update the active pipeline', () => {
+    const pipeline = 'abc123';
+    const expectedAction = {
+      type: UPDATE_ACTIVE_PIPELINE,
+      pipeline
+    };
+    expect(updateActivePipeline(pipeline)).toEqual(expectedAction);
   });
 
   it('should create an action to update the chart size', () => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -91,6 +91,19 @@ export function toggleTheme(theme) {
   };
 }
 
+export const UPDATE_ACTIVE_PIPELINE = 'UPDATE_ACTIVE_PIPELINE';
+
+/**
+ * Update the actively-selected pipeline
+ * @param {string} pipeline Pipeline ID
+ */
+export function updateActivePipeline(pipeline) {
+  return {
+    type: UPDATE_ACTIVE_PIPELINE,
+    pipeline
+  };
+}
+
 export const UPDATE_CHART_SIZE = 'UPDATE_CHART_SIZE';
 
 /**

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -24,7 +24,7 @@ const createReducer = (initialState, type, key) => (
   state = initialState,
   action
 ) => {
-  if (action.type === type) {
+  if (typeof key !== 'undefined' && action.type === type) {
     return action[key];
   }
   return state;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,6 +3,7 @@ import node from './nodes';
 import tag from './tags';
 import nodeType from './node-type';
 import visible from './visible';
+import pipeline from './pipeline';
 import flags from './flags';
 import {
   RESET_DATA,
@@ -44,11 +45,12 @@ function resetDataReducer(state = {}, action) {
 
 const combinedReducer = combineReducers({
   // These props have their own reducers in other files
+  flags,
   node,
   nodeType,
+  pipeline,
   tag,
   visible,
-  flags,
   // These props don't have any actions associated with them
   edge: createReducer({}),
   id: createReducer(null),

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -14,12 +14,12 @@ import {
 
 /**
  * Create a generic reducer
+ * @param {*} initialState Default state
  * @param {string} type Action type
  * @param {string} key Action payload key
- * @param {*} initialState Default state
  * @return {*} Updated state
  */
-const createReducer = (type, key, initialState) => (
+const createReducer = (initialState, type, key) => (
   state = initialState,
   action
 ) => {
@@ -43,18 +43,21 @@ function resetDataReducer(state = {}, action) {
 }
 
 const combinedReducer = combineReducers({
+  // These props have their own reducers in other files
   node,
   nodeType,
   tag,
   visible,
   flags,
-  edge: (state = {}) => state,
-  id: (state = null) => state,
-  layer: (state = {}) => state,
-  chartSize: createReducer(UPDATE_CHART_SIZE, 'chartSize', {}),
-  fontLoaded: createReducer(UPDATE_FONT_LOADED, 'fontLoaded', false),
-  textLabels: createReducer(TOGGLE_TEXT_LABELS, 'textLabels', true),
-  theme: createReducer(TOGGLE_THEME, 'theme', 'dark')
+  // These props don't have any actions associated with them
+  edge: createReducer({}),
+  id: createReducer(null),
+  layer: createReducer({}),
+  // These props have very simple non-nested actions
+  chartSize: createReducer({}, UPDATE_CHART_SIZE, 'chartSize'),
+  fontLoaded: createReducer(false, UPDATE_FONT_LOADED, 'fontLoaded'),
+  textLabels: createReducer(true, TOGGLE_TEXT_LABELS, 'textLabels'),
+  theme: createReducer('dark', TOGGLE_THEME, 'theme')
 });
 
 const rootReducer = (state, action) =>

--- a/src/reducers/pipeline.js
+++ b/src/reducers/pipeline.js
@@ -1,0 +1,16 @@
+import { UPDATE_ACTIVE_PIPELINE } from '../actions';
+
+function pipelineReducer(pipelineState = {}, action) {
+  switch (action.type) {
+    case UPDATE_ACTIVE_PIPELINE: {
+      return Object.assign({}, pipelineState, {
+        active: action.pipeline
+      });
+    }
+
+    default:
+      return pipelineState;
+  }
+}
+
+export default pipelineReducer;

--- a/src/reducers/reducers.test.js
+++ b/src/reducers/reducers.test.js
@@ -9,6 +9,7 @@ import {
   TOGGLE_SIDEBAR,
   TOGGLE_TEXT_LABELS,
   TOGGLE_THEME,
+  UPDATE_ACTIVE_PIPELINE,
   UPDATE_CHART_SIZE,
   UPDATE_FONT_LOADED
 } from '../actions';
@@ -165,6 +166,17 @@ describe('Reducer', () => {
         visible: false
       });
       expect(newState.visible.sidebar).toEqual(false);
+    });
+  });
+
+  describe('UPDATE_ACTIVE_PIPELINE', () => {
+    it('should update the active pipeline', () => {
+      const pipeline = 'abc123';
+      const newState = reducer(mockState.animals, {
+        type: UPDATE_ACTIVE_PIPELINE,
+        pipeline
+      });
+      expect(newState.pipeline.active).toEqual(pipeline);
     });
   });
 

--- a/src/selectors/disabled.js
+++ b/src/selectors/disabled.js
@@ -13,6 +13,22 @@ const getEdgeSources = state => state.edge.sources;
 const getEdgeTargets = state => state.edge.targets;
 const getLayerIDs = state => state.layer.ids;
 const getNodeLayer = state => state.node.layer;
+const getNodePipelines = state => state.node.pipelines;
+const getActivePipeline = state => state.pipeline.active;
+
+/**
+ * Calculate whether nodes should be disabled based on their tags
+ */
+export const getNodeDisabledPipeline = createSelector(
+  [getNodeIDs, getNodePipelines, getActivePipeline],
+  (nodeIDs, nodePipelines, activePipeline) =>
+    arrayToObject(nodeIDs, nodeID => {
+      if (!activePipeline) {
+        return false;
+      }
+      return !nodePipelines[nodeID][activePipeline];
+    })
+);
 
 /**
  * Calculate whether nodes should be disabled based on their tags
@@ -40,16 +56,25 @@ export const getNodeDisabled = createSelector(
     getNodeIDs,
     getNodeDisabledNode,
     getNodeDisabledTag,
+    getNodeDisabledPipeline,
     getNodeType,
     getNodeTypeDisabled
   ],
-  (nodeIDs, nodeDisabledNode, nodeDisabledTag, nodeType, typeDisabled) =>
+  (
+    nodeIDs,
+    nodeDisabledNode,
+    nodeDisabledTag,
+    nodeDisabledPipeline,
+    nodeType,
+    typeDisabled
+  ) =>
     arrayToObject(nodeIDs, id =>
-      Boolean(
-        nodeDisabledNode[id] ||
-          nodeDisabledTag[id] ||
-          typeDisabled[nodeType[id]]
-      )
+      [
+        nodeDisabledNode[id],
+        nodeDisabledTag[id],
+        nodeDisabledPipeline[id],
+        typeDisabled[nodeType[id]]
+      ].some(Boolean)
     )
 );
 

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -40,6 +40,11 @@ export const getPipelineData = data => {
  */
 export const getInitialPipelineState = () => ({
   id: null,
+  pipeline: {
+    ids: [],
+    name: {},
+    active: null
+  },
   node: {
     ids: [],
     name: {},
@@ -49,6 +54,7 @@ export const getInitialPipelineState = () => ({
     tags: {},
     layer: {},
     disabled: {},
+    pipelines: {},
     clicked: null,
     hovered: null
   },

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -2,6 +2,28 @@ import { getInitialPipelineState } from '../store/initial-state';
 import { arrayToObject } from '../utils';
 
 /**
+ * Check whether data is in expected format
+ * @param {Object} data - The parsed data input
+ * @return {Boolean} True if valid for formatting
+ */
+const validateInput = data => {
+  if (!data) {
+    // Data may still be loading, so return initial state
+    return false;
+  }
+  if (!Array.isArray(data.edges) || !Array.isArray(data.nodes)) {
+    if (typeof jest === 'undefined') {
+      console.error(
+        'Invalid data input: Please ensure that your pipeline data includes arrays of nodes and edges',
+        data
+      );
+    }
+    return false;
+  }
+  return true;
+};
+
+/**
  * Get unique, reproducible ID for each edge, based on its nodes
  * @param {Object} source - Name and type of the source node
  * @param {Object} target - Name and type of the target node
@@ -89,16 +111,7 @@ const addLayer = state => layer => {
 const formatData = data => {
   const state = getInitialPipelineState();
 
-  if (!data) {
-    // Data may still be loading, so return initial state
-    return state;
-  }
-
-  if (!Array.isArray(data.edges) || !Array.isArray(data.nodes)) {
-    console.error(
-      'Invalid data input: Please ensure that your pipeline data includes arrays of nodes and edges',
-      data
-    );
+  if (!validateInput(data)) {
     return state;
   }
 

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -104,11 +104,11 @@ const addLayer = state => layer => {
 };
 
 /**
- * Convert the pipeline data into a normalised state object
+ * Convert the pipeline data into a normalized state object
  * @param {Object} data Raw unformatted data input
  * @return {Object} Formatted, normalized state
  */
-const formatData = data => {
+const normalizeData = data => {
   const state = getInitialPipelineState();
 
   if (!validateInput(data)) {
@@ -136,4 +136,4 @@ const formatData = data => {
   return state;
 };
 
-export default formatData;
+export default normalizeData;

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -1,15 +1,4 @@
 import { getInitialPipelineState } from '../store/initial-state';
-/**
- * Check whether data is in expected format
- * @param {Object} data - The parsed data input
- * @return {Boolean} True if valid for formatting
- */
-const validateInput = data => {
-  const { isArray } = Array;
-  return (
-    data && isArray(data.edges) && isArray(data.nodes) && isArray(data.tags)
-  );
-};
 
 /**
  * Get unique, reproducible ID for each edge, based on its nodes
@@ -82,18 +71,29 @@ const addLayer = state => layer => {
 const formatData = data => {
   const state = getInitialPipelineState();
 
-  if (validateInput(data)) {
-    if (data.schema_id) {
-      state.id = data.schema_id;
-    }
-    data.nodes.forEach(addNode(state));
-    data.edges.forEach(addEdge(state));
-    if (data.tags) {
-      data.tags.forEach(addTag(state));
-    }
-    if (data.layers) {
-      data.layers.forEach(addLayer(state));
-    }
+  if (!data) {
+    // Data may still be loading, so return initial state
+    return state;
+  }
+
+  if (!Array.isArray(data.edges) || !Array.isArray(data.nodes)) {
+    console.error(
+      'Invalid data input: Please ensure that your pipeline data includes arrays of nodes and edges',
+      data
+    );
+    return state;
+  }
+
+  if (data.schema_id) {
+    state.id = data.schema_id;
+  }
+  data.nodes.forEach(addNode(state));
+  data.edges.forEach(addEdge(state));
+  if (data.tags) {
+    data.tags.forEach(addTag(state));
+  }
+  if (data.layers) {
+    data.layers.forEach(addLayer(state));
   }
 
   return state;

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -8,7 +8,7 @@ import { arrayToObject } from '../utils';
  */
 const validateInput = data => {
   if (!data) {
-    // Data may still be loading, so return initial state
+    // Data may still be loading, or has not been supplied
     return false;
   }
   if (!Array.isArray(data.edges) || !Array.isArray(data.nodes)) {

--- a/src/store/normalize-data.test.js
+++ b/src/store/normalize-data.test.js
@@ -1,0 +1,71 @@
+import normalizeData from './normalize-data';
+import { getInitialPipelineState } from '../store/initial-state';
+import animals from '../utils/data/animals.mock';
+
+const initialState = getInitialPipelineState();
+
+describe('normalizeData', () => {
+  it('should return initialState if input is invalid', () => {
+    expect(normalizeData(undefined)).toEqual(initialState);
+    expect(normalizeData(null)).toEqual(initialState);
+    expect(normalizeData('json')).toEqual(initialState);
+    expect(normalizeData({})).toEqual(initialState);
+    expect(normalizeData({ nodes: null, edges: 100 })).toEqual(initialState);
+  });
+
+  it('should not add tags if tags are not supplied', () => {
+    const data = Object.assign({}, animals, { tags: undefined });
+    data.nodes.forEach(node => {
+      delete node.tags;
+    });
+    expect(normalizeData(data).tag.ids).toHaveLength(0);
+  });
+
+  it('should not add pipelines if pipelines are not supplied', () => {
+    const data = Object.assign({}, animals, { pipelines: undefined });
+    data.nodes.forEach(node => {
+      delete node.pipelines;
+    });
+    expect(normalizeData(data).pipeline.ids).toHaveLength(0);
+  });
+
+  it('should not add an active pipeline if pipelines.length is 0', () => {
+    const data = Object.assign({}, animals, { pipelines: [] });
+    data.nodes.forEach(node => {
+      node.pipelines = [];
+    });
+    expect(normalizeData(data).pipeline.active).toBe(null);
+  });
+
+  it('should not add layers if layers are not supplied', () => {
+    const data = Object.assign({}, animals, { layers: undefined });
+    data.nodes.forEach(node => {
+      delete node.layer;
+    });
+    expect(normalizeData(data).layer.ids).toHaveLength(0);
+  });
+
+  it('should not add duplicate nodes', () => {
+    const data = Object.assign({}, animals);
+    data.nodes.push(data.nodes[0]);
+    data.nodes.push(data.nodes[1]);
+    data.nodes.push(data.nodes[2]);
+    expect(normalizeData(data).node.ids.length).toEqual(
+      normalizeData(animals).node.ids.length
+    );
+  });
+
+  it('should fall back to node.name if node.full_name is not supplied', () => {
+    const data = Object.assign({}, animals);
+    data.nodes.forEach(node => {
+      node.name = node.name + '-name';
+      delete node.full_name;
+    });
+    const state = normalizeData(data);
+    expect(
+      state.node.ids.every(
+        nodeID => state.node.fullName[nodeID] === state.node.name[nodeID]
+      )
+    ).toBe(true);
+  });
+});

--- a/src/utils/data/animals.mock.js
+++ b/src/utils/data/animals.mock.js
@@ -1,5 +1,19 @@
 export default {
   schema_id: '09876543210987654321',
+  pipelines: [
+    {
+      id: '__default__',
+      name: 'Default'
+    },
+    {
+      id: 'de',
+      name: 'Data engineering'
+    },
+    {
+      id: 'ds',
+      name: 'Data science'
+    }
+  ],
   layers: [
     'Raw',
     'Intermediate',
@@ -29,6 +43,7 @@ export default {
       full_name: 'salmon',
       tags: ['small'],
       layer: 'Intermediate',
+      pipelines: ['__default__', 'de'],
       type: 'task'
     },
     {
@@ -37,6 +52,7 @@ export default {
       full_name: 'shark',
       tags: ['medium', 'huge'],
       layer: 'Intermediate',
+      pipelines: ['__default__', 'de'],
       type: 'task'
     },
     {
@@ -45,6 +61,7 @@ export default {
       full_name: 'trout',
       tags: ['small'],
       layer: 'Model Input',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -53,6 +70,7 @@ export default {
       full_name: 'whale',
       tags: ['huge'],
       layer: 'Model Output',
+      pipelines: ['__default__', 'ds'],
       type: 'data'
     },
     {
@@ -61,6 +79,7 @@ export default {
       full_name: 'dog',
       tags: ['small', 'medium'],
       layer: 'Raw',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -69,6 +88,7 @@ export default {
       full_name: 'cat',
       tags: ['small', 'medium', 'huge'],
       layer: 'Raw',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -77,6 +97,7 @@ export default {
       full_name: 'parameters_rabbit',
       tags: ['small'],
       layer: 'Intermediate',
+      pipelines: ['__default__', 'de'],
       type: 'parameters'
     },
     {
@@ -85,6 +106,7 @@ export default {
       full_name: 'parameters',
       tags: [],
       layer: 'Intermediate',
+      pipelines: ['__default__', 'de'],
       type: 'parameters'
     },
     {
@@ -93,6 +115,7 @@ export default {
       full_name: 'sheep',
       tags: ['medium'],
       layer: 'Primary',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -101,6 +124,7 @@ export default {
       full_name: 'horse',
       tags: ['huge'],
       layer: 'Model Output',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -109,6 +133,7 @@ export default {
       full_name: 'weasel',
       tags: ['small'],
       layer: 'Raw',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -117,6 +142,7 @@ export default {
       full_name: 'elephant',
       tags: ['huge'],
       layer: 'Raw',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -125,6 +151,7 @@ export default {
       full_name: 'bear',
       tags: ['huge'],
       layer: 'Raw',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -133,6 +160,7 @@ export default {
       full_name: 'giraffe',
       tags: ['huge'],
       layer: 'Model Output',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -141,6 +169,7 @@ export default {
       full_name: 'pig',
       tags: ['medium'],
       layer: 'Feature',
+      pipelines: ['__default__', 'ds'],
       type: 'data'
     }
   ],

--- a/src/utils/data/demo.mock.js
+++ b/src/utils/data/demo.mock.js
@@ -1,5 +1,19 @@
 export default {
   schema_id: '12345678901234567890',
+  pipelines: [
+    {
+      id: '__default__',
+      name: 'Default'
+    },
+    {
+      id: 'de',
+      name: 'Data engineering'
+    },
+    {
+      id: 'ds',
+      name: 'Data science'
+    }
+  ],
   layers: [
     'Raw',
     'Intermediate',
@@ -319,6 +333,7 @@ export default {
       name: 'Load Raw Interaction Data',
       tags: ['data_engineering', 'preprocessing'],
       layer: 'Raw',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -327,6 +342,7 @@ export default {
       name: 'Load Raw Country Data',
       tags: ['data_engineering', 'preprocessing'],
       layer: 'Raw',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -335,6 +351,7 @@ export default {
       name: 'Load Raw Shopper Spend Data',
       tags: ['data_engineering', 'preprocessing'],
       layer: 'Raw',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -343,6 +360,7 @@ export default {
       name: 'Preprocess Intermediate Interaction Data',
       tags: ['data_engineering', 'preprocessing'],
       layer: 'Intermediate',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -351,6 +369,7 @@ export default {
       name: 'Preprocess Intermediate Country Data',
       tags: ['data_engineering', 'preprocessing'],
       layer: 'Intermediate',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -359,6 +378,7 @@ export default {
       name: 'Preprocess Intermediate Shopper Spend Data',
       tags: ['data_engineering', 'preprocessing'],
       layer: 'Intermediate',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -367,6 +387,7 @@ export default {
       name: 'Create Shopper Spend Features',
       tags: ['feature_engineering', 'data_engineering'],
       layer: 'Feature',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -375,6 +396,7 @@ export default {
       name: 'Create Shopper Churn Features',
       tags: ['feature_engineering', 'data_engineering'],
       layer: 'Feature',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -383,6 +405,7 @@ export default {
       name: 'Prepare Vendor Input',
       tags: ['feature_engineering', 'data_engineering'],
       layer: 'Intermediate',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -391,6 +414,7 @@ export default {
       name: 'Prepare CRM Input',
       tags: ['feature_engineering', 'data_engineering'],
       layer: 'Intermediate',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -399,6 +423,7 @@ export default {
       name: 'Predictive Sales Model',
       tags: ['model_training', 'data_science'],
       layer: 'Model Input',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -407,6 +432,7 @@ export default {
       name: 'Predictive Engagement Model',
       tags: ['model_training', 'data_science'],
       layer: 'Model Input',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -415,6 +441,7 @@ export default {
       name: 'Sales Model Explainable AI',
       tags: ['model_explaination', 'data_science'],
       layer: 'Model Input',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -423,6 +450,7 @@ export default {
       name: 'Engagement Model Explainable AI',
       tags: ['model_explaination', 'data_science'],
       layer: 'Models',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -431,6 +459,7 @@ export default {
       name: 'Perform Digital Analysis',
       tags: ['model_training', 'data_science'],
       layer: 'Model Input',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -439,6 +468,7 @@ export default {
       name: 'Engagement Recommendation Engine',
       tags: ['model_training', 'data_science'],
       layer: 'Models',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -447,6 +477,7 @@ export default {
       name: 'Sales Model Performance Monitoring',
       tags: ['model_performance_monitoring', 'data_science'],
       layer: 'Reporting',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -455,6 +486,7 @@ export default {
       name: 'Engagement Model Performance Monitoring',
       tags: ['model_performance_monitoring', 'data_science'],
       layer: 'Reporting',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -463,6 +495,7 @@ export default {
       name: 'Multi-Channel Optimisation',
       tags: ['optimisation', 'data_science'],
       layer: 'Models',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -471,6 +504,7 @@ export default {
       name: 'Content Optimisation',
       tags: ['optimisation', 'data_science'],
       layer: 'Models',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -479,6 +513,7 @@ export default {
       name: 'Segment Journeys',
       tags: ['optimisation', 'data_science'],
       layer: 'Model Output',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -487,6 +522,7 @@ export default {
       name: 'Generate Dashboard Inputs',
       tags: ['reporting', 'data_science'],
       layer: 'Reporting',
+      pipelines: ['__default__', 'ds'],
       type: 'task'
     },
     {
@@ -495,6 +531,7 @@ export default {
       name: 'Interaction Raw',
       tags: ['data_engineering', 'preprocessing'],
       layer: 'Raw',
+      pipelines: ['__default__', 'ds'],
       type: 'data'
     },
     {
@@ -503,6 +540,7 @@ export default {
       name: 'Interaction Intermediate',
       tags: ['data_engineering', 'preprocessing'],
       layer: 'Intermediate',
+      pipelines: ['__default__', 'ds'],
       type: 'data'
     },
     {
@@ -511,6 +549,7 @@ export default {
       name: 'Country Raw',
       tags: ['data_engineering', 'preprocessing'],
       layer: 'Raw',
+      pipelines: ['__default__', 'ds'],
       type: 'data'
     },
     {
@@ -519,6 +558,7 @@ export default {
       name: 'Country Intermediate',
       tags: ['data_engineering', 'preprocessing'],
       layer: 'Intermediate',
+      pipelines: ['__default__', 'ds'],
       type: 'data'
     },
     {
@@ -527,6 +567,7 @@ export default {
       name: 'Shopper Spend Raw',
       tags: ['data_engineering', 'preprocessing'],
       layer: 'Raw',
+      pipelines: ['__default__', 'ds'],
       type: 'data'
     },
     {
@@ -535,6 +576,7 @@ export default {
       name: 'Shopper Spend Intermediate',
       tags: ['data_engineering', 'preprocessing'],
       layer: 'Intermediate',
+      pipelines: ['__default__', 'ds'],
       type: 'data'
     },
     {
@@ -543,6 +585,7 @@ export default {
       name: 'Interaction Primary',
       tags: ['feature_engineering', 'data_engineering', 'preprocessing'],
       layer: 'Primary',
+      pipelines: ['__default__', 'ds'],
       type: 'data'
     },
     {
@@ -551,6 +594,7 @@ export default {
       name: 'Country Primary',
       tags: ['feature_engineering', 'data_engineering', 'preprocessing'],
       layer: 'Primary',
+      pipelines: ['__default__', 'ds'],
       type: 'data'
     },
     {
@@ -559,6 +603,7 @@ export default {
       name: 'Shopper Spend Primary',
       tags: ['feature_engineering', 'data_engineering', 'preprocessing'],
       layer: 'Primary',
+      pipelines: ['__default__', 'ds'],
       type: 'data'
     },
     {
@@ -567,6 +612,7 @@ export default {
       name: 'CRM Predictions',
       tags: ['feature_engineering', 'data_engineering'],
       layer: 'Primary',
+      pipelines: ['__default__', 'ds'],
       type: 'data'
     },
     {
@@ -581,6 +627,7 @@ export default {
         'data_engineering'
       ],
       layer: 'Feature',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -595,6 +642,7 @@ export default {
         'data_engineering'
       ],
       layer: 'Feature',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -603,6 +651,7 @@ export default {
       name: 'Vendor Master',
       tags: ['feature_engineering', 'data_engineering'],
       layer: 'Raw',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -611,6 +660,7 @@ export default {
       name: 'Salesforce CRM',
       tags: ['feature_engineering', 'data_engineering'],
       layer: 'Raw',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -624,6 +674,7 @@ export default {
         'model_training'
       ],
       layer: 'Primary',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -632,6 +683,7 @@ export default {
       name: 'Salesforce Accounts',
       tags: ['feature_engineering', 'data_engineering'],
       layer: 'Raw',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -640,6 +692,7 @@ export default {
       name: 'params: Sales Model',
       tags: ['data_science', 'model_training'],
       layer: 'Model Input',
+      pipelines: ['__default__', 'de'],
       type: 'parameters'
     },
     {
@@ -648,6 +701,7 @@ export default {
       name: 'Sales Validation Results',
       tags: ['model_performance_monitoring', 'data_science', 'model_training'],
       layer: 'Model Output',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -656,6 +710,7 @@ export default {
       name: 'Sales Trained Model',
       tags: ['model_explaination', 'data_science', 'model_training'],
       layer: 'Model Input',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -664,6 +719,7 @@ export default {
       name: 'params: Engagement Model',
       tags: ['data_science', 'model_training'],
       layer: 'Model Input',
+      pipelines: ['__default__', 'de'],
       type: 'parameters'
     },
     {
@@ -672,6 +728,7 @@ export default {
       name: 'Engagement Validation Results',
       tags: ['model_performance_monitoring', 'data_science', 'model_training'],
       layer: 'Model Output',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -680,6 +737,7 @@ export default {
       name: 'Engagement Trained Model',
       tags: ['model_explaination', 'data_science', 'model_training'],
       layer: 'Models',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -693,6 +751,7 @@ export default {
         'reporting'
       ],
       layer: 'Model Output',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -706,6 +765,7 @@ export default {
         'reporting'
       ],
       layer: 'Model Output',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -714,6 +774,7 @@ export default {
       name: 'params: Optimisation',
       tags: ['data_science', 'model_training', 'optimisation'],
       layer: 'Model Input',
+      pipelines: ['__default__', 'de'],
       type: 'parameters'
     },
     {
@@ -722,6 +783,7 @@ export default {
       name: 'Digital Analysis',
       tags: ['data_science', 'model_training', 'optimisation'],
       layer: 'Model Input',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -730,6 +792,7 @@ export default {
       name: 'Engagement Recommendations',
       tags: ['data_science', 'model_training'],
       layer: 'Model Output',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -738,6 +801,7 @@ export default {
       name: 'Action Cost Table',
       tags: ['data_science', 'optimisation'],
       layer: 'Raw',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -746,6 +810,7 @@ export default {
       name: 'Multi-Channel Resolutions',
       tags: ['reporting', 'data_science', 'optimisation'],
       layer: 'Model Output',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -754,6 +819,7 @@ export default {
       name: 'Content Resolutions',
       tags: ['reporting', 'data_science', 'optimisation'],
       layer: 'Model Output',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -762,6 +828,7 @@ export default {
       name: 'Segment Journeys Allocations',
       tags: ['reporting', 'data_science', 'optimisation'],
       layer: 'Model Output',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -770,6 +837,7 @@ export default {
       name: 'Upselling Readiness Dashboard Input',
       tags: ['reporting', 'data_science'],
       layer: 'Reporting',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -778,6 +846,7 @@ export default {
       name: 'Lead Scoring Dashboard Input',
       tags: ['reporting', 'data_science'],
       layer: 'Reporting',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -786,6 +855,7 @@ export default {
       name: 'Lifetime Value Prediction Dashboard Input',
       tags: ['reporting', 'data_science'],
       layer: 'Reporting',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -794,6 +864,7 @@ export default {
       name: 'Digital Sales Dashboard Input',
       tags: ['reporting', 'data_science'],
       layer: 'Reporting',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     },
     {
@@ -802,6 +873,7 @@ export default {
       name: 'Vendor Sales Dashboard Input',
       tags: ['reporting', 'data_science'],
       layer: 'Reporting',
+      pipelines: ['__default__', 'de'],
       type: 'data'
     }
   ],

--- a/src/utils/graph/layout.js
+++ b/src/utils/graph/layout.js
@@ -301,7 +301,7 @@ const rowDensity = edges => {
   const rows = {};
 
   for (const edge of edges) {
-    // Find the normalised angle of the edge source and target nodes, relative to the X axis
+    // Find the normalized angle of the edge source and target nodes, relative to the X axis
     const edgeAngle =
       Math.abs(angle(edge.targetNode, edge.sourceNode) - halfPI) / halfPI;
 


### PR DESCRIPTION
## Description

We are adding the ability to create multiple ('modular') pipelines, and will add a dropdown to allow users to filter by pipeline. This is being added to the API in #192. This PR adds this information to the application state via the data normalizer, and adds corresponding actions, reducers and selectors to allow the active pipeline to be updated, and the nodes/edges etc to be filtered accordingly.

## Development notes

The UI to allow users to select an active pipeline will be added in a subsequent PR.

I've also added some new tests for the normalizer, as it didn't have any.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
