### PR TITLE
[KED-2187] Fix heading order

### DIFF
--- a/src/components/node-list/node-list-groups.js
+++ b/src/components/node-list/node-list-groups.js
@@ -29,7 +29,7 @@ const NodeListGroups = ({
 
   return sections.map(section => (
     <nav className="pipeline-nodelist-section kedro" key={section.name}>
-      <h4 className="pipeline-nodelist-section__title">{section.name}</h4>
+      <h2 className="pipeline-nodelist-section__title">{section.name}</h2>
       <ul className="pipeline-nodelist">
         {section.types.map(typeId => {
           const group = groups[typeId];

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -233,7 +233,3 @@
     opacity: 1;
   }
 }
-
-.pipeline-nodelist__row__checkbox {
-  @include screenReaderOnly;
-}

--- a/src/components/wrapper/index.js
+++ b/src/components/wrapper/index.js
@@ -17,6 +17,7 @@ export const Wrapper = ({ loading, theme }) => (
       'kui-theme--dark': theme === 'dark',
       'kui-theme--light': theme === 'light'
     })}>
+    <h1 className="pipeline-title">Kedro-Viz</h1>
     <Sidebar />
     <div className="pipeline-wrapper">
       <FlowChart />

--- a/src/components/wrapper/wrapper.scss
+++ b/src/components/wrapper/wrapper.scss
@@ -1,4 +1,5 @@
 @import '../../styles/variables';
+@import '../../styles/mixins';
 
 .kedro-pipeline {
   position: relative;
@@ -19,6 +20,10 @@
     color: #fff;
     background: $color-bg-dark-1;
   }
+}
+
+.pipeline-title {
+  @include screenReaderOnly;
 }
 
 .pipeline-wrapper {


### PR DESCRIPTION
## Description

I noticed an invalid heading order (h4 > h3) while running [tota11y](https://khan.github.io/tota11y/), and while fixing that I noticed a couple of other small issues so I fixed them too.
![image](https://user-images.githubusercontent.com/1155816/96253922-57fe3080-0fac-11eb-8ba1-bb808cb07e71.png)


## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
