### PR TITLE
[KED-1941]Remove isParam and schema_id from Kedro-Viz store

### DIFF
--- a/src/components/app/app.test.js
+++ b/src/components/app/app.test.js
@@ -4,6 +4,7 @@ import App from './index';
 import getRandomPipeline from '../../utils/random-data';
 import animals from '../../utils/data/animals.mock';
 import demo from '../../utils/data/demo.mock';
+import { mockState } from '../../utils/state.mock';
 import { Flags } from '../../utils/flags';
 import { saveState } from '../../store/helpers';
 import { prepareNonPipelineState } from '../../store/initial-state';
@@ -28,13 +29,13 @@ describe('App', () => {
 
     it('when data prop is set on first load', () => {
       const wrapper = shallow(<App data={animals} />);
-      expect(getState(wrapper).id).toEqual(animals.schema_id);
+      expect(getState(wrapper).node).toEqual(mockState.animals.node);
     });
 
     it('when data prop is updated', () => {
       const wrapper = shallow(<App data={demo} />);
       wrapper.setProps({ data: animals });
-      expect(getState(wrapper).id).toEqual(animals.schema_id);
+      expect(getState(wrapper).node).toEqual(mockState.animals.node);
     });
 
     it('but does not override localStorage values', () => {

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -81,7 +81,6 @@ App.propTypes = {
   data: PropTypes.oneOfType([
     PropTypes.oneOf(['json']),
     PropTypes.shape({
-      schema_id: PropTypes.string,
       edges: PropTypes.array.isRequired,
       layers: PropTypes.array,
       nodes: PropTypes.array.isRequired,

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -5,7 +5,6 @@ import { arrayToObject } from '../utils';
  * @return {object} state
  */
 export const createInitialPipelineState = () => ({
-  id: null,
   pipeline: {
     ids: [],
     name: {},
@@ -17,7 +16,6 @@ export const createInitialPipelineState = () => ({
     name: {},
     fullName: {},
     type: {},
-    isParam: {},
     tags: {},
     layer: {},
     disabled: {},
@@ -116,7 +114,6 @@ const addNode = state => node => {
   state.node.pipelines[id] = node.pipelines
     ? arrayToObject(node.pipelines, () => true)
     : {};
-  state.node.isParam[id] = node.type === 'parameters';
   state.node.tags[id] = node.tags || [];
 };
 
@@ -168,9 +165,6 @@ const normalizeData = data => {
     return state;
   }
 
-  if (data.schema_id) {
-    state.id = data.schema_id;
-  }
   data.nodes.forEach(addNode(state));
   data.edges.forEach(addEdge(state));
   if (data.pipelines) {

--- a/src/utils/data/animals.mock.js
+++ b/src/utils/data/animals.mock.js
@@ -1,5 +1,4 @@
 export default {
-  schema_id: '09876543210987654321',
   selected_pipeline: '__default__',
   pipelines: [
     {

--- a/src/utils/data/demo.mock.js
+++ b/src/utils/data/demo.mock.js
@@ -1,5 +1,4 @@
 export default {
-  schema_id: '12345678901234567890',
   selected_pipeline: '__default__',
   pipelines: [
     {


### PR DESCRIPTION
## Description

Given that isParam and schema_id is not in use anymore, they can be deprecated and taken out. 

## Development notes

I have removed all instances of `id` and `isParam` and their relevant tests. 

## QA notes

N/A

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
