### PR TITLE
Rename default json endpoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,11 +85,11 @@ Kedro-Viz uses an unique identifier to determine the data source. You can config
 DATA=random npm start
 ```
 
-There are several different data sources available. By default in production, the app asynchronously loads JSON from the `/api/nodes.json` endpoint, and you can replicate this in development by placing a dataset at `/public/api/nodes.json`. Alternatively, you can use one of the mock unit-testing/demo datasets, or pseudo-random data procedurally-generated on page load, which is often useful for local development.
+There are several different data sources available. By default in production, the app asynchronously loads JSON from the `/api/main` endpoint, and you can replicate this in development by placing a dataset at `/public/api/main`. Note that `main` is the name of the json file, but should not have an extension. Alternatively, you can use one of the mock unit-testing/demo datasets, or pseudo-random data procedurally-generated on page load, which is often useful for local development.
 
 | Identifier | Data source |
 |------------|-------------|
-| `json` (default) | `/public/api/nodes.json` |
+| `json` (default) | `/public/api/main` |
 | `random` | Randomly-generated data |
 | `demo` | `/src/utils/data/demo.mock.js` |
 | `animals` | `/src/utils/data/animals.mock.js` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ Kedro-Viz uses an unique identifier to determine the data source. You can config
 DATA=random npm start
 ```
 
-There are several different data sources available. By default in production, the app asynchronously loads JSON from the `/api/main` endpoint, and you can replicate this in development by placing a dataset at `/public/api/main`. Note that `main` is the name of the json file, but should not have an extension. Alternatively, you can use one of the mock unit-testing/demo datasets, or pseudo-random data procedurally-generated on page load, which is often useful for local development.
+There are several different data sources available. By default in production, the app asynchronously loads JSON from the `/api/main` endpoint. You can replicate this in development by placing a dataset in `/public/api/main`, using `main` as the name of the JSON file, without an extension. Alternatively, you can use one of the mock unit-testing/demo datasets, or pseudo-random data procedurally-generated on page load, which is often useful for local development.
 
 | Identifier | Data source |
 |------------|-------------|

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ As a JavaScript React component, the project is designed to be used in two diffe
 
 1. **Standalone application**
 
-   Run `npm run build` to generate a production build as a full-page app. The built app will be placed in the `/build` directory. Data for the chart should be placed in `/public/api/nodes.json` because this directory is marked `gitignore`.
+   Run `npm run build` to generate a production build as a full-page app. The built app will be placed in the `/build` directory. Data for the chart should be placed in `/public/api/main` because this directory is marked `gitignore`.
 
 2. **React component**
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,6 +20,7 @@ Please follow the established format:
 - Move data source loading into standalone-app entry point (#215)
 - Allow an argument to be passed to loadJsonData (#215)
 - Add information for multiple pipelines in `nodes.json` (#192)
+- Rename default endpoint from `/api/nodes.json` to `/api/nodes` (#239)
 
 # Release 3.4.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,8 @@ Please follow the established format:
 
 <!-- Add release notes for the upcoming release here -->
 
+- Rename default endpoint from `/api/nodes.json` to `/api/main` (#239)
+
 ## Bug fixes and other changes
 
 <!-- Add release notes for the upcoming release here -->
@@ -20,7 +22,6 @@ Please follow the established format:
 - Move data source loading into standalone-app entry point (#215)
 - Allow an argument to be passed to loadJsonData (#215)
 - Add information for multiple pipelines in `nodes.json` (#192)
-- Rename default endpoint from `/api/nodes.json` to `/api/main` (#239)
 
 # Release 3.4.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,7 @@ Please follow the established format:
 - Move data source loading into standalone-app entry point (#215)
 - Allow an argument to be passed to loadJsonData (#215)
 - Add information for multiple pipelines in `nodes.json` (#192)
-- Rename default endpoint from `/api/nodes.json` to `/api/nodes` (#239)
+- Rename default endpoint from `/api/nodes.json` to `/api/main` (#239)
 
 # Release 3.4.0
 

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -172,7 +172,7 @@ def _check_kedroviz_running(context):
     Args:
         context (behave.runner.Context): Test context
     """
-    data_json = json.loads(download_url("http://localhost:4141/api/nodes.json"))
+    data_json = json.loads(download_url("http://localhost:4141/api/nodes"))
     try:
         assert context.result.poll() is None
         assert (

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -172,7 +172,7 @@ def _check_kedroviz_running(context):
     Args:
         context (behave.runner.Context): Test context
     """
-    data_json = json.loads(download_url("http://localhost:4141/api/nodes"))
+    data_json = json.loads(download_url("http://localhost:4141/api/main"))
     try:
         assert context.result.poll() is None
         assert (

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -486,9 +486,9 @@ def _get_dataset_node(node_id, namespace):
     return {"type": "data", "obj": dataset}
 
 
-@app.route("/api/nodes")
+@app.route("/api/main")
 def nodes_json():
-    """Serve the pipeline data."""
+    """Serve the pipeline data. This includes basic node data amongst others edges, tags, and layers."""
     return jsonify(_DATA)
 
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -486,7 +486,7 @@ def _get_dataset_node(node_id, namespace):
     return {"type": "data", "obj": dataset}
 
 
-@app.route("/api/nodes.json")
+@app.route("/api/nodes")
 def nodes_json():
     """Serve the pipeline data."""
     return jsonify(_DATA)

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -269,9 +269,9 @@ def test_root_endpoint(client):
 
 @pytest.mark.usefixtures("patched_get_project_context")
 def test_nodes_endpoint(cli_runner, client):
-    """Test `/api/nodes` endpoint is functional and returns a valid JSON."""
+    """Test `/api/main` endpoint is functional and returns a valid JSON."""
     cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
-    response = client.get("/api/nodes")
+    response = client.get("/api/main")
     assert response.status_code == 200
     data = json.loads(response.data.decode())
     assert data == EXPECTED_PIPELINE_DATA
@@ -412,7 +412,7 @@ def test_node_metadata_endpoint_invalid(cli_runner, client):
 def test_pipeline_flag(cli_runner, client):
     """Test that running viz with `--pipeline` flag will return a correct pipeline."""
     cli_runner.invoke(server.commands, ["viz", "--pipeline", "second"])
-    response = client.get("/api/nodes")
+    response = client.get("/api/main")
     assert response.status_code == 200
     data = json.loads(response.data.decode())
     assert data == {

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -269,9 +269,9 @@ def test_root_endpoint(client):
 
 @pytest.mark.usefixtures("patched_get_project_context")
 def test_nodes_endpoint(cli_runner, client):
-    """Test `/api/nodes.json` endpoint is functional and returns a valid JSON."""
+    """Test `/api/nodes` endpoint is functional and returns a valid JSON."""
     cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
-    response = client.get("/api/nodes.json")
+    response = client.get("/api/nodes")
     assert response.status_code == 200
     data = json.loads(response.data.decode())
     assert data == EXPECTED_PIPELINE_DATA
@@ -412,7 +412,7 @@ def test_node_metadata_endpoint_invalid(cli_runner, client):
 def test_pipeline_flag(cli_runner, client):
     """Test that running viz with `--pipeline` flag will return a correct pipeline."""
     cli_runner.invoke(server.commands, ["viz", "--pipeline", "second"])
-    response = client.get("/api/nodes.json")
+    response = client.get("/api/nodes")
     assert response.status_code == 200
     data = json.loads(response.data.decode())
     assert data == {

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -97,7 +97,7 @@ App.defaultProps = {
    * You can supply an object containing lists of edges, nodes, tags -
    * See /src/utils/data for examples of the expected data format.
    * Alternatively, the string 'json' indicates that data is being
-   * loaded asynchronously from /public/api/nodes.json
+   * loaded asynchronously from /public/api/main
    */
   data: null,
   /**

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-export const dataPath = './api/nodes';
+export const dataPath = './api/main';
 export const fullDataPath = `/public${dataPath.substr(1)}`;
 
 export const localStorageName = 'KedroViz';

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-export const dataPath = './api/nodes.json';
+export const dataPath = './api/nodes';
 export const fullDataPath = `/public${dataPath.substr(1)}`;
 
 export const localStorageName = 'KedroViz';

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -3,7 +3,7 @@ import { dataPath, localStorageName } from './config';
 describe('config', () => {
   describe('dataPath', () => {
     it('should return the name of a json file', () => {
-      expect(dataPath).toEqual(expect.stringContaining('/nodes'));
+      expect(dataPath).toEqual(expect.stringContaining('/main'));
     });
 
     it('should return a relative path', () => {

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -3,7 +3,7 @@ import { dataPath, localStorageName } from './config';
 describe('config', () => {
   describe('dataPath', () => {
     it('should return the name of a json file', () => {
-      expect(dataPath).toEqual(expect.stringContaining('.json'));
+      expect(dataPath).toEqual(expect.stringContaining('/nodes'));
     });
 
     it('should return a relative path', () => {

--- a/src/utils/data-source.js
+++ b/src/utils/data-source.js
@@ -9,7 +9,7 @@ import demo from './data/demo.mock';
    - 'random': Use randomly-generated data
    - 'animals': Use data from the 'animals' test dataset
    - 'demo': Use data from the 'demo' test dataset
-   - 'json': Load data from a local json file (in /public/api/nodes.json)
+   - 'json': Load data from a local json file (in /public/api/main)
  * @return {string} Data source identifier
  */
 export const getSourceID = () => {


### PR DESCRIPTION
## Description

https://jira.quantumblack.com/browse/KED-1969

## Development notes

I renamed the endpoint from `/api/nodes.json` to `/api/main`. 

## QA notes

Updated tests and ran kedro-viz locally to see if everything still works. 

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
