### PR TITLE
[KED-2181] Deprecate pipelines flag

### DIFF
--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -14,7 +14,6 @@ import { resetData } from './index';
  * 4. Whether localStorage has an active pipeline already defined.
  * 5. If so, whether it exists in the current dataset.
  * 6. Whether the requested endpoint is the 'main' one, or not.
- * 7. Whether the pipeline flag is disabled.
  *
  * These are mostly handled either within this file, in the preparePipelineState
  * utility, or in the getNodeDisabledPipeline selector. Please see their tests
@@ -62,14 +61,10 @@ export const getPipelineUrl = pipeline => {
  * Check whether another async data pipeline request is needed on first page-load.
  * A second request is typically only required when an active pipeline is set in
  * localStorage, and it's not the 'main' pipeline endpoint.
- * @param {object} flags Flag state
  * @param {object} pipeline Pipeline state
  * @return {boolean} True if another request is needed
  */
-export const requiresSecondRequest = (flags, pipeline) => {
-  // Pipelines are disabled via flags
-  // TODO: Delete this line when removing flags.pipeline
-  if (!flags.pipelines) return false;
+export const requiresSecondRequest = pipeline => {
   // Pipelines are not present in the data
   if (!pipeline.ids.length || !pipeline.main) return false;
   // There is no active pipeline set
@@ -99,7 +94,7 @@ export function loadInitialPipelineData() {
       preparePipelineState(data, true)
     );
     // If the active pipeline isn't 'main' then request data from new URL
-    if (requiresSecondRequest(state.flags, newState.pipeline)) {
+    if (requiresSecondRequest(newState.pipeline)) {
       const url = getPipelineUrl(newState.pipeline);
       newState = await loadJsonData(url).then(preparePipelineState);
     }

--- a/src/actions/pipelines.test.js
+++ b/src/actions/pipelines.test.js
@@ -1,6 +1,5 @@
 import { createStore } from 'redux';
 import reducer from '../reducers';
-import { changeFlag } from './index';
 import { mockState } from '../utils/state.mock';
 import { saveState } from '../store/helpers';
 import {
@@ -56,30 +55,24 @@ describe('pipeline actions', () => {
   });
 
   describe('requiresSecondRequest', () => {
-    it('should return false if the pipelines flag is false', () => {
-      expect(requiresSecondRequest({ pipelines: false }, {})).toBe(false);
-    });
-
-    const flags = { pipelines: true };
-
     it('should return false if pipelines are not present in the data', () => {
       const pipeline = { ids: [], active: 'a' };
-      expect(requiresSecondRequest(flags, pipeline)).toBe(false);
+      expect(requiresSecondRequest(pipeline)).toBe(false);
     });
 
     it('should return false if there is no active pipeline', () => {
       const pipeline = { ids: ['a', 'b'], main: 'a' };
-      expect(requiresSecondRequest(flags, pipeline)).toBe(false);
+      expect(requiresSecondRequest(pipeline)).toBe(false);
     });
 
     it('should return false if the main pipeline is active', () => {
       const pipeline = { ids: ['a', 'b'], main: 'a', active: 'a' };
-      expect(requiresSecondRequest(flags, pipeline)).toBe(false);
+      expect(requiresSecondRequest(pipeline)).toBe(false);
     });
 
     it('should return true if the main pipeline is not active', () => {
       const pipeline = { ids: ['a', 'b'], main: 'a', active: 'b' };
-      expect(requiresSecondRequest(flags, pipeline)).toBe(true);
+      expect(requiresSecondRequest(pipeline)).toBe(true);
     });
   });
 
@@ -140,16 +133,6 @@ describe('pipeline actions', () => {
         const state = store.getState();
         expect(state.pipeline.active).toBe(state.pipeline.main);
         expect(state.node).toEqual(mockState.animals.node);
-      });
-
-      it("shouldn't make a second data request if the pipeline flag is false", async () => {
-        const { pipeline } = mockState.animals;
-        const active = pipeline.ids.find(id => id !== pipeline.main);
-        saveState({ pipeline: { active } });
-        const state = reducer(mockState.json, changeFlag('pipelines', false));
-        const store = createStore(reducer, state);
-        await loadInitialPipelineData()(store.dispatch, store.getState);
-        expect(store.getState().node).toEqual(mockState.animals.node);
       });
 
       it("shouldn't make a second data request if the dataset doesn't support pipelines", async () => {

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -10,10 +10,9 @@ import './sidebar.css';
 
 /**
  * Main app container. Handles showing/hiding the sidebar nav, and theme classes.
- * @param {object} props.flags Feature flags from URL/localStorage
  * @param {boolean} props.visible Whether the sidebar is open/closed
  */
-export const Sidebar = ({ flags, visible }) => {
+export const Sidebar = ({ visible }) => {
   const [pipelineIsOpen, togglePipeline] = useState(false);
 
   return (
@@ -23,7 +22,7 @@ export const Sidebar = ({ flags, visible }) => {
           'pipeline-sidebar--visible': visible
         })}>
         <div className="pipeline-ui">
-          {flags.pipelines && <PipelineList onToggleOpen={togglePipeline} />}
+          <PipelineList onToggleOpen={togglePipeline} />
           <NodeList faded={pipelineIsOpen} />
         </div>
         <nav className="pipeline-toolbar">
@@ -37,7 +36,6 @@ export const Sidebar = ({ flags, visible }) => {
 };
 
 const mapStateToProps = state => ({
-  flags: state.flags,
   visible: state.visible.sidebar
 });
 

--- a/src/config.js
+++ b/src/config.js
@@ -24,11 +24,6 @@ export const flags = {
     default: false,
     icon: '📈'
   },
-  pipelines: {
-    description: 'Select from multiple pipelines',
-    default: typeof jest !== 'undefined',
-    icon: '🔀'
-  },
   meta: {
     description: 'Show the metadata panel',
     default: false,

--- a/src/selectors/pipeline.js
+++ b/src/selectors/pipeline.js
@@ -6,21 +6,14 @@ const getNodePipelines = state => state.node.pipelines;
 const getActivePipeline = state => state.pipeline.active;
 const getNodeTags = state => state.node.tags;
 const getAsyncDataSource = state => state.asyncDataSource;
-const getPipelineFlag = state => state.flags.pipelines;
 
 /**
  * Calculate whether nodes should be disabled based on their tags
  */
 export const getNodeDisabledPipeline = createSelector(
-  [
-    getNodeIDs,
-    getNodePipelines,
-    getActivePipeline,
-    getAsyncDataSource,
-    getPipelineFlag
-  ],
-  (nodeIDs, nodePipelines, activePipeline, asyncDataSource, pipelineFlag) => {
-    if (asyncDataSource || !activePipeline || !pipelineFlag) {
+  [getNodeIDs, getNodePipelines, getActivePipeline, getAsyncDataSource],
+  (nodeIDs, nodePipelines, activePipeline, asyncDataSource) => {
+    if (asyncDataSource || !activePipeline) {
       return {};
     }
     return arrayToObject(

--- a/src/selectors/pipeline.test.js
+++ b/src/selectors/pipeline.test.js
@@ -6,7 +6,6 @@ import {
   getPipelineTagIDs
 } from './pipeline';
 import reducer from '../reducers';
-import { changeFlag } from '../actions';
 import { updateActivePipeline } from '../actions/pipelines';
 
 const getNodeIDs = state => state.node.ids;
@@ -82,14 +81,6 @@ describe('Selectors', () => {
       const newMockState = reducer(
         mockState.animals,
         updateActivePipeline(undefined)
-      );
-      expect(getNodeDisabledPipeline(newMockState)).toEqual({});
-    });
-
-    it('does not disable any nodes if the pipelines flag is false', () => {
-      const newMockState = reducer(
-        mockState.animals,
-        changeFlag('pipelines', false)
       );
       expect(getNodeDisabledPipeline(newMockState)).toEqual({});
     });

--- a/src/store/initial-state.test.js
+++ b/src/store/initial-state.test.js
@@ -78,8 +78,7 @@ describe('prepareNonPipelineState', () => {
     // In this case, location.href is not provided
     expect(prepareNonPipelineState({ data: animals })).toMatchObject({
       flags: {
-        newgraph: expect.any(Boolean),
-        pipelines: expect.any(Boolean)
+        newgraph: expect.any(Boolean)
       }
     });
   });


### PR DESCRIPTION
## Description

The feature flag was being used to allow us to work on this feature while it was still a work-in-progress, and have releases go out without it being ready, so that it was hidden from users.

This PR is to remove the flag, so that this feature can be officially released. This should be merged only once the new modular pipelines selector is ready to ship


## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
