### PR TITLE
Fix chart rendering edge cases and hover styles

### DIFF
--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -13,10 +13,6 @@
   .kui-theme--dark & {
     fill: $color-light;
   }
-
-  .pipeline-icon-toolbar__button:hover & {
-    opacity: 1;
-  }
 }
 
 .pipeline-icon--stroke {

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -180,8 +180,12 @@ export const drawNodes = function(changed) {
       .duration(this.DURATION)
       .attr('transform', node => `translate(${node.x}, ${node.y})`)
       .on('end', () => {
-        // Sort nodes so tab focus order follows X/Y position
-        allNodes.sort((a, b) => a.order - b.order);
+        try {
+          // Sort nodes so tab focus order follows X/Y position
+          allNodes.sort((a, b) => a.order - b.order);
+        } catch (ex) {
+          // Avoid rare DOM errors thrown due to timing issues
+        }
       });
 
     enterNodes.select('rect').call(updateNodeRects);

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -266,8 +266,10 @@ export const drawEdges = function(changed) {
   if (changed('edges', 'centralNode', 'linkedNodes')) {
     allEdges.classed(
       'pipeline-edge--faded',
-      ({ source, target }) =>
-        centralNode && (!linkedNodes[source] || !linkedNodes[target])
+      edge =>
+        edge &&
+        centralNode &&
+        (!linkedNodes[edge.source] || !linkedNodes[edge.target])
     );
   }
 };

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -183,7 +183,7 @@ export const drawNodes = function(changed) {
         try {
           // Sort nodes so tab focus order follows X/Y position
           allNodes.sort((a, b) => a.order - b.order);
-        } catch (ex) {
+        } catch (err) {
           // Avoid rare DOM errors thrown due to timing issues
         }
       });

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -28,6 +28,10 @@
     }
   }
 
+  &:hover svg {
+    opacity: 1;
+  }
+
   &:disabled {
     cursor: not-allowed;
 


### PR DESCRIPTION
## Description

Fixes two rare errors with chart rendering, that are likely due to timing edge cases.

Also fixes sidebar hover styling for disabled buttons.

## Development notes

As above.

## QA notes

The errors themselves are hard to reproduce, but they seem to mostly occur in Safari, after rapidly applying filters on the sidebar in random order.

To test the sidebar issue, load a graph with no layers such that the layers button is disabled. Hovering should no longer cause this or other disabled buttons to highlight.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
