### PR TITLE
Fix bug caused by typo in saveStateToLocalStorage

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -41,7 +41,7 @@ const saveStateToLocalStorage = state => {
     textLabels: state.textLabels,
     theme: state.theme,
     visible: state.visible,
-    flag: state.flags
+    flags: state.flags
   });
 };
 


### PR DESCRIPTION
## Description

The saved localStorage values of flags are being ignored on reload if the flag isn't present in the URL

## Development notes

Might be worth adding tests for this

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
