### PR TITLE
Fix console errors in Minimap component when all nodes are hidden

### DIFF
--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -59,6 +59,21 @@ describe('FlowChart', () => {
     expect(spy2).not.toHaveBeenCalled();
   });
 
+  it('does not throw an error/warning when no data is displayed', () => {
+    // Setup
+    const originalConsole = console;
+    console.warn = jest.fn();
+    console.error = jest.fn();
+    // Test
+    const emptyData = { data: { nodes: [], edges: [] } };
+    expect(() => setup.mount(<FlowChart />, emptyData)).not.toThrow();
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+    // Teardown
+    console.warn = originalConsole.warn;
+    console.error = originalConsole.error;
+  });
+
   it('maps state to props', () => {
     const expectedResult = {
       centralNode: null,

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -300,7 +300,7 @@ export class FlowChart extends Component {
     let translateY = 0;
 
     // Fit the graph exactly in the viewport
-    if (chartSize.width && graphSize.width) {
+    if (chartSize.width > 0 && graphSize.width > 0) {
       scale = Math.min(
         chartSize.width / graphSize.width,
         chartSize.height / graphSize.height

--- a/src/components/minimap/index.js
+++ b/src/components/minimap/index.js
@@ -258,7 +258,7 @@ export class MiniMap extends Component {
     let translateY = 0;
 
     // Fit the graph exactly in the viewport
-    if (mapSize.width && graphSize.width) {
+    if (mapSize.width > 0 && graphSize.width > 0) {
       scale = Math.min(
         (mapSize.width - padding) / graphSize.width,
         (mapSize.height - padding) / graphSize.height
@@ -385,16 +385,16 @@ const getMapSize = state => {
   const graphWidth = size.width || 0;
   const graphHeight = size.height || 0;
 
-  // Use minimum size if no graph
-  if (!graphWidth || !graphHeight) {
-    return { width: minWidth, height: height };
+  if (graphWidth > 0 && graphHeight > 0) {
+    // Constrain width
+    const scaledWidth = graphWidth * (height / graphHeight);
+    const width = Math.min(Math.max(scaledWidth, minWidth), maxWidth);
+
+    return { width, height };
   }
 
-  // Constrain width
-  const scaledWidth = graphWidth * (height / graphHeight);
-  const width = Math.min(Math.max(scaledWidth, minWidth), maxWidth);
-
-  return { width, height };
+  // Use minimum size if no graph
+  return { width: minWidth, height: height };
 };
 
 // Maintain a single reference to support change detection

--- a/src/components/minimap/minimap.test.js
+++ b/src/components/minimap/minimap.test.js
@@ -18,6 +18,21 @@ describe('MiniMap', () => {
     expect(nodes.length).toEqual(mockNodes.length);
   });
 
+  it('does not throw an error/warning when no data is displayed', () => {
+    // Setup
+    const originalConsole = console;
+    console.warn = jest.fn();
+    console.error = jest.fn();
+    // Test
+    const emptyData = { data: { nodes: [], edges: [] } };
+    expect(() => setup.mount(<MiniMap />, emptyData)).not.toThrow();
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+    // Teardown
+    console.warn = originalConsole.warn;
+    console.error = originalConsole.error;
+  });
+
   it('maps state to props', () => {
     const expectedResult = {
       visible: expect.any(Boolean),

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -60,7 +60,7 @@ const combinedReducer = combineReducers({
   layer: createReducer({}),
   // These props have very simple non-nested actions
   chartSize: createReducer({}, UPDATE_CHART_SIZE, 'chartSize'),
-  zoom: createReducer({}, UPDATE_ZOOM, 'zoom', {}),
+  zoom: createReducer({}, UPDATE_ZOOM, 'zoom'),
   fontLoaded: createReducer(false, UPDATE_FONT_LOADED, 'fontLoaded'),
   textLabels: createReducer(true, TOGGLE_TEXT_LABELS, 'textLabels'),
   theme: createReducer('dark', TOGGLE_THEME, 'theme')


### PR DESCRIPTION
## Description

The minimap component is throwing errors when there are no nodes displayed on the page.

## Development notes

- [x] Add tests to ensure that this doesn't happen again (because it's not the first time this regression has been introduced)
- [x] Fix the error

## QA notes

Disable all nodes (e.g. by clicking 'Hide all', or disabling each of the 3 node-types)

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
