### PR TITLE
3.5.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,15 +13,39 @@ Please follow the established format:
 
 <!-- Add release notes for the upcoming release here -->
 
-- Rename default endpoint from `/api/nodes.json` to `/api/main` (#239)
-
 ## Bug fixes and other changes
 
 <!-- Add release notes for the upcoming release here -->
 
-- Move data source loading into standalone-app entry point (#215)
-- Allow an argument to be passed to loadJsonData (#215)
-- Add information for multiple pipelines in `nodes.json` (#192)
+# Release 3.5.0
+
+## Major features and improvements
+
+- **BREAKING CHANGE:** Rename default endpoint from `/api/nodes.json` to `/api/main`. This should only affect local JS development. (#239, #259)
+- Add an interactive minimap to the toolbar (#203, #238, #247)
+- Add web worker to make the expensive graph layout calculation into an asynchronous action, to prevent it from blocking other tasks on the main thread. (#217)
+- Focus search bar with Cmd+F/Ctrl+F keyboard shortcuts (#261)
+- Allow an argument to be passed to loadJsonData, for external use if needed (#215)
+- Add support for multiple pipelines. This is a work-in-progress, and is currently disabled by default and hidden behind a flag. (#192, #215, #216, #221, #254)
+- Save disabled state of individual nodes in localStorage (#220)
+- Add automated testing for npm package import (#222)
+- Rename master branch to main ✊🏿 and deprecate develop (#248)
+
+## Bug fixes and other changes
+
+- Fix prepublishOnly task by changing from parallel jobs to sequential (#264)
+- Refactor layer visibility state (#253)
+- Expose an endpoint to query pipeline-specific node  (#252)
+- Reduce toolbar-button height on smaller screens (#251)
+- Delete duplicate icon-button component (#250)
+- Fix mispelling in demo dataset (#249)
+- Improve performance of `getLinkedNodes` (#235)
+- Expose node and dataset metadata in "api/nodes/" endpoint  (#231)
+- Move react-redux from peerDependencies to regular dependencies, and move react-scripts from dependencies to devDependencies (#223)
+- Refactor initial state setup (#220)
+- Enable Windows CI  (#218, #241)
+- Increase width of layer rects (#209)
+- Update various dependency versions via Snyk/Dependabot (#262, #258, #257, #219, #246, #245, #244, #243, #242, #240, #237, #234, #233, #232, #230, #228, #227, #226, #225, #224, #214, #213, #212, #211, #210, #208, #207, #206, #205, #204)
 
 # Release 3.4.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantumblack/kedro-viz",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantumblack/kedro-viz",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "main": "lib/components/app/index.js",
   "files": [
     "lib"

--- a/package/kedro_viz/__init__.py
+++ b/package/kedro_viz/__init__.py
@@ -28,7 +28,7 @@
 
 """ Kedro plugin for vizualising a Kedro pipeline """
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 
 
 from kedro_viz.server import format_pipeline_data  # noqa


### PR DESCRIPTION
# Release 3.5.0

## Major features and improvements

- **BREAKING CHANGE:** Rename default endpoint from `/api/nodes.json` to `/api/main`. This should only affect local JS development. (#239, #259)
- Add an interactive minimap to the toolbar (#203, #238, #247)
- Add web worker to make the expensive graph layout calculation into an asynchronous action, to prevent it from blocking other tasks on the main thread. (#217)
- Focus search bar with Cmd+F/Ctrl+F keyboard shortcuts (#261)
- Allow an argument to be passed to loadJsonData, for external use if needed (#215)
- Add support for multiple pipelines. This is a work-in-progress, and is currently disabled by default and hidden behind a flag. (#192, #215, #216, #221, #254)
- Save disabled state of individual nodes in localStorage (#220)
- Add automated testing for npm package import (#222)
- Rename master branch to main ✊🏿 and deprecate develop (#248)

## Bug fixes and other changes

- Fix prepublishOnly task by changing from parallel jobs to sequential (#264)
- Refactor layer visibility state (#253)
- Expose an endpoint to query pipeline-specific node  (#252)
- Reduce toolbar-button height on smaller screens (#251)
- Delete duplicate icon-button component (#250)
- Fix mispelling in demo dataset (#249)
- Improve performance of `getLinkedNodes` (#235)
- Expose node and dataset metadata in "api/nodes/" endpoint  (#231)
- Move react-redux from peerDependencies to regular dependencies, and move react-scripts from dependencies to devDependencies (#223)
- Refactor initial state setup (#220)
- Enable Windows CI  (#218, #241)
- Increase width of layer rects (#209)
- Update various dependency versions via Snyk/Dependabot (#262, #258, #257, #219, #246, #245, #244, #243, #242, #240, #237, #234, #233, #232, #230, #228, #227, #226, #225, #224, #214, #213, #212, #211, #210, #208, #207, #206, #205, #204)

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
