### PR TITLE
[KED-1422] Expose an endpoint to query pipeline-specific node

### DIFF
--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -369,8 +369,9 @@ def format_pipelines_data(pipelines: Dict[str, "Pipeline"]) -> Dict[str, list]:
     sorted_layers = _sort_layers(nodes, node_dependencies)
 
     default_pipeline = {"id": _DEFAULT_KEY, "name": _pretty_name(_DEFAULT_KEY)}
-    selected_pipeline = default_pipeline if default_pipeline in pipelines_list \
-        else pipelines_list[0]
+    selected_pipeline = (
+        default_pipeline if default_pipeline in pipelines_list else pipelines_list[0]
+    )
 
     return {
         "nodes": nodes_list,
@@ -378,7 +379,7 @@ def format_pipelines_data(pipelines: Dict[str, "Pipeline"]) -> Dict[str, list]:
         "tags": sorted_tags,
         "layers": sorted_layers,
         "pipelines": pipelines_list,
-        "selected_pipeline": selected_pipeline
+        "selected_pipeline": selected_pipeline,
     }
 
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -44,7 +44,7 @@ from typing import Dict, List, Set, Tuple, Union
 import click
 import kedro
 import requests
-from flask import Flask, jsonify, send_from_directory, abort
+from flask import Flask, abort, jsonify, send_from_directory
 from IPython.core.display import HTML, display
 from kedro.io import AbstractDataSet, DataCatalog, DataSetNotFoundError
 from kedro.pipeline.node import Node
@@ -515,13 +515,15 @@ def pipeline_data(pipeline_id):
         if edge["source"] in pipeline_node_ids and edge["target"] in pipeline_node_ids:
             pipeline_edges.append(edge)
 
-    return jsonify({
-        "nodes": pipeline_nodes,
-        "edges": pipeline_edges,
-        "tags": _DATA["tags"],
-        "layers": _DATA["layers"],
-        "pipelines": pipelines_list,
-    })
+    return jsonify(
+        {
+            "nodes": pipeline_nodes,
+            "edges": pipeline_edges,
+            "tags": _DATA["tags"],
+            "layers": _DATA["layers"],
+            "pipelines": pipelines_list,
+        }
+    )
 
 
 @app.route("/api/nodes/<string:node_id>")

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -496,6 +496,9 @@ def nodes_json():
 @app.route("/api/pipelines/<string:pipeline_id>")
 def pipeline_data(pipeline_id):
     """Serve the data from a single pipeline in a Kedro project."""
+    if pipeline_id not in _DATA["pipelines"]:
+        abort(404, description="Invalid pipeline ID.")
+
     pipeline_node_ids = set()
     pipeline_nodes = []
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -497,7 +497,8 @@ def nodes_json():
 @app.route("/api/pipelines/<string:pipeline_id>")
 def pipeline_data(pipeline_id):
     """Serve the data from a single pipeline in a Kedro project."""
-    if pipeline_id not in _DATA["pipelines"]:
+    current_pipeline = {"id": pipeline_id, "name": _pretty_name(pipeline_id)}
+    if current_pipeline not in _DATA["pipelines"]:
         abort(404, description="Invalid pipeline ID.")
 
     pipeline_node_ids = set()
@@ -513,7 +514,6 @@ def pipeline_data(pipeline_id):
         if {edge["source"], edge["target"]} <= pipeline_node_ids:
             pipeline_edges.append(edge)
 
-    current_pipeline = {"id": pipeline_id, "name": _pretty_name(pipeline_id)}
     return jsonify(
         {
             "nodes": pipeline_nodes,

--- a/package/tests/input.json
+++ b/package/tests/input.json
@@ -177,5 +177,6 @@
             "id": "bob",
             "name": "Bob"
         }
-    ]
+    ],
+    "selected_pipeline": {"id": "__default__", "name": "Default"}
 }

--- a/package/tests/result.json
+++ b/package/tests/result.json
@@ -97,5 +97,6 @@
             "id": "__default__",
             "name": "Default"
         }
-    ]
+    ],
+    "selected_pipeline": {"id": "__default__", "name": "Default"}
 }

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -291,8 +291,8 @@ def test_pipelines_endpoint(cli_runner, client):
     assert data["selected_pipeline"]["id"] == selected_pipeline_id
 
     # make sure all returned nodes belong to the correct pipelines
-    for node in data["nodes"]:
-        assert selected_pipeline_id in node["pipelines"]
+    for n in data["nodes"]:
+        assert selected_pipeline_id in n["pipelines"]
 
     # make sure only edges in the selected pipelines are returned
     assert data["edges"] == [

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -508,7 +508,7 @@ def test_pipeline_flag(cli_runner, client):
             },
         ],
         "pipelines": [{"id": "second", "name": "Second"}],
-        'selected_pipeline': {'id': 'second', 'name': 'Second'},
+        "selected_pipeline": {"id": "second", "name": "Second"},
         "tags": [],
     }
 

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -306,6 +306,16 @@ def test_pipelines_endpoint(cli_runner, client):
 
 
 @pytest.mark.usefixtures("patched_get_project_context")
+def test_pipelines_endpoint_invalid_pipeline_id(cli_runner, client):
+    """Test `/api/pipelines/invalid_id` endpoint returns an empty JSON."""
+    cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
+    response = client.get(f"/api/pipelines/invalid")
+    assert response.status_code == 404
+    data = json.loads(response.data.decode())
+    assert data["error"] == "404 Not Found: Invalid pipeline ID."
+
+
+@pytest.mark.usefixtures("patched_get_project_context")
 def test_node_metadata_endpoint_task(cli_runner, client, mocker, tmp_path):
     """Test `/api/nodes/task_id` endpoint is functional and returns a valid JSON."""
     project_root = "project_root"

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -38,14 +38,14 @@ from pathlib import Path
 
 import pytest
 from kedro.extras.datasets.pickle import PickleDataSet
-from kedro.io import DataCatalog, MemoryDataSet, DataSetNotFoundError
+from kedro.io import DataCatalog, DataSetNotFoundError, MemoryDataSet
 from kedro.pipeline import Pipeline, node
 from semver import VersionInfo
 from toposort import CircularDependencyError
 
 import kedro_viz
 from kedro_viz import server
-from kedro_viz.server import _allocate_port, _sort_layers, format_pipelines_data, _hash
+from kedro_viz.server import _allocate_port, _hash, _sort_layers, format_pipelines_data
 from kedro_viz.utils import WaitForException
 
 input_json_path = Path(__file__).parent / "input.json"
@@ -288,9 +288,10 @@ def test_pipelines_endpoint(cli_runner, client):
 
     # make sure the selected pipeline is the first on the list
     # and the list of all pipelines are returned
-    assert data["pipelines"][0]['id'] == selected_pipeline_id
-    assert {p["name"] for p in data["pipelines"]} == \
-        {p["name"] for p in EXPECTED_PIPELINE_DATA["pipelines"]}
+    assert data["pipelines"][0]["id"] == selected_pipeline_id
+    assert {p["name"] for p in data["pipelines"]} == {
+        p["name"] for p in EXPECTED_PIPELINE_DATA["pipelines"]
+    }
 
     # make sure all returned nodes belong to the correct pipelines
     for node in data["nodes"]:
@@ -298,9 +299,9 @@ def test_pipelines_endpoint(cli_runner, client):
 
     # make sure only edges in the selected pipelines are returned
     assert data["edges"] == [
-        {'source': '7366ec9f', 'target': '01a6a5cb'},
-        {'source': 'f1f1425b', 'target': '01a6a5cb'},
-        {'source': '01a6a5cb', 'target': '60e68b8e'}
+        {"source": "7366ec9f", "target": "01a6a5cb"},
+        {"source": "f1f1425b", "target": "01a6a5cb"},
+        {"source": "01a6a5cb", "target": "60e68b8e"},
     ]
 
     # make sure all tags are returned

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -279,19 +279,16 @@ def test_nodes_endpoint(cli_runner, client):
 
 @pytest.mark.usefixtures("patched_get_project_context")
 def test_pipelines_endpoint(cli_runner, client):
-    """Test `/api/main` endpoint is functional and returns a valid JSON."""
+    """Test `/api/pipelines` endpoint is functional and returns a valid JSON."""
     cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
     selected_pipeline_id = "third"
     response = client.get(f"/api/pipelines/{selected_pipeline_id}")
     assert response.status_code == 200
     data = json.loads(response.data.decode())
 
-    # make sure the selected pipeline is the first on the list
-    # and the list of all pipelines are returned
-    assert data["pipelines"][0]["id"] == selected_pipeline_id
-    assert {p["name"] for p in data["pipelines"]} == {
-        p["name"] for p in EXPECTED_PIPELINE_DATA["pipelines"]
-    }
+    # make sure the list of all pipelines are returned
+    assert data["pipelines"] == EXPECTED_PIPELINE_DATA["pipelines"]
+    assert data["selected_pipeline"]["id"] == selected_pipeline_id
 
     # make sure all returned nodes belong to the correct pipelines
     for node in data["nodes"]:
@@ -501,6 +498,7 @@ def test_pipeline_flag(cli_runner, client):
             },
         ],
         "pipelines": [{"id": "second", "name": "Second"}],
+        'selected_pipeline': {'id': 'second', 'name': 'Second'},
         "tags": [],
     }
 


### PR DESCRIPTION
## Description

This PR exposes an endpoint for the FE to query pipeline-specific nodes information. At first, I tried refactoring the backend to make it more robust (i.e. calculating the response from Kedro-native objects), but went down a rabbit hole, so I opt-ed for this implementation instead (filtering the global `_DATA` object). 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
