### PR TITLE
[KED-2092] Fix pipeline selector so that it shows the correct default pipeline

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,7 +26,7 @@ Please follow the established format:
 - Add web worker to make the expensive graph layout calculation into an asynchronous action, to prevent it from blocking other tasks on the main thread. (#217)
 - Focus search bar with Cmd+F/Ctrl+F keyboard shortcuts (#261)
 - Allow an argument to be passed to loadJsonData, for external use if needed (#215)
-- Add support for multiple pipelines. This is a work-in-progress, and is currently disabled by default and hidden behind a flag. (#192, #215, #216, #221, #254)
+- Add support for multiple pipelines. This is a work-in-progress, and is currently disabled by default and hidden behind a flag. (#192, #215, #216, #221, #252, #254)
 - Save disabled state of individual nodes in localStorage (#220)
 - Add automated testing for npm package import (#222)
 - Rename master branch to main ✊🏿 and deprecate develop (#248)
@@ -35,7 +35,6 @@ Please follow the established format:
 
 - Fix prepublishOnly task by changing from parallel jobs to sequential (#264)
 - Refactor layer visibility state (#253)
-- Expose an endpoint to query pipeline-specific node  (#252)
 - Reduce toolbar-button height on smaller screens (#251)
 - Delete duplicate icon-button component (#250)
 - Fix mispelling in demo dataset (#249)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -370,7 +370,7 @@ def format_pipelines_data(pipelines: Dict[str, "Pipeline"]) -> Dict[str, list]:
 
     default_pipeline = {"id": _DEFAULT_KEY, "name": _pretty_name(_DEFAULT_KEY)}
     selected_pipeline = (
-        default_pipeline if default_pipeline in pipelines_list else pipelines_list[0]
+        default_pipeline["id"] if default_pipeline in pipelines_list else pipelines_list[0]["id"]
     )
 
     return {
@@ -521,7 +521,7 @@ def pipeline_data(pipeline_id):
             "tags": _DATA["tags"],
             "layers": _DATA["layers"],
             "pipelines": _DATA["pipelines"],
-            "selected_pipeline": current_pipeline,
+            "selected_pipeline": current_pipeline["id"],
         }
     )
 

--- a/package/tests/input.json
+++ b/package/tests/input.json
@@ -178,5 +178,5 @@
             "name": "Bob"
         }
     ],
-    "selected_pipeline": {"id": "__default__", "name": "Default"}
+    "selected_pipeline": "__default__"
 }

--- a/package/tests/result.json
+++ b/package/tests/result.json
@@ -98,5 +98,5 @@
             "name": "Default"
         }
     ],
-    "selected_pipeline": {"id": "__default__", "name": "Default"}
+    "selected_pipeline": "__default__"
 }

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -288,7 +288,7 @@ def test_pipelines_endpoint(cli_runner, client):
 
     # make sure the list of all pipelines are returned
     assert data["pipelines"] == EXPECTED_PIPELINE_DATA["pipelines"]
-    assert data["selected_pipeline"]["id"] == selected_pipeline_id
+    assert data["selected_pipeline"] == selected_pipeline_id
 
     # make sure all returned nodes belong to the correct pipelines
     for n in data["nodes"]:
@@ -508,7 +508,7 @@ def test_pipeline_flag(cli_runner, client):
             },
         ],
         "pipelines": [{"id": "second", "name": "Second"}],
-        "selected_pipeline": {"id": "second", "name": "Second"},
+        "selected_pipeline": "second",
         "tags": [],
     }
 

--- a/src/components/pipeline-list/pipeline-list.test.js
+++ b/src/components/pipeline-list/pipeline-list.test.js
@@ -9,22 +9,24 @@ describe('PipelineList', () => {
     expect(container.length).toBe(1);
   });
 
-  it('should change the active pipeline on clicking a menu option', () => {
-    const wrapper = setup.mount(<PipelineList />);
-    expect(wrapper.find('PipelineList').props().pipeline.active).toBe(
-      '__default__'
-    );
-    wrapper
-      .find('MenuOption')
-      .at(1)
-      .simulate('click');
-    expect(wrapper.find('PipelineList').props().pipeline.active).toBe('de');
-  });
+  const pipelineIDs = mockState.animals.pipeline.ids.map((id, i) => [id, i]);
+  test.each(pipelineIDs)(
+    'should change the active pipeline to %s on clicking menu option %s',
+    (id, i) => {
+      const wrapper = setup.mount(<PipelineList />);
+      wrapper
+        .find('MenuOption')
+        .at(i)
+        .simulate('click');
+      expect(wrapper.find('PipelineList').props().pipeline.active).toBe(id);
+    }
+  );
 
   it('maps state to props', () => {
     expect(mapStateToProps(mockState.animals)).toEqual({
       pipeline: {
         active: expect.any(String),
+        default: expect.any(String),
         name: expect.any(Object),
         ids: expect.any(Array)
       },

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -52,7 +52,7 @@ export const preparePipelineState = props => {
   const state = mergeLocalStorage(normalizeData(props.data));
   // Use first pipeline in list if active pipeline from localStorage isn't recognised
   if (!state.pipeline.ids.includes(state.pipeline.active)) {
-    state.pipeline.active = state.pipeline.ids[0] || null;
+    state.pipeline.active = state.pipeline.default;
   }
   return state;
 };

--- a/src/store/initial-state.test.js
+++ b/src/store/initial-state.test.js
@@ -53,11 +53,11 @@ describe('mergeLocalStorage', () => {
 });
 
 describe('preparePipelineState', () => {
-  it('uses first pipeline in list if stored active pipeline from localStorage is not one of the pipelines in the current list', () => {
+  it('uses default pipeline if stored active pipeline from localStorage is not one of the pipelines in the current list', () => {
     saveState({ pipeline: { active: 'unknown' } });
     expect(preparePipelineState({ data: animals })).toMatchObject({
       pipeline: {
-        active: animals.pipelines[0].id
+        active: animals.selected_pipeline
       }
     });
     window.localStorage.clear();

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -9,6 +9,7 @@ export const createInitialPipelineState = () => ({
   pipeline: {
     ids: [],
     name: {},
+    default: null,
     active: null
   },
   node: {
@@ -175,7 +176,8 @@ const normalizeData = data => {
   if (data.pipelines) {
     data.pipelines.forEach(addPipeline(state));
     if (state.pipeline.ids.length) {
-      state.pipeline.active = state.pipeline.ids[0];
+      state.pipeline.default = data.selected_pipeline || state.pipeline.ids[0];
+      state.pipeline.active = state.pipeline.default;
     }
   }
   if (data.tags) {

--- a/src/utils/data/animals.mock.js
+++ b/src/utils/data/animals.mock.js
@@ -1,10 +1,7 @@
 export default {
   schema_id: '09876543210987654321',
+  selected_pipeline: '__default__',
   pipelines: [
-    {
-      id: '__default__',
-      name: 'Default'
-    },
     {
       id: 'de',
       name: 'Data engineering'
@@ -12,6 +9,10 @@ export default {
     {
       id: 'ds',
       name: 'Data science'
+    },
+    {
+      id: '__default__',
+      name: 'Default'
     },
     {
       id: 'empty',

--- a/src/utils/data/demo.mock.js
+++ b/src/utils/data/demo.mock.js
@@ -1,5 +1,6 @@
 export default {
   schema_id: '12345678901234567890',
+  selected_pipeline: '__default__',
   pipelines: [
     {
       id: '__default__',


### PR DESCRIPTION
## Description

Hotfix for an issue in the [v3.5.0](https://github.com/quantumblacklabs/kedro-viz/pull/265) release of Kedro-Viz, where the default/initial pipeline behaviour is out of sync between the front and back end. This PR resolves this issue by adding support for the `selected_pipeline` prop in the front end, so that the default pipeline will use this prop, rather than the first pipeline in the list.

Related PRs: #252

## Development notes

This PR also changes the `selected_pipeline` prop so that it is just a string ID, instead of an object containing the ID and name of the default pipeline. This is because the other info is redundant, so we felt it better to simplify it.

## QA notes

Check that the multiple pipeline selector shows the correct pipeline on first load. You will need to enable the `pipelines` flag with `?pipelines=1`. You might need to run in incognito mode to avoid interference from localStorage values.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
