### PR TITLE
[KED-2172] Rename pipeline.default to pipeline.main in state

### DIFF
--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -52,7 +52,7 @@ export function toggleLoading(loading) {
  * @param {object} pipeline Pipeline state
  */
 export const getPipelineUrl = pipeline => {
-  if (pipeline.active === pipeline.default) {
+  if (pipeline.active === pipeline.main) {
     return getUrl('main');
   }
   return getUrl('pipeline', pipeline.active);
@@ -71,11 +71,11 @@ export const requiresSecondRequest = (flags, pipeline) => {
   // TODO: Delete this line when removing flags.pipeline
   if (!flags.pipelines) return false;
   // Pipelines are not present in the data
-  if (!pipeline.ids.length || !pipeline.default) return false;
+  if (!pipeline.ids.length || !pipeline.main) return false;
   // There is no active pipeline set
   if (!pipeline.active) return false;
   // The active pipeline is not 'main'
-  return pipeline.active !== pipeline.default;
+  return pipeline.active !== pipeline.main;
 };
 
 /**
@@ -122,7 +122,7 @@ export function loadPipelineData(pipelineID) {
     if (asyncDataSource) {
       dispatch(toggleLoading(true));
       const url = getPipelineUrl({
-        default: pipeline.default,
+        main: pipeline.main,
         active: pipelineID
       });
       const newState = await loadJsonData(url).then(preparePipelineState);

--- a/src/actions/pipelines.test.js
+++ b/src/actions/pipelines.test.js
@@ -42,13 +42,13 @@ describe('pipeline actions', () => {
   describe('getPipelineUrl', () => {
     const id = 'abc123';
 
-    it('should return the "main" endpoint URL if active === default', () => {
-      const pipeline = { active: id, default: id };
+    it('should return the "main" endpoint URL if active === main', () => {
+      const pipeline = { active: id, main: id };
       expect(getPipelineUrl(pipeline)).toEqual(expect.stringContaining('main'));
     });
 
-    it('should return the "main" endpoint URL if active !== default', () => {
-      const pipeline = { active: id, default: '__default__' };
+    it('should return a "pipelines" endpoint URL if active !== main', () => {
+      const pipeline = { active: id, main: '__default__' };
       expect(getPipelineUrl(pipeline)).toEqual(
         expect.stringContaining(`pipelines/${id}`)
       );
@@ -68,17 +68,17 @@ describe('pipeline actions', () => {
     });
 
     it('should return false if there is no active pipeline', () => {
-      const pipeline = { ids: ['a', 'b'], default: 'a' };
+      const pipeline = { ids: ['a', 'b'], main: 'a' };
       expect(requiresSecondRequest(flags, pipeline)).toBe(false);
     });
 
-    it('should return false if the default pipeline is active', () => {
-      const pipeline = { ids: ['a', 'b'], default: 'a', active: 'a' };
+    it('should return false if the main pipeline is active', () => {
+      const pipeline = { ids: ['a', 'b'], main: 'a', active: 'a' };
       expect(requiresSecondRequest(flags, pipeline)).toBe(false);
     });
 
-    it('should return true if the default pipeline is not active', () => {
-      const pipeline = { ids: ['a', 'b'], default: 'a', active: 'b' };
+    it('should return true if the main pipeline is not active', () => {
+      const pipeline = { ids: ['a', 'b'], main: 'a', active: 'b' };
       expect(requiresSecondRequest(flags, pipeline)).toBe(true);
     });
   });
@@ -120,13 +120,13 @@ describe('pipeline actions', () => {
         const store = createStore(reducer, mockState.json);
         await loadInitialPipelineData()(store.dispatch, store.getState);
         const state = store.getState();
-        expect(state.pipeline.active).toBe(state.pipeline.default);
+        expect(state.pipeline.active).toBe(state.pipeline.main);
         expect(state.node).toEqual(mockState.animals.node);
       });
 
       it('should request data from a different dataset if the active pipeline is set', async () => {
         const { pipeline } = mockState.animals;
-        const active = pipeline.ids.find(id => id !== pipeline.default);
+        const active = pipeline.ids.find(id => id !== pipeline.main);
         saveState({ pipeline: { active } });
         const store = createStore(reducer, mockState.json);
         await loadInitialPipelineData()(store.dispatch, store.getState);
@@ -138,13 +138,13 @@ describe('pipeline actions', () => {
         const store = createStore(reducer, mockState.json);
         await loadInitialPipelineData()(store.dispatch, store.getState);
         const state = store.getState();
-        expect(state.pipeline.active).toBe(state.pipeline.default);
+        expect(state.pipeline.active).toBe(state.pipeline.main);
         expect(state.node).toEqual(mockState.animals.node);
       });
 
       it("shouldn't make a second data request if the pipeline flag is false", async () => {
         const { pipeline } = mockState.animals;
-        const active = pipeline.ids.find(id => id !== pipeline.default);
+        const active = pipeline.ids.find(id => id !== pipeline.main);
         saveState({ pipeline: { active } });
         const state = reducer(mockState.json, changeFlag('pipelines', false));
         const store = createStore(reducer, state);
@@ -155,7 +155,7 @@ describe('pipeline actions', () => {
       it("shouldn't make a second data request if the dataset doesn't support pipelines", async () => {
         window.deletePipelines = true; // pass option to load-data mock
         const { pipeline } = mockState.animals;
-        const active = pipeline.ids.find(id => id !== pipeline.default);
+        const active = pipeline.ids.find(id => id !== pipeline.main);
         saveState({ pipeline: { active } });
         const store = createStore(reducer, mockState.json);
         await loadInitialPipelineData()(store.dispatch, store.getState);

--- a/src/components/pipeline-list/pipeline-list.test.js
+++ b/src/components/pipeline-list/pipeline-list.test.js
@@ -26,7 +26,7 @@ describe('PipelineList', () => {
     expect(mapStateToProps(mockState.animals)).toEqual({
       pipeline: {
         active: expect.any(String),
-        default: expect.any(String),
+        main: expect.any(String),
         name: expect.any(Object),
         ids: expect.any(Array)
       },

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -59,9 +59,9 @@ export const mergeLocalStorage = state => {
 export const preparePipelineState = (data, applyFixes) => {
   const state = mergeLocalStorage(normalizeData(data));
   if (applyFixes) {
-    // Use default pipeline if active pipeline from localStorage isn't recognised
+    // Use main pipeline if active pipeline from localStorage isn't recognised
     if (!state.pipeline.ids.includes(state.pipeline.active)) {
-      state.pipeline.active = state.pipeline.default;
+      state.pipeline.active = state.pipeline.main;
     }
   }
   return state;

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -172,8 +172,8 @@ const normalizeData = data => {
   if (data.pipelines) {
     data.pipelines.forEach(addPipeline(state));
     if (state.pipeline.ids.length) {
-      state.pipeline.default = data.selected_pipeline || state.pipeline.ids[0];
-      state.pipeline.active = state.pipeline.default;
+      state.pipeline.main = data.selected_pipeline || state.pipeline.ids[0];
+      state.pipeline.active = state.pipeline.main;
     }
   }
   if (data.tags) {


### PR DESCRIPTION
## Description

'Main' is a better name for this prop, because 'default' has a specific meaning in Kedro. We're using 'main' for the endpoint, so it makes sense to use the same name for the prop.

## Development notes

I also renamed a test which had a name that was wrong

## QA notes

No visible changes

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
