### PR TITLE
[KED-1960] Support ES Modules + CommonJS in lib package

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,5 +8,5 @@
       }
     ]
   ],
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "presets": ["@babel/preset-react"]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@quantumblack/kedro-viz",
   "version": "3.4.0",
-  "main": "lib/components/app/index.js",
+  "main": "lib/cjs/components/app/index.js",
+  "module": "lib/esm/components/app/index.js",
   "files": [
     "lib"
   ],
@@ -12,11 +13,12 @@
     "start": "REACT_APP_DATA_SOURCE=$DATA npm-run-all -p start:css start:app",
     "start:app": "PORT=4141 react-scripts start",
     "start:css": "npm run build:css && node-sass src/ -o src/ --watch --recursive",
-    "lib": "npm-run-all -s lib:clean lib:copy lib:webpack lib:babel lib:prune",
+    "lib": "npm-run-all -s lib:clean lib:copy lib:worker lib:esm lib:cjs lib:prune",
     "lib:clean": "rm -rf lib",
-    "lib:copy": "cp -rf src lib",
-    "lib:webpack": "webpack --config webpack.lib.js",
-    "lib:babel": "babel lib --out-dir lib",
+    "lib:copy": "mkdir lib && cp -rf src lib/esm",
+    "lib:worker": "webpack --config webpack.lib.js",
+    "lib:esm": "babel lib/esm --out-dir lib/esm --presets @babel/preset-react",
+    "lib:cjs": "cp -rf lib/esm lib/cjs && babel lib/cjs --out-dir lib/cjs --presets @babel/preset-env",
     "lib:prune": "find lib -type f -name '*.test.*' -delete && find lib -type f -name '*.scss' -delete",
     "lib-test": "npm-run-all -s lib lib-test:setup lib-test:serve",
     "lib-test:setup": "node ./tools/test-lib/setup.js",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,9 @@
   "scripts": {
     "build": "npm run build:css && react-scripts build",
     "build:css": "node-sass src/ -o src/",
-    "start": "REACT_APP_DATA_SOURCE=$DATA npm-run-all -p start:css start:app start:lib",
+    "start": "REACT_APP_DATA_SOURCE=$DATA npm-run-all -p start:css start:app",
     "start:app": "PORT=4141 react-scripts start",
     "start:css": "npm run build:css && node-sass src/ -o src/ --watch --recursive",
-    "start:lib": "rm -rf lib && babel src --out-dir lib --copy-files --watch",
     "lib": "npm-run-all -s lib:clean lib:copy lib:webpack lib:babel lib:prune",
     "lib:clean": "rm -rf lib",
     "lib:copy": "cp -rf src lib",

--- a/tools/test-lib/react-app/app.js
+++ b/tools/test-lib/react-app/app.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import KedroViz from '@quantumblack/kedro-viz';
-import animals from '@quantumblack/kedro-viz/lib/utils/data/animals.mock';
-import demo from '@quantumblack/kedro-viz/lib/utils/data/demo.mock';
-import getRandomData from '@quantumblack/kedro-viz/lib/utils/random-data';
+import animals from '@quantumblack/kedro-viz/lib/esm/utils/data/animals.mock';
+import demo from '@quantumblack/kedro-viz/lib/esm/utils/data/demo.mock';
+import getRandomData from '@quantumblack/kedro-viz/lib/esm/utils/random-data';
 
 export const dataSources = {
   animals: () => animals,

--- a/tools/test-lib/react-app/app.test.js
+++ b/tools/test-lib/react-app/app.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import { LOREM_IPSUM } from '@quantumblack/kedro-viz/lib/utils/random-utils';
+import { LOREM_IPSUM } from '@quantumblack/kedro-viz/lib/esm/utils/random-utils';
 import App, { dataSources } from './app';
 
 configure({ adapter: new Adapter() });

--- a/webpack.lib.js
+++ b/webpack.lib.js
@@ -3,11 +3,11 @@ const path = require('path');
 // Bundle and inline web-workers
 module.exports = {
   mode: 'production',
-  entry: './lib/utils/worker.js',
+  entry: './lib/esm/utils/worker.js',
   output: {
     filename: 'worker.js',
     globalObject: 'this',
     libraryTarget: 'umd',
-    path: path.resolve(__dirname, 'lib/utils')
+    path: path.resolve(__dirname, 'lib/esm/utils')
   }
 };


### PR DESCRIPTION
## Description

1. **Support ES Modules + CommonJS in lib package**
  Update the lib packaging process so that it uses both the main and module endpoints in package.json, with transpiled CommonJS files provided to main, and ES Modules provided to the module endpoint for those who support it. This requires 2 separate babel transforms: The first transpiles React JSX to JS, and the second transpiles ESM to CJS.
2. **Deprecate `start:lib` script**
  This script probably isn't be useful anymore, because npm link doesn't work very well since we upgraded React to 16.8 (with Hooks), and the web worker isn't live-updated, and we have lib-test for this anyway. So we might as well remove it.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
