### PR TITLE
[KED-2222] Don't run eslint against .json files on pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
       "prettier --single-quote --write",
       "git add"
     ],
-    "src/**/*.{js,jsx,ts,tsx,json}": [
+    "src/**/*.{js,jsx,ts,tsx}": [
       "eslint src/ --fix",
       "git add"
     ]


### PR DESCRIPTION
## Description

ESLint is for validating JavaScript, not JSON

## Development notes

Fixes pre-commit errors on the new testing .json files

## QA notes

I tried committing a change to a .json file, it works now

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
