### PR TITLE
[KED-2186] Hide graph when loading+switching to new pipeline

### DIFF
--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -121,6 +121,7 @@ export function loadPipelineData(pipelineID) {
     }
     if (asyncDataSource) {
       dispatch(toggleLoading(true));
+      dispatch(resetData(preparePipelineState('json')));
       const url = getPipelineUrl({
         main: pipeline.main,
         active: pipelineID

--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -121,6 +121,7 @@ export function loadPipelineData(pipelineID) {
     }
     if (asyncDataSource) {
       dispatch(toggleLoading(true));
+      // Remove the previous graph to show that a new pipeline is being loaded
       dispatch(resetData(preparePipelineState('json')));
       const url = getPipelineUrl({
         main: pipeline.main,

--- a/src/actions/pipelines.test.js
+++ b/src/actions/pipelines.test.js
@@ -189,22 +189,33 @@ describe('pipeline actions', () => {
     });
 
     describe('if loading data asynchronously', () => {
+      const active = 'new active id';
+
       it('should set loading to true immediately', () => {
         const store = createStore(reducer, mockState.json);
         expect(store.getState().loading.pipeline).toBe(false);
-        loadPipelineData('new active id')(store.dispatch, store.getState);
+        loadPipelineData(active)(store.dispatch, store.getState);
         expect(store.getState().loading.pipeline).toBe(true);
+      });
+
+      it('should hide the current graph before loading the new pipeline', () => {
+        const store = createStore(reducer, {
+          ...mockState.animals,
+          asyncDataSource: true
+        });
+        expect(store.getState().node.ids).not.toHaveLength(0);
+        loadPipelineData(active)(store.dispatch, store.getState);
+        expect(store.getState().node.ids).toHaveLength(0);
       });
 
       it('should set loading to false when complete', async () => {
         const store = createStore(reducer, mockState.json);
-        await loadPipelineData('new active id')(store.dispatch, store.getState);
+        await loadPipelineData(active)(store.dispatch, store.getState);
         expect(store.getState().loading.pipeline).toBe(false);
       });
 
       it('should load the new data, reset the state and update the active pipeline', async () => {
         const store = createStore(reducer, mockState.json);
-        const active = 'new active id';
         await loadPipelineData(active)(store.dispatch, store.getState);
         const state = store.getState();
         expect(state.pipeline.active).toBe(active);


### PR DESCRIPTION
## Description

I've noticed that often, when loading the graph while changing the pipeline, it's not sufficiently obvious that the chart is still loading. This is because the sidebar updates before the graph does, which gives the impression that it's ready when it isn't yet. This change aims to prevent this by removing the old graph when loading, to make it obvious that the new graph is still being generated.

This PR supercedes #282, which was an alternative fix for the same problem, but had more unwanted side-effects.

## Development notes

Resetting the store appears to only take a couple of milliseconds in testing. Removing the old graph probably takes more, but likely not too much time.

## QA notes

Load multiple large pipelines asynchronously, and try switching between them. The pipeline graph now disappears when the new one is being loaded and calculated.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
