### PR TITLE
Improve performance of `getLinkedNodes`

### DIFF
--- a/src/selectors/linked-nodes.js
+++ b/src/selectors/linked-nodes.js
@@ -1,8 +1,6 @@
 import { createSelector } from 'reselect';
+import { getVisibleEdges } from './edges';
 
-const getEdgeIDs = state => state.edge.ids;
-const getEdgeSources = state => state.edge.sources;
-const getEdgeTargets = state => state.edge.targets;
 const getClickedNode = state => state.node.clicked;
 const getHoveredNode = state => state.node.hovered;
 
@@ -17,35 +15,88 @@ export const getCentralNode = createSelector(
 );
 
 /**
- * Recursively search through the edges data for ancestor and descendant nodes
+ * Gets a map of nodeIDs to the visible source edges and target edges
  * @param {Array} edges
+ */
+export const getVisibleEdgesByNode = createSelector(
+  [getVisibleEdges],
+  edges => {
+    const sourceEdges = {};
+    const targetEdges = {};
+
+    for (const edge of edges) {
+      sourceEdges[edge.target] = sourceEdges[edge.target] || [];
+      sourceEdges[edge.target].push(edge);
+    }
+
+    for (const edge of edges) {
+      targetEdges[edge.source] = targetEdges[edge.source] || [];
+      targetEdges[edge.source].push(edge);
+    }
+
+    return { sourceEdges, targetEdges };
+  }
+);
+
+/**
+ * Finds all visible successors for the given nodeID in given direction
+ * @param {string} nodeID
+ * @param {Object} edgesByNode
+ * @param {string} direction
+ * @param {?Array} result
+ * @param {?object} visited
+ * @param {?Array} empty
+ */
+const findLinkedNodes = (
+  nodeId,
+  edgesByNode,
+  direction,
+  result = [],
+  visited = {},
+  empty = []
+) => {
+  if (visited[nodeId]) {
+    return result;
+  }
+
+  visited[nodeId] = true;
+  result.push(nodeId);
+
+  (edgesByNode[nodeId] || empty).forEach(edge =>
+    findLinkedNodes(
+      edge[direction],
+      edgesByNode,
+      direction,
+      result,
+      visited,
+      empty
+    )
+  );
+
+  return result;
+};
+
+/**
+ * Gets all visible ancestors and descendents for the given nodeID
+ * @param {Object} visibleEdgeMaps
  * @param {string} nodeID
  */
 export const getLinkedNodes = createSelector(
-  [getEdgeIDs, getEdgeSources, getEdgeTargets, getCentralNode],
-  (edges, edgeSources, edgeTargets, nodeID) => {
+  [getVisibleEdgesByNode, getCentralNode],
+  ({ sourceEdges, targetEdges }, nodeID) => {
     if (!nodeID) {
       return {};
     }
 
-    const linkedNodes = {
-      [nodeID]: true
-    };
+    const nodeIDs = findLinkedNodes(nodeID, sourceEdges, 'source').concat(
+      findLinkedNodes(nodeID, targetEdges, 'target')
+    );
 
-    const traverseGraph = (prev, next) => {
-      (function walk(id) {
-        edges.forEach(edge => {
-          if (prev[edge] === id) {
-            linkedNodes[next[edge]] = true;
-            walk(next[edge]);
-          }
-        });
-      })(nodeID);
-    };
+    const linkedNodes = {};
 
-    const direction = [edgeSources, edgeTargets];
-    traverseGraph.apply(null, direction);
-    traverseGraph.apply(null, direction.reverse());
+    for (const nodeID of nodeIDs) {
+      linkedNodes[nodeID] = true;
+    }
 
     return linkedNodes;
   }

--- a/src/selectors/linked-nodes.js
+++ b/src/selectors/linked-nodes.js
@@ -43,37 +43,34 @@ export const getVisibleEdgesByNode = createSelector(
  * @param {string} nodeID
  * @param {Object} edgesByNode
  * @param {string} direction
- * @param {?Array} result
  * @param {?object} visited
+ * @param {?boolean} isStart
  * @param {?Array} empty
  */
 const findLinkedNodes = (
   nodeId,
   edgesByNode,
   direction,
-  result = [],
   visited = {},
+  isStart = true,
   empty = []
 ) => {
-  if (visited[nodeId]) {
-    return result;
+  if (isStart || !visited[nodeId]) {
+    visited[nodeId] = true;
+
+    (edgesByNode[nodeId] || empty).forEach(edge =>
+      findLinkedNodes(
+        edge[direction],
+        edgesByNode,
+        direction,
+        visited,
+        false,
+        empty
+      )
+    );
   }
 
-  visited[nodeId] = true;
-  result.push(nodeId);
-
-  (edgesByNode[nodeId] || empty).forEach(edge =>
-    findLinkedNodes(
-      edge[direction],
-      edgesByNode,
-      direction,
-      result,
-      visited,
-      empty
-    )
-  );
-
-  return result;
+  return visited;
 };
 
 /**
@@ -88,16 +85,9 @@ export const getLinkedNodes = createSelector(
       return {};
     }
 
-    const nodeIDs = findLinkedNodes(nodeID, sourceEdges, 'source').concat(
-      findLinkedNodes(nodeID, targetEdges, 'target')
-    );
-
     const linkedNodes = {};
-
-    for (const nodeID of nodeIDs) {
-      linkedNodes[nodeID] = true;
-    }
-
+    findLinkedNodes(nodeID, sourceEdges, 'source', linkedNodes);
+    findLinkedNodes(nodeID, targetEdges, 'target', linkedNodes);
     return linkedNodes;
   }
 );

--- a/src/selectors/linked-nodes.js
+++ b/src/selectors/linked-nodes.js
@@ -15,7 +15,7 @@ export const getCentralNode = createSelector(
 );
 
 /**
- * Gets a map of nodeIDs to the visible source edges and target edges
+ * Gets a map of visible nodeIDs to successors nodeIDs in both directions
  * @param {Array} edges
  */
 export const getVisibleEdgesByNode = createSelector(
@@ -29,13 +29,13 @@ export const getVisibleEdgesByNode = createSelector(
         sourceEdges[edge.target] = [];
       }
 
-      sourceEdges[edge.target].push(edge);
+      sourceEdges[edge.target].push(edge.source);
 
       if (!targetEdges[edge.source]) {
         targetEdges[edge.source] = [];
       }
 
-      targetEdges[edge.source].push(edge);
+      targetEdges[edge.source].push(edge.target);
     }
 
     return { sourceEdges, targetEdges };
@@ -43,20 +43,19 @@ export const getVisibleEdgesByNode = createSelector(
 );
 
 /**
- * Finds all visible successor for the given nodeID in given direction
+ * Finds all visible successor nodeIDs for the given nodeID
  * @param {string} nodeID the starting nodeID
- * @param {Object} edgesByNode an object mapping nodeIDs to edges
- * @param {string} direction 'source' or 'target', direction to traverse along each edge
+ * @param {Object} edgesByNode an object mapping nodeIDs to successor nodeIDs
  * @param {object} visited an object for storing all visited node ids
  * @returns {object} the supplied `visited` object
  */
-const findLinkedNodes = (nodeID, edgesByNode, direction, visited) => {
+const findLinkedNodes = (nodeID, edgesByNode, visited) => {
   if (!visited[nodeID]) {
     visited[nodeID] = true;
 
     if (edgesByNode[nodeID]) {
-      edgesByNode[nodeID].forEach(edge =>
-        findLinkedNodes(edge[direction], edgesByNode, direction, visited)
+      edgesByNode[nodeID].forEach(nodeID =>
+        findLinkedNodes(nodeID, edgesByNode, visited)
       );
     }
   }
@@ -77,10 +76,10 @@ export const getLinkedNodes = createSelector(
     }
 
     const linkedNodes = {};
-    findLinkedNodes(nodeID, sourceEdges, 'source', linkedNodes);
+    findLinkedNodes(nodeID, sourceEdges, linkedNodes);
 
     linkedNodes[nodeID] = false;
-    findLinkedNodes(nodeID, targetEdges, 'target', linkedNodes);
+    findLinkedNodes(nodeID, targetEdges, linkedNodes);
 
     return linkedNodes;
   }

--- a/src/selectors/linked-nodes.js
+++ b/src/selectors/linked-nodes.js
@@ -43,35 +43,35 @@ export const getVisibleEdgesByNode = createSelector(
 );
 
 /**
- * Finds all visible successors for the given nodeID in given direction
- * @param {string} nodeID
- * @param {Object} edgesByNode
- * @param {string} direction
- * @param {?object} visited
- * @param {?boolean} isStart
- * @param {?Array} empty
+ * Finds all visible successor for the given nodeID in given direction
+ * @param {string} nodeID the starting nodeID
+ * @param {Object} edgesByNode an object mapping nodeIDs to edges
+ * @param {string} direction 'source' or 'target', direction to traverse along each edge
+ * @param {object} visited an object for storing all visited node ids
+ * @param {?number} depth the current depth so far traversed
+ * @returns {object} the supplied `visited` object
  */
 const findLinkedNodes = (
-  nodeId,
+  nodeID,
   edgesByNode,
   direction,
-  visited = {},
-  isStart = true,
-  empty = []
+  visited,
+  depth = 0
 ) => {
-  if (isStart || !visited[nodeId]) {
-    visited[nodeId] = true;
+  if (depth === 0 || !visited[nodeID]) {
+    visited[nodeID] = true;
 
-    (edgesByNode[nodeId] || empty).forEach(edge =>
-      findLinkedNodes(
-        edge[direction],
-        edgesByNode,
-        direction,
-        visited,
-        false,
-        empty
-      )
-    );
+    if (edgesByNode[nodeID]) {
+      edgesByNode[nodeID].forEach(edge =>
+        findLinkedNodes(
+          edge[direction],
+          edgesByNode,
+          direction,
+          visited,
+          depth + 1
+        )
+      );
+    }
   }
 
   return visited;

--- a/src/selectors/linked-nodes.js
+++ b/src/selectors/linked-nodes.js
@@ -48,28 +48,15 @@ export const getVisibleEdgesByNode = createSelector(
  * @param {Object} edgesByNode an object mapping nodeIDs to edges
  * @param {string} direction 'source' or 'target', direction to traverse along each edge
  * @param {object} visited an object for storing all visited node ids
- * @param {?number} depth the current depth so far traversed
  * @returns {object} the supplied `visited` object
  */
-const findLinkedNodes = (
-  nodeID,
-  edgesByNode,
-  direction,
-  visited,
-  depth = 0
-) => {
-  if (depth === 0 || !visited[nodeID]) {
+const findLinkedNodes = (nodeID, edgesByNode, direction, visited) => {
+  if (!visited[nodeID]) {
     visited[nodeID] = true;
 
     if (edgesByNode[nodeID]) {
       edgesByNode[nodeID].forEach(edge =>
-        findLinkedNodes(
-          edge[direction],
-          edgesByNode,
-          direction,
-          visited,
-          depth + 1
-        )
+        findLinkedNodes(edge[direction], edgesByNode, direction, visited)
       );
     }
   }
@@ -91,7 +78,10 @@ export const getLinkedNodes = createSelector(
 
     const linkedNodes = {};
     findLinkedNodes(nodeID, sourceEdges, 'source', linkedNodes);
+
+    linkedNodes[nodeID] = false;
     findLinkedNodes(nodeID, targetEdges, 'target', linkedNodes);
+
     return linkedNodes;
   }
 );

--- a/src/selectors/linked-nodes.js
+++ b/src/selectors/linked-nodes.js
@@ -25,12 +25,16 @@ export const getVisibleEdgesByNode = createSelector(
     const targetEdges = {};
 
     for (const edge of edges) {
-      sourceEdges[edge.target] = sourceEdges[edge.target] || [];
-      sourceEdges[edge.target].push(edge);
-    }
+      if (!sourceEdges[edge.target]) {
+        sourceEdges[edge.target] = [];
+      }
 
-    for (const edge of edges) {
-      targetEdges[edge.source] = targetEdges[edge.source] || [];
+      sourceEdges[edge.target].push(edge);
+
+      if (!targetEdges[edge.source]) {
+        targetEdges[edge.source] = [];
+      }
+
       targetEdges[edge.source].push(edge);
     }
 


### PR DESCRIPTION
## Description

Improves performance of `getLinkedNodes`.

## Development notes

The original implementation appears to be `O(n^2)` or worse, causing high CPU usage on hover and freezing with large numbers of nodes. This replaces it with an `O(n)` implementation that will scale better with more edges.

## QA notes

No changes in behaviour.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
