### PR TITLE
[KED-2135]Fix side-effects in prepareState caused by pipeline flag setup

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,7 @@ export const flags = {
   },
   pipelines: {
     description: 'Select from multiple pipelines',
-    default: false,
+    default: typeof jest !== undefined,
     icon: '🔀'
   }
 };

--- a/src/utils/state.mock.js
+++ b/src/utils/state.mock.js
@@ -18,8 +18,6 @@ import { saveState } from '../store/helpers';
  * @param {Object} props
  */
 export const prepareState = (...props) => {
-  // Set pipeline flag to true:
-  saveState({ flags: { pipelines: true } });
   const initialState = getInitialState(...props);
   const actions = [
     // Set fontLoaded = true:


### PR DESCRIPTION
## Description

This is a fix to a failing test that was uncovered while working on KED-1941. Currently `mockState` would assign the `pipeline` field within `flags` as true to accomodate some tests, which in turn causes discrepancies with the defaule value for `flags` within the app thereby causing the test for `'it announces flags'` to fail. 

## Development notes

I have added a simple check to assign different default values for `pipeline` under testing scenerios. With this check, we can also delete the assignment of the default value of `flags` within the `mockState` file.

merging this in will resolve #272

P.S Special thanks to the amazing @richardwestenra for going through this problem and pairing with me on this ticket! 

## QA notes

N/A

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
