### PR TITLE
Reduce toolbar-button height on smaller screens

### DIFF
--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -15,6 +15,10 @@
   cursor: pointer;
   user-select: none;
 
+  @media (max-height: 550px) {
+    height: $sidebar-width-closed - 14;
+  }
+
   &:focus {
     outline: none;
 

--- a/src/components/minimap-toolbar/minimap-toolbar.scss
+++ b/src/components/minimap-toolbar/minimap-toolbar.scss
@@ -8,7 +8,7 @@
 }
 
 .pipeline-minimap-button {
-  height: 46px;
+  height: $sidebar-width-closed - 14;
   transition: background-color 300ms ease;
 }
 


### PR DESCRIPTION
## Description

Fix the slightly-broken layout where screen height is between 470-550px, by reducing the height of the main toolbar buttons. I've also made use of the variable names where possible.
![image](https://user-images.githubusercontent.com/1155816/91300115-a48e7200-e79a-11ea-8ef2-4e97c1888189.png)

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
