### PR TITLE
[KED-2166] Add additional fields to meta data panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lib"
   ],
   "homepage": ".",
+  "proxy": "http://localhost:4142/",
   "scripts": {
     "build": "npm run build:css && react-scripts build",
     "build:css": "node-sass src/ -o src/",

--- a/src/components/metadata/index.js
+++ b/src/components/metadata/index.js
@@ -21,6 +21,7 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
   const [showCopied, setShowCopied] = useState(false);
 
   const isTaskNode = metadata?.node.type === 'task';
+  const isDataNode = metadata?.node.type === 'data';
 
   const onCopyClick = () => {
     window.navigator.clipboard.writeText(metadata.runCommand);
@@ -55,6 +56,18 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
       </div>
       <dl className="pipeline-metadata__list">
         <MetaDataRow label="Type:" value={metadata.node.type} />
+        <MetaDataRow
+          label="File Path:"
+          visible={isDataNode}
+          value={metadata.filePath}
+        />
+        <MetaDataRow
+          label={`Parameters (${metadata.parameters.length}):`}
+          visible={isTaskNode}
+          commas={false}
+          inline={false}
+          value={metadata.parameters}
+        />
         <MetaDataRow
           label="Inputs:"
           property="name"
@@ -109,6 +122,12 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
             )}
           </div>
         </MetaDataRow>
+        <MetaDataRow
+          label="Description (docstring)"
+          visible={isTaskNode}
+          value={metadata.description}
+        />
+        <MetaDataRow label="Location of code in Kedro:" value={metadata.path} />
       </dl>
     </div>
   );

--- a/src/components/metadata/index.js
+++ b/src/components/metadata/index.js
@@ -21,6 +21,7 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
   const [showCopied, setShowCopied] = useState(false);
 
   const isTaskNode = metadata?.node.type === 'task';
+  const isParametersNode = metadata?.node.type === 'parameters';
   const isDataNode = metadata?.node.type === 'data';
 
   const onCopyClick = () => {
@@ -65,7 +66,7 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
         <MetaDataRow label="File Path:" kind="path" value={metadata.filepath} />
         <MetaDataRow
           label={`Parameters (${metadata.parameters?.length || '-'}):`}
-          visible={isTaskNode}
+          visible={isParametersNode || isTaskNode}
           commas={false}
           inline={false}
           value={metadata.parameters}
@@ -129,7 +130,6 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
           visible={isTaskNode}
           value={metadata.docstring}
         />
-        <MetaDataRow label="Code:" visible={isTaskNode} value={metadata.code} />
       </dl>
     </div>
   );

--- a/src/components/metadata/index.js
+++ b/src/components/metadata/index.js
@@ -59,9 +59,10 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
         <MetaDataRow
           label="Dataset Type:"
           visible={isDataNode}
+          kind="type"
           value={metadata.datasetType}
         />
-        <MetaDataRow label="File Path:" value={metadata.filepath} />
+        <MetaDataRow label="File Path:" kind="path" value={metadata.filepath} />
         <MetaDataRow
           label={`Parameters (${metadata.parameters?.length || '-'}):`}
           visible={isTaskNode}

--- a/src/components/metadata/index.js
+++ b/src/components/metadata/index.js
@@ -57,12 +57,13 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
       <dl className="pipeline-metadata__list">
         <MetaDataRow label="Type:" value={metadata.node.type} />
         <MetaDataRow
-          label="File Path:"
+          label="Dataset Type:"
           visible={isDataNode}
-          value={metadata.filePath}
+          value={metadata.datasetType}
         />
+        <MetaDataRow label="File Path:" value={metadata.filepath} />
         <MetaDataRow
-          label={`Parameters (${metadata.parameters.length}):`}
+          label={`Parameters (${metadata.parameters?.length || '-'}):`}
           visible={isTaskNode}
           commas={false}
           inline={false}
@@ -123,11 +124,11 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
           </div>
         </MetaDataRow>
         <MetaDataRow
-          label="Description (docstring)"
+          label="Description (docstring):"
           visible={isTaskNode}
-          value={metadata.description}
+          value={metadata.docstring}
         />
-        <MetaDataRow label="Location of code in Kedro:" value={metadata.path} />
+        <MetaDataRow label="Code:" visible={isTaskNode} value={metadata.code} />
       </dl>
     </div>
   );

--- a/src/components/metadata/index.js
+++ b/src/components/metadata/index.js
@@ -70,6 +70,7 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
           commas={false}
           inline={false}
           value={metadata.parameters}
+          limit={10}
         />
         <MetaDataRow
           label="Inputs:"

--- a/src/components/metadata/metadata-list.js
+++ b/src/components/metadata/metadata-list.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import modifiers from '../../utils/modifiers';
 import MetaDataValue from './metadata-value';
 import './styles/metadata.css';
@@ -15,7 +15,8 @@ const MetaDataList = ({
   commas = true,
   limit = false
 }) => {
-  const showValues = limit ? values.slice(0, limit) : values;
+  const [expanded, setExpanded] = useState(false);
+  const showValues = !expanded && limit ? values.slice(0, limit) : values;
   const remainder = values.length - showValues.length;
 
   return values.length > 0 ? (
@@ -36,9 +37,12 @@ const MetaDataList = ({
         ))}
       </ul>
       {remainder > 0 ? (
-        <span className="pipeline-metadata__value-list-remainder">
+        <button
+          className="pipeline-metadata__value-list-expand"
+          aria-expanded={expanded}
+          onClick={() => setExpanded(true)}>
           + {remainder} more
-        </span>
+        </button>
       ) : null}
     </>
   ) : (

--- a/src/components/metadata/metadata-list.js
+++ b/src/components/metadata/metadata-list.js
@@ -12,26 +12,38 @@ const MetaDataList = ({
   kind = 'text',
   empty = '-',
   inline = true,
-  commas = true
-}) =>
-  values.length > 0 ? (
-    <ul
-      className={modifiers('pipeline-metadata__value-list', {
-        inline,
-        commas
-      })}>
-      {values.map((item, index) => (
-        <li key={index}>
-          <MetaDataValue
-            value={property ? item[property] : item}
-            kind={kind}
-            empty={empty}
-          />
-        </li>
-      ))}
-    </ul>
+  commas = true,
+  limit = false
+}) => {
+  const showValues = limit ? values.slice(0, limit) : values;
+  const remainder = values.length - showValues.length;
+
+  return values.length > 0 ? (
+    <>
+      <ul
+        className={modifiers('pipeline-metadata__value-list', {
+          inline,
+          commas
+        })}>
+        {showValues.map((item, index) => (
+          <li key={index}>
+            <MetaDataValue
+              value={property ? item[property] : item}
+              kind={kind}
+              empty={empty}
+            />
+          </li>
+        ))}
+      </ul>
+      {remainder > 0 ? (
+        <span className="pipeline-metadata__value-list-remainder">
+          + {remainder} more
+        </span>
+      ) : null}
+    </>
   ) : (
     <MetaDataValue empty={empty} />
   );
+};
 
 export default MetaDataList;

--- a/src/components/metadata/metadata-row.js
+++ b/src/components/metadata/metadata-row.js
@@ -15,6 +15,7 @@ const MetaDataRow = ({
   visible = true,
   inline = true,
   commas = true,
+  limit = false,
   children
 }) => {
   const showList = Array.isArray(value);
@@ -32,6 +33,7 @@ const MetaDataRow = ({
               kind={kind}
               empty={empty}
               values={value}
+              limit={limit}
             />
           )}
           {!showList && !children && (

--- a/src/components/metadata/metadata-row.js
+++ b/src/components/metadata/metadata-row.js
@@ -34,7 +34,7 @@ const MetaDataRow = ({
               values={value}
             />
           )}
-          {!showList && (
+          {!showList && !children && (
             <MetaDataValue value={value} kind={kind} empty={empty} />
           )}
           {children}

--- a/src/components/metadata/metadata-row.js
+++ b/src/components/metadata/metadata-row.js
@@ -18,7 +18,6 @@ const MetaDataRow = ({
   children
 }) => {
   const showList = Array.isArray(value);
-  const showValue = !showList && typeof value !== 'undefined';
 
   return (
     visible && (
@@ -35,7 +34,7 @@ const MetaDataRow = ({
               values={value}
             />
           )}
-          {showValue && (
+          {!showList && (
             <MetaDataValue value={value} kind={kind} empty={empty} />
           )}
           {children}

--- a/src/components/metadata/metadata-value.js
+++ b/src/components/metadata/metadata-value.js
@@ -13,6 +13,7 @@ const MetaDataValue = ({
   empty
 }) => (
   <Container
+    title={value}
     className={modifiers('pipeline-metadata__value', { kind }, className)}>
     {!value && value !== 0 ? empty : value}
   </Container>

--- a/src/components/metadata/metadata.test.js
+++ b/src/components/metadata/metadata.test.js
@@ -4,7 +4,9 @@ import { getClickedNodeMetaData } from '../../selectors/metadata';
 import { setup, mockState } from '../../utils/state.mock';
 import { addEdgeLinks } from '../../utils/graph/graph';
 
-const salmonNodeId = '443cf06a';
+const salmonTaskNodeId = '443cf06a';
+const catDatasetNodeId = '9d989e8d';
+const rabbitParamsNodeId = 'c38d4c6a';
 
 describe('MetaData', () => {
   // Add edge links, can be removed when new graph is default
@@ -28,71 +30,194 @@ describe('MetaData', () => {
     // Using attribute since traversal by sibling not supported
     wrapper.find(`.pipeline-metadata__row[data-label="${label}"]`);
 
-  it('shows the node type as an icon', () => {
-    const wrapper = mount({ nodeId: salmonNodeId });
-    expect(rowIcon(wrapper).hasClass('pipeline-node-icon--type-task')).toBe(
-      true
-    );
+  describe('Task nodes', () => {
+    it('shows the node type as an icon', () => {
+      const wrapper = mount({ nodeId: salmonTaskNodeId });
+      expect(rowIcon(wrapper).hasClass('pipeline-node-icon--type-task')).toBe(
+        true
+      );
+    });
+
+    it('shows the node name as the title', () => {
+      const wrapper = mount({ nodeId: salmonTaskNodeId });
+      expect(textOf(title(wrapper))).toEqual(['salmon']);
+    });
+
+    it('shows the node type as text', () => {
+      const wrapper = mount({ nodeId: salmonTaskNodeId });
+      const row = rowByLabel(wrapper, 'Type:');
+      expect(textOf(rowValue(row))).toEqual(['task']);
+    });
+
+    it('shows the node parameters', () => {
+      const wrapper = mount({ nodeId: salmonTaskNodeId });
+      const row = rowByLabel(wrapper, 'Parameters (-):');
+      expect(textOf(rowValue(row))).toEqual(['-']);
+    });
+
+    it('shows the node inputs', () => {
+      const wrapper = mount({ nodeId: salmonTaskNodeId });
+      const row = rowByLabel(wrapper, 'Inputs:');
+      expect(textOf(rowValue(row))).toEqual([
+        'Cat',
+        'Dog',
+        'Parameters',
+        'Params:rabbit'
+      ]);
+    });
+
+    it('shows the node outputs', () => {
+      const wrapper = mount({ nodeId: salmonTaskNodeId });
+      const row = rowByLabel(wrapper, 'Outputs:');
+      expect(textOf(rowValue(row))).toEqual(['Horse', 'Sheep']);
+    });
+
+    it('shows the node tags', () => {
+      const wrapper = mount({ nodeId: salmonTaskNodeId });
+      const row = rowByLabel(wrapper, 'Tags:');
+      expect(textOf(rowValue(row))).toEqual(['Small']);
+    });
+
+    it('shows the node pipeline', () => {
+      const wrapper = mount({ nodeId: salmonTaskNodeId });
+      const row = rowByLabel(wrapper, 'Pipeline:');
+      expect(textOf(rowValue(row))).toEqual(['Default']);
+    });
+
+    it('shows the node run command', () => {
+      const wrapper = mount({ nodeId: salmonTaskNodeId });
+      const row = rowByLabel(wrapper, 'Run Command:');
+      expect(textOf(rowValue(row))).toEqual(['kedro run --to-nodes salmon']);
+    });
+
+    it('shows the node docstring', () => {
+      const wrapper = mount({ nodeId: salmonTaskNodeId });
+      const row = rowByLabel(wrapper, 'Description (docstring):');
+      expect(textOf(rowValue(row))).toEqual(['-']);
+    });
+
+    it('copies run command when button clicked', () => {
+      window.navigator.clipboard = {
+        writeText: jest.fn()
+      };
+
+      const wrapper = mount({ nodeId: salmonTaskNodeId });
+      const copyButton = wrapper.find('button.pipeline-metadata__copy-button');
+
+      copyButton.simulate('click');
+
+      expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+        'kedro run --to-nodes salmon'
+      );
+    });
   });
 
-  it('shows the node name as the title', () => {
-    const wrapper = mount({ nodeId: salmonNodeId });
-    expect(textOf(title(wrapper))).toEqual(['salmon']);
+  describe('Dataset nodes', () => {
+    it('shows the node type as an icon', () => {
+      const wrapper = mount({ nodeId: catDatasetNodeId });
+      expect(rowIcon(wrapper).hasClass('pipeline-node-icon--type-data')).toBe(
+        true
+      );
+    });
+
+    it('shows the node name as the title', () => {
+      const wrapper = mount({ nodeId: catDatasetNodeId });
+      expect(textOf(title(wrapper))).toEqual(['Cat']);
+    });
+
+    it('shows the node type as text', () => {
+      const wrapper = mount({ nodeId: catDatasetNodeId });
+      const row = rowByLabel(wrapper, 'Type:');
+      expect(textOf(rowValue(row))).toEqual(['data']);
+    });
+
+    it('shows the node dataset type', () => {
+      const wrapper = mount({ nodeId: catDatasetNodeId });
+      const row = rowByLabel(wrapper, 'Dataset Type:');
+      expect(textOf(rowValue(row))).toEqual(['-']);
+    });
+
+    it('shows the node filepath', () => {
+      const wrapper = mount({ nodeId: catDatasetNodeId });
+      const row = rowByLabel(wrapper, 'File Path:');
+      expect(textOf(rowValue(row))).toEqual(['-']);
+    });
+
+    it('shows the node tags', () => {
+      const wrapper = mount({ nodeId: catDatasetNodeId });
+      const row = rowByLabel(wrapper, 'Tags:');
+      expect(textOf(rowValue(row))).toEqual(['Large', 'Medium', 'Small']);
+    });
+
+    it('shows the node pipeline', () => {
+      const wrapper = mount({ nodeId: catDatasetNodeId });
+      const row = rowByLabel(wrapper, 'Pipeline:');
+      expect(textOf(rowValue(row))).toEqual(['Default']);
+    });
+
+    it('shows the node run command', () => {
+      const wrapper = mount({ nodeId: catDatasetNodeId });
+      const row = rowByLabel(wrapper, 'Run Command:');
+      expect(textOf(rowValue(row))).toEqual(['kedro run --to-inputs cat']);
+    });
+
+    it('copies run command when button clicked', () => {
+      window.navigator.clipboard = {
+        writeText: jest.fn()
+      };
+
+      const wrapper = mount({ nodeId: catDatasetNodeId });
+      const copyButton = wrapper.find('button.pipeline-metadata__copy-button');
+
+      copyButton.simulate('click');
+
+      expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+        'kedro run --to-inputs cat'
+      );
+    });
   });
 
-  it('shows the node type as text', () => {
-    const wrapper = mount({ nodeId: salmonNodeId });
-    const row = rowByLabel(wrapper, 'Type:');
-    expect(textOf(rowValue(row))).toEqual(['task']);
-  });
+  describe('Parameter nodes', () => {
+    it('shows the node type as an icon', () => {
+      const wrapper = mount({ nodeId: rabbitParamsNodeId });
+      expect(
+        rowIcon(wrapper).hasClass('pipeline-node-icon--type-parameters')
+      ).toBe(true);
+    });
 
-  it('shows the node inputs', () => {
-    const wrapper = mount({ nodeId: salmonNodeId });
-    const row = rowByLabel(wrapper, 'Inputs:');
-    expect(textOf(rowValue(row))).toEqual([
-      'Cat',
-      'Dog',
-      'Parameters',
-      'Params:rabbit'
-    ]);
-  });
+    it('shows the node name as the title', () => {
+      const wrapper = mount({ nodeId: rabbitParamsNodeId });
+      expect(textOf(title(wrapper))).toEqual(['Params:rabbit']);
+    });
 
-  it('shows the node outputs', () => {
-    const wrapper = mount({ nodeId: salmonNodeId });
-    const row = rowByLabel(wrapper, 'Outputs:');
-    expect(textOf(rowValue(row))).toEqual(['Horse', 'Sheep']);
-  });
+    it('shows the node type as text', () => {
+      const wrapper = mount({ nodeId: rabbitParamsNodeId });
+      const row = rowByLabel(wrapper, 'Type:');
+      expect(textOf(rowValue(row))).toEqual(['parameters']);
+    });
 
-  it('shows the node tags', () => {
-    const wrapper = mount({ nodeId: salmonNodeId });
-    const row = rowByLabel(wrapper, 'Tags:');
-    expect(textOf(rowValue(row))).toEqual(['Small']);
-  });
+    it('shows the node filepath', () => {
+      const wrapper = mount({ nodeId: rabbitParamsNodeId });
+      const row = rowByLabel(wrapper, 'File Path:');
+      expect(textOf(rowValue(row))).toEqual(['-']);
+    });
 
-  it('shows the node pipeline', () => {
-    const wrapper = mount({ nodeId: salmonNodeId });
-    const row = rowByLabel(wrapper, 'Pipeline:');
-    expect(textOf(rowValue(row))).toEqual(['Default']);
-  });
+    it('shows the node parameters', () => {
+      const wrapper = mount({ nodeId: rabbitParamsNodeId });
+      const row = rowByLabel(wrapper, 'Parameters (-):');
+      expect(textOf(rowValue(row))).toEqual(['-']);
+    });
 
-  it('shows the node run command', () => {
-    const wrapper = mount({ nodeId: salmonNodeId });
-    const row = rowByLabel(wrapper, 'Run Command:');
-    expect(textOf(rowValue(row))).toEqual(['kedro run --to-nodes salmon']);
-  });
+    it('shows the node tags', () => {
+      const wrapper = mount({ nodeId: rabbitParamsNodeId });
+      const row = rowByLabel(wrapper, 'Tags:');
+      expect(textOf(rowValue(row))).toEqual(['Small']);
+    });
 
-  it('copies run command when button clicked', () => {
-    window.navigator.clipboard = {
-      writeText: jest.fn()
-    };
-
-    const wrapper = mount({ nodeId: salmonNodeId });
-    const copyButton = wrapper.find('button.pipeline-metadata__copy-button');
-
-    copyButton.simulate('click');
-
-    expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-      'kedro run --to-nodes salmon'
-    );
+    it('shows the node pipeline', () => {
+      const wrapper = mount({ nodeId: rabbitParamsNodeId });
+      const row = rowByLabel(wrapper, 'Pipeline:');
+      expect(textOf(rowValue(row))).toEqual(['Default']);
+    });
   });
 });

--- a/src/components/metadata/metadata.test.js
+++ b/src/components/metadata/metadata.test.js
@@ -30,6 +30,38 @@ describe('MetaData', () => {
     // Using attribute since traversal by sibling not supported
     wrapper.find(`.pipeline-metadata__row[data-label="${label}"]`);
 
+  describe('All nodes', () => {
+    it('limits parameters to 10 values and expands when button clicked', () => {
+      // Get metadata for a sample
+      mockState.animals.node.clicked = salmonTaskNodeId;
+      const metadata = getClickedNodeMetaData(mockState.animals);
+
+      // Add extra mock parameters
+      metadata.parameters = Array.from({ length: 20 }, (_, i) => `Test: ${i}`);
+
+      const wrapper = setup.mount(
+        <MetaData visible={true} metadata={metadata} />
+      );
+
+      const parametersRow = () => rowByLabel(wrapper, 'Parameters (20):');
+      const expandButton = parametersRow().find(
+        '.pipeline-metadata__value-list-expand'
+      );
+
+      // Expand button should show remainder
+      expect(expandButton.text()).toBe('+ 10 more');
+
+      // Should show 10 values
+      expect(parametersRow().find('.pipeline-metadata__value').length).toBe(10);
+
+      // User clicks to expand
+      expandButton.simulate('click');
+
+      // Should show all 20 values
+      expect(parametersRow().find('.pipeline-metadata__value').length).toBe(20);
+    });
+  });
+
   describe('Task nodes', () => {
     it('shows the node type as an icon', () => {
       const wrapper = mount({ nodeId: salmonTaskNodeId });

--- a/src/components/metadata/styles/metadata.scss
+++ b/src/components/metadata/styles/metadata.scss
@@ -127,6 +127,12 @@
   }
 }
 
+.pipeline-metadata__value-list-remainder {
+  display: block;
+  margin: 0.4em 0 0 0;
+  opacity: 0.45;
+}
+
 .pipeline-metadata__value-list--no-inline {
   margin: 0;
   padding: 0;

--- a/src/components/metadata/styles/metadata.scss
+++ b/src/components/metadata/styles/metadata.scss
@@ -127,10 +127,23 @@
   }
 }
 
-.pipeline-metadata__value-list-remainder {
+.pipeline-metadata__value-list-expand {
   display: block;
-  margin: 0.4em 0 0 0;
+  margin: 0.6em 0 0 0;
+  padding: 0 0 0.12em 0;
+  color: var(--color-text);
+  font-size: 0.96em;
+  background: none;
+  border: 0;
+  border-bottom: 1px solid transparent;
+  cursor: pointer;
   opacity: 0.45;
+  appearance: none;
+
+  &:hover {
+    border-bottom-color: var(--color-text);
+    opacity: 0.55;
+  }
 }
 
 .pipeline-metadata__value-list--no-inline {

--- a/src/components/metadata/styles/metadata.scss
+++ b/src/components/metadata/styles/metadata.scss
@@ -103,6 +103,16 @@
   word-break: break-word;
 }
 
+.pipeline-metadata__value--kind-type,
+.pipeline-metadata__value--kind-path {
+  display: block;
+  overflow: hidden;
+  direction: rtl;
+  white-space: nowrap;
+  text-align: left;
+  text-overflow: ellipsis;
+}
+
 .pipeline-metadata__value--kind-token {
   display: inline-block;
   padding: 0.18em 0.6em 0.2em 0.6em;

--- a/src/components/metadata/styles/metadata.scss
+++ b/src/components/metadata/styles/metadata.scss
@@ -117,6 +117,24 @@
   }
 }
 
+.pipeline-metadata__value-list--no-inline {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.pipeline-metadata__value-list--no-inline li {
+  position: relative;
+  margin-left: 1em;
+
+  &:before {
+    position: absolute;
+    margin-left: -1em;
+    // For small square bullets
+    content: '▪';
+  }
+}
+
 $list-inline-spacing: 0.2em;
 
 .pipeline-metadata__value-list--inline {

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -36,6 +36,21 @@ const getRunCommand = node => {
 };
 
 /**
+ * Example placeholder values for missing APIs
+ */
+const placeholders = {
+  parameters: [
+    'num_neighbors:  5',
+    'train_ratio:  0.8',
+    "dist_metric:  'cosine'",
+    "eval_metric:  ['denoise_text', 'filter_pos_tags', 'find_pos_text', 'add_pos_name']"
+  ],
+  description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec ipsum elit. Morbi interdum ligula nec finibus ultrices. Vivamus vitae sapien vitae nulla elementum maximus id nec dolor. Fusce lacus turpis, egestas ut massa ac, suscipit faucibus augue. Vestibulum fringilla aliquet nibh, vitae accumsan enim placerat in.`,
+  path: 'Client001/Nodes/Library/XXX0/pipeline.py',
+  filePath: 's3://my-bucket-name/path/to/folder/dataset.parquet'
+};
+
+/**
  * Gets metadata for the currently clicked node if any
  */
 export const getClickedNodeMetaData = createSelector(
@@ -59,7 +74,8 @@ export const getClickedNodeMetaData = createSelector(
         .map(tagId => tagNames[tagId])
         .sort(sortAlpha),
       pipeline: pipeline.name[pipeline.active],
-      runCommand: getRunCommand(node)
+      runCommand: getRunCommand(node),
+      ...placeholders
     };
 
     // Note: node.sources node.targets require newgraph enabled

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -36,21 +36,6 @@ const getRunCommand = node => {
 };
 
 /**
- * Example placeholder values for missing APIs
- */
-const placeholders = {
-  parameters: [
-    'num_neighbors:  5',
-    'train_ratio:  0.8',
-    "dist_metric:  'cosine'",
-    "eval_metric:  ['denoise_text', 'filter_pos_tags', 'find_pos_text', 'add_pos_name']"
-  ],
-  description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec ipsum elit. Morbi interdum ligula nec finibus ultrices. Vivamus vitae sapien vitae nulla elementum maximus id nec dolor. Fusce lacus turpis, egestas ut massa ac, suscipit faucibus augue. Vestibulum fringilla aliquet nibh, vitae accumsan enim placerat in.`,
-  path: 'Client001/Nodes/Library/XXX0/pipeline.py',
-  filePath: 's3://my-bucket-name/path/to/folder/dataset.parquet'
-};
-
-/**
  * Gets metadata for the currently clicked node if any
  */
 export const getClickedNodeMetaData = createSelector(
@@ -59,9 +44,25 @@ export const getClickedNodeMetaData = createSelector(
     getGraphNodes,
     state => state.node.tags,
     state => state.tag.name,
-    state => state.pipeline
+    state => state.pipeline,
+    state => state.node.filepath,
+    state => state.node.code,
+    state => state.node.docstring,
+    state => state.node.parameters,
+    state => state.node.datasetType
   ],
-  (nodeId, nodes = {}, nodeTags, tagNames, pipeline) => {
+  (
+    nodeId,
+    nodes = {},
+    nodeTags,
+    tagNames,
+    pipeline,
+    filepaths,
+    codes,
+    docstrings,
+    parameters,
+    datasetTypes
+  ) => {
     const node = nodes[nodeId];
 
     if (!node) {
@@ -74,8 +75,12 @@ export const getClickedNodeMetaData = createSelector(
         .map(tagId => tagNames[tagId])
         .sort(sortAlpha),
       pipeline: pipeline.name[pipeline.active],
-      runCommand: getRunCommand(node),
-      ...placeholders
+      parameters: parameters[node.id],
+      runCommand: getRunCommand(node.id),
+      docstring: docstrings[node.id],
+      code: codes[node.id],
+      filepath: filepaths[node.id],
+      datasetType: datasetTypes[node.id]
     };
 
     // Note: node.sources node.targets require newgraph enabled

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -57,11 +57,11 @@ export const getClickedNodeMetaData = createSelector(
     nodeTags,
     tagNames,
     pipeline,
-    filepaths,
-    codes,
-    docstrings,
-    parameters,
-    datasetTypes
+    nodeFilepaths,
+    nodeCodes,
+    nodeDocstrings,
+    nodeParameters,
+    nodeDatasetTypes
   ) => {
     const node = nodes[nodeId];
 
@@ -69,18 +69,24 @@ export const getClickedNodeMetaData = createSelector(
       return null;
     }
 
+    const parameters =
+      nodeParameters[node.id] &&
+      Object.entries(nodeParameters[node.id]).map(
+        ([key, value]) => `${key}: ${value}`
+      );
+
     const metadata = {
       node,
       tags: [...nodeTags[node.id]]
         .map(tagId => tagNames[tagId])
         .sort(sortAlpha),
       pipeline: pipeline.name[pipeline.active],
-      parameters: parameters[node.id],
+      parameters,
       runCommand: getRunCommand(node.id),
-      docstring: docstrings[node.id],
-      code: codes[node.id],
-      filepath: filepaths[node.id],
-      datasetType: datasetTypes[node.id]
+      docstring: nodeDocstrings[node.id],
+      code: nodeCodes[node.id],
+      filepath: nodeFilepaths[node.id],
+      datasetType: nodeDatasetTypes[node.id]
     };
 
     // Note: node.sources node.targets require newgraph enabled

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -82,7 +82,7 @@ export const getClickedNodeMetaData = createSelector(
         .sort(sortAlpha),
       pipeline: pipeline.name[pipeline.active],
       parameters,
-      runCommand: getRunCommand(node.id),
+      runCommand: getRunCommand(node),
       docstring: nodeDocstrings[node.id],
       code: nodeCodes[node.id],
       filepath: nodeFilepaths[node.id],


### PR DESCRIPTION
## Description

Adds additional fields to the metadata panel:

For parameter type nodes:
- file path
- parameters

For data type nodes:
- dataset type
- file path

For task type nodes:
- file path
- parameters (data appears when API finished)
- docstring

## Development notes

Parameters for function nodes will appear automatically once the backend API update is completed.

## QA notes

Check the above fields are correct for each type of node.

Test a real project through the proxy e.g. [spaceflights](https://github.com/quantumblacklabs/kedro-starter-spaceflights), `pip install` your local viz repo, then run `kedro viz --port 4142` alongside `npm run start` without any `api/main` file.

Any fields with missing or empty values will show as `-` (e.g. actually no value or not yet returned by API).

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
