### PR TITLE
[KED-2035] Expose parameter metadata 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 <!-- Add release notes for the upcoming release here -->
-- Expose parameter metadata in "api/nodes/" endpoint  (#275)
+- Expose parameter metadata in "api/nodes/" endpoint (#275)
 
 # Release 3.5.1
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 <!-- Add release notes for the upcoming release here -->
+- Expose parameter metadata in "api/nodes/" endpoint  (#275)
 
 # Release 3.5.1
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -455,12 +455,11 @@ def format_pipeline_data(
         is_param = bool("param" in namespace.lower())
         node_id = _hash(namespace)
 
-        node_data = (
-            _get_parameter_node(node_id, namespace)
-            if is_param
-            else _get_dataset_node(node_id, namespace)
-        )
-        _JSON_NODES[node_id] = node_data
+        node_data = _get_dataset_data_params(node_id, namespace)
+        _JSON_NODES[node_id] = {
+            "type": "parameters" if is_param else "data",
+            "obj": node_data,
+        }
 
         if node_id not in nodes:
             nodes[node_id] = {
@@ -477,20 +476,15 @@ def format_pipeline_data(
             nodes[node_id]["pipelines"].append(pipeline_key)
 
 
-def _get_parameter_node(node_id, namespace):
-    parameters = _CATALOG._get_dataset(namespace)
-    return {"type": "parameters", "obj": parameters}
-
-
-def _get_dataset_node(node_id, namespace):
+def _get_dataset_data_params(node_id, namespace):
     if KEDRO_VERSION.match(">=0.16.0"):
         try:
-            dataset = _CATALOG._get_dataset(namespace)
+            node_data = _CATALOG._get_dataset(namespace)
         except DataSetNotFoundError:
-            dataset = None
+            node_data = None
     else:
-        dataset = _CATALOG._data_sets.get(namespace)
-    return {"type": "data", "obj": dataset}
+        node_data = _CATALOG._data_sets.get(namespace)
+    return node_data
 
 
 @app.route("/api/main")

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -457,7 +457,7 @@ def format_pipeline_data(
         is_param = bool("param" in namespace.lower())
         node_id = _hash(namespace)
 
-        node_data = _get_dataset_data_params(node_id, namespace)
+        node_data = _get_dataset_data_params(namespace)
         _JSON_NODES[node_id] = {
             "type": "parameters" if is_param else "data",
             "obj": {namespace.replace("params:", ""): node_data}
@@ -480,7 +480,7 @@ def format_pipeline_data(
             nodes[node_id]["pipelines"].append(pipeline_key)
 
 
-def _get_dataset_data_params(node_id, namespace):
+def _get_dataset_data_params(namespace: str):
     if KEDRO_VERSION.match(">=0.16.0"):
         try:
             node_data = _CATALOG._get_dataset(namespace)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -546,14 +546,14 @@ def nodes_metadata(node_id):
 
     parameters = node["obj"]
     if isinstance(parameters, dict):
-        # In case of `params:` prefix
+        # In case of 'params:' prefix
         parameters_metadata = {
             "parameters": {
                 next(iter(parameters)): next(iter(parameters.values())).load()
             }
         }
         return jsonify(parameters_metadata)
-    # In case of `parameters`
+    # In case of 'parameters'
     parameters_metadata = {"parameters": node["obj"].load()}
     return jsonify(parameters_metadata)
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -545,11 +545,9 @@ def nodes_metadata(node_id):
     if node["type"] == "data":
         dataset_metadata = _get_dataset_metadata(node)
         return jsonify(dataset_metadata)
-    if node["type"] == "parameters":
-        parameters_metadata = {"parameters": node["obj"].load()}
-        return jsonify(parameters_metadata)
-    # return empty JSON for parameters type
-    return jsonify({})
+
+    parameters_metadata = {"parameters": node["obj"].load()}
+    return jsonify(parameters_metadata)
 
 
 @app.errorhandler(404)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -541,14 +541,13 @@ def nodes_metadata(node_id):
         dataset_metadata = _get_dataset_metadata(node)
         return jsonify(dataset_metadata)
 
+    parameter_values = node["obj"].load()
     if "parameter_name" in node:
         # In case of 'params:' prefix
-        parameters_metadata = {
-            "parameters": {node["parameter_name"]: node["obj"].load()}
-        }
+        parameters_metadata = {"parameters": {node["parameter_name"]: parameter_values}}
     else:
         # In case of 'parameters'
-        parameters_metadata = {"parameters": node["obj"].load()}
+        parameters_metadata = {"parameters": parameter_values}
     return jsonify(parameters_metadata)
 
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -68,7 +68,7 @@ _DEFAULT_KEY = "__default__"
 
 _DATA = None  # type: Dict
 _CATALOG = None  # type: DataCatalog
-_JSON_NODES = {}  # type: Dict[str, Dict[str, Union[Node, AbstractDataSet, None]]
+_JSON_NODES = {}  # type: Dict[str, Dict[str, Union[Node, AbstractDataSet, None]]]
 
 app = Flask(  # pylint: disable=invalid-name
     __name__, static_folder=str(Path(__file__).parent.absolute() / "html" / "static")

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -62,16 +62,13 @@ else:
     from kedro.cli import get_project_context  # pragma: no cover
     from kedro.cli.utils import KedroCliError  # pragma: no cover
 
-
 _VIZ_PROCESSES = {}  # type: Dict[int, multiprocessing.Process]
 
 _DEFAULT_KEY = "__default__"
 
 _DATA = None  # type: Dict
 _CATALOG = None  # type: DataCatalog
-_JSON_NODES = (
-    {}
-)  # type: Dict[str, Dict[str, Union[Node, AbstractDataSet, None, Dict[str, AbstractDataSet]]]]
+_JSON_NODES = {}  # type: Dict[str, Dict[str, Union[Node, AbstractDataSet, None]]
 
 app = Flask(  # pylint: disable=invalid-name
     __name__, static_folder=str(Path(__file__).parent.absolute() / "html" / "static")
@@ -457,13 +454,13 @@ def format_pipeline_data(
         is_param = bool("param" in namespace.lower())
         node_id = _hash(namespace)
 
-        node_data = _get_dataset_data_params(namespace)
         _JSON_NODES[node_id] = {
             "type": "parameters" if is_param else "data",
-            "obj": {namespace.replace("params:", ""): node_data}
-            if is_param and "params:" in namespace
-            else node_data,
+            "obj": _get_dataset_data_params(namespace),
         }
+        if is_param and namespace != "parameters":
+            # Add "parameter_name" key only for "params:" prefix.
+            _JSON_NODES[node_id]["parameter_name"] = namespace.replace("params:", "")
 
         if node_id not in nodes:
             nodes[node_id] = {
@@ -544,17 +541,14 @@ def nodes_metadata(node_id):
         dataset_metadata = _get_dataset_metadata(node)
         return jsonify(dataset_metadata)
 
-    parameters = node["obj"]
-    if isinstance(parameters, dict):
+    if "parameter_name" in node:
         # In case of 'params:' prefix
         parameters_metadata = {
-            "parameters": {
-                next(iter(parameters)): next(iter(parameters.values())).load()
-            }
+            "parameters": {node["parameter_name"]: node["obj"].load()}
         }
-        return jsonify(parameters_metadata)
-    # In case of 'parameters'
-    parameters_metadata = {"parameters": node["obj"].load()}
+    else:
+        # In case of 'parameters'
+        parameters_metadata = {"parameters": node["obj"].load()}
     return jsonify(parameters_metadata)
 
 

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -370,7 +370,9 @@ def format_pipelines_data(pipelines: Dict[str, "Pipeline"]) -> Dict[str, list]:
 
     default_pipeline = {"id": _DEFAULT_KEY, "name": _pretty_name(_DEFAULT_KEY)}
     selected_pipeline = (
-        default_pipeline["id"] if default_pipeline in pipelines_list else pipelines_list[0]["id"]
+        default_pipeline["id"]
+        if default_pipeline in pipelines_list
+        else pipelines_list[0]["id"]
     )
 
     return {
@@ -454,7 +456,7 @@ def format_pipeline_data(
         node_id = _hash(namespace)
 
         node_data = (
-            {"type": "parameters", "obj": None}
+            _get_parameter_node(node_id, namespace)
             if is_param
             else _get_dataset_node(node_id, namespace)
         )
@@ -473,6 +475,11 @@ def format_pipeline_data(
             nodes_list.append(nodes[node_id])
         else:
             nodes[node_id]["pipelines"].append(pipeline_key)
+
+
+def _get_parameter_node(node_id, namespace):
+    parameters = _CATALOG._get_dataset(namespace)
+    return {"type": "parameters", "obj": parameters}
 
 
 def _get_dataset_node(node_id, namespace):
@@ -538,7 +545,9 @@ def nodes_metadata(node_id):
     if node["type"] == "data":
         dataset_metadata = _get_dataset_metadata(node)
         return jsonify(dataset_metadata)
-
+    if node["type"] == "parameters":
+        parameters_metadata = {"parameters": node["obj"].load()}
+        return jsonify(parameters_metadata)
     # return empty JSON for parameters type
     return jsonify({})
 

--- a/package/tests/input.json
+++ b/package/tests/input.json
@@ -26,14 +26,14 @@
         },
         {
             "source": "7366ec9f",
-            "target": "760f5b5e"
+            "target": "0340373e"
         },
         {
-            "source": "f1f1425b",
-            "target": "760f5b5e"
+            "source": "68bbc660",
+            "target": "0340373e"
         },
         {
-            "source": "760f5b5e",
+            "source": "0340373e",
             "target": "60e68b8e"
         },
         {
@@ -139,7 +139,7 @@
         },
         {
             "full_name": "func",
-            "id": "760f5b5e",
+            "id": "0340373e",
             "name": "Func",
             "pipelines": [
                 "second"
@@ -156,6 +156,17 @@
             ],
             "tags": [],
             "type": "task"
+        },
+        {
+            "full_name": "params:key",
+            "id": "68bbc660",
+            "layer": null,
+            "name": "Params:key",
+            "pipelines": [
+                "second"
+            ],
+            "tags": [],
+            "type": "parameters"
         }
     ],
     "pipelines": [
@@ -172,11 +183,11 @@
             "name": "Third"
         }
     ],
+    "selected_pipeline": "__default__",
     "tags": [
         {
             "id": "bob",
             "name": "Bob"
         }
-    ],
-    "selected_pipeline": "__default__"
+    ]
 }

--- a/package/tests/result.json
+++ b/package/tests/result.json
@@ -2,7 +2,7 @@
     "nodes": [
         {
             "type": "task",
-            "id": "71527409",
+            "id": "b2a701fc",
             "name": "Func1",
             "full_name": "func1",
             "tags": [],
@@ -44,9 +44,9 @@
         },
         {
             "type": "parameters",
-            "id": "755dc08f",
-            "name": "Params:value",
-            "full_name": "params:value",
+            "id": "68bbc660",
+            "name": "Params:key",
+            "full_name": "params:key",
             "tags": [],
             "layer": null,
             "pipelines": [
@@ -68,14 +68,14 @@
     "edges": [
         {
             "source": "7366ec9f",
-            "target": "71527409"
+            "target": "b2a701fc"
         },
         {
-            "source": "755dc08f",
-            "target": "71527409"
+            "source": "68bbc660",
+            "target": "b2a701fc"
         },
         {
-            "source": "71527409",
+            "source": "b2a701fc",
             "target": "60e68b8e"
         },
         {

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -812,7 +812,7 @@ def pipeline():
     return {
         "__default__": Pipeline(
             [
-                node(func1, ["bob_in", "params:value"], "bob_out"),
+                node(func1, ["bob_in", "params:key"], "bob_out"),
                 node(func2, "bob_out", "result"),
             ]
         )
@@ -823,7 +823,7 @@ def pipeline():
 def old_catalog_with_layers():
     data_sets = {
         "bob_in": PickleDataSet("raw.csv"),
-        "params:value": MemoryDataSet("value"),
+        "params:key": MemoryDataSet("value"),
         "result": PickleDataSet("final.csv"),
     }
     setattr(data_sets["bob_in"], "_layer", "raw")
@@ -841,7 +841,7 @@ def old_catalog_with_layers():
 def new_catalog_with_layers():
     data_sets = {
         "bob_in": PickleDataSet("raw.csv"),
-        "params:value": MemoryDataSet("value"),
+        "params:key": MemoryDataSet("value"),
         "result": PickleDataSet("final.csv"),
     }
     layers = {"raw": {"bob_in"}, "final": {"result"}}

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -66,7 +66,7 @@ def get_pipelines():
         "__default__": create_pipeline(),
         "second": Pipeline(
             [
-                node(func, ["bob_in", "parameters"], ["bob_out"]),
+                node(func, ["bob_in", "params:key"], ["bob_out"]),
                 node(func1, ["bob_out", "parameters"], None),
             ]
         ),
@@ -117,6 +117,7 @@ def patched_get_project_context(mocker, tmp_path):
             self._data_sets = {
                 "bob_in": PickleDataSet(filepath=str(tmp_path)),
                 "parameters": MemoryDataSet("value"),
+                "params:key": MemoryDataSet("value"),
             }
 
         def _describe(self):
@@ -358,7 +359,7 @@ def test_node_metadata_endpoint_task_missing_docstring(
         return_value=tmp_path / project_root / code_location,
     )
     cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
-    task_id = "760f5b5e"
+    task_id = "0340373e"
     response = client.get(f"/api/nodes/{task_id}")
     assert response.status_code == 200
     data = json.loads(response.data.decode())
@@ -428,7 +429,7 @@ def test_node_metadata_endpoint_data_kedro14(cli_runner, client, tmp_path, mocke
 
 
 @pytest.mark.usefixtures("patched_get_project_context")
-def test_node_metadata_endpoint_params(cli_runner, client):
+def test_node_metadata_endpoint_parameters(cli_runner, client):
     """Test `/api/nodes/param_id` endpoint is functional and returns an empty JSON."""
     cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
     param_id = "f1f1425b"
@@ -436,6 +437,17 @@ def test_node_metadata_endpoint_params(cli_runner, client):
     assert response.status_code == 200
     data = json.loads(response.data.decode())
     assert data == {"parameters": "value"}
+
+
+@pytest.mark.usefixtures("patched_get_project_context")
+def test_node_metadata_endpoint_param_prefix(cli_runner, client):
+    """Test `/api/nodes/param_id` with param prefix endpoint is functional and returns an empty JSON."""
+    cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
+    param_id = "68bbc660"
+    response = client.get(f"/api/nodes/{param_id}")
+    assert response.status_code == 200
+    data = json.loads(response.data.decode())
+    assert data == {"parameters": {"key": "value"}}
 
 
 @pytest.mark.usefixtures("patched_get_project_context")
@@ -458,9 +470,9 @@ def test_pipeline_flag(cli_runner, client):
     data = json.loads(response.data.decode())
     assert data == {
         "edges": [
-            {"source": "7366ec9f", "target": "760f5b5e"},
-            {"source": "f1f1425b", "target": "760f5b5e"},
-            {"source": "760f5b5e", "target": "60e68b8e"},
+            {"source": "7366ec9f", "target": "0340373e"},
+            {"source": "68bbc660", "target": "0340373e"},
+            {"source": "0340373e", "target": "60e68b8e"},
             {"source": "60e68b8e", "target": "24d754e7"},
             {"source": "f1f1425b", "target": "24d754e7"},
         ],
@@ -468,7 +480,7 @@ def test_pipeline_flag(cli_runner, client):
         "nodes": [
             {
                 "full_name": "func",
-                "id": "760f5b5e",
+                "id": "0340373e",
                 "name": "Func",
                 "pipelines": ["second"],
                 "tags": [],
@@ -505,6 +517,15 @@ def test_pipeline_flag(cli_runner, client):
                 "id": "f1f1425b",
                 "layer": None,
                 "name": "Parameters",
+                "pipelines": ["second"],
+                "tags": [],
+                "type": "parameters",
+            },
+            {
+                "full_name": "params:key",
+                "id": "68bbc660",
+                "layer": None,
+                "name": "Params:key",
                 "pipelines": ["second"],
                 "tags": [],
                 "type": "parameters",

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -114,7 +114,10 @@ def start_server(mocker):
 def patched_get_project_context(mocker, tmp_path):
     class DummyDataCatalog:
         def __init__(self):
-            self._data_sets = {"bob_in": PickleDataSet(filepath=str(tmp_path))}
+            self._data_sets = {
+                "bob_in": PickleDataSet(filepath=str(tmp_path)),
+                "parameters": MemoryDataSet("value"),
+            }
 
         def _describe(self):
             return {"filepath": str(tmp_path)}
@@ -432,7 +435,7 @@ def test_node_metadata_endpoint_params(cli_runner, client):
     response = client.get(f"/api/nodes/{param_id}")
     assert response.status_code == 200
     data = json.loads(response.data.decode())
-    assert not data
+    assert data == {"parameters": "value"}
 
 
 @pytest.mark.usefixtures("patched_get_project_context")
@@ -820,7 +823,7 @@ def pipeline():
 def old_catalog_with_layers():
     data_sets = {
         "bob_in": PickleDataSet("raw.csv"),
-        "paras:value": MemoryDataSet("value"),
+        "params:value": MemoryDataSet("value"),
         "result": PickleDataSet("final.csv"),
     }
     setattr(data_sets["bob_in"], "_layer", "raw")
@@ -838,7 +841,7 @@ def old_catalog_with_layers():
 def new_catalog_with_layers():
     data_sets = {
         "bob_in": PickleDataSet("raw.csv"),
-        "paras:value": MemoryDataSet("value"),
+        "params:value": MemoryDataSet("value"),
         "result": PickleDataSet("final.csv"),
     }
     layers = {"raw": {"bob_in"}, "final": {"result"}}


### PR DESCRIPTION
## Description

As an extension for metadata side panel, we are exposing parameters metadata to Viz. Here are examples of the endpoints and and outputs. 


`http://127.0.0.1:4141/api/nodes/d577578a` (endpoint for `params:xxx`)

```json
{
  "parameters": 0.2
}
```

`http://127.0.0.1:4141/api/nodes/f1f1425b` (endpoint for `parameters`)

```json
{
  "parameters": {
    "example_learning_rate": 0.01,
    "example_num_train_iter": 10000,
    "example_test_data_ratio": 0.2
  }
}
```

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

Modified unit tests
## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
