### PR TITLE
[KED-2253] Fix pipeline selector flicker when switching pipelines

### DIFF
--- a/src/actions/graph.js
+++ b/src/actions/graph.js
@@ -1,4 +1,5 @@
 import { graph as worker, preventWorkerQueues } from '../utils/worker';
+import { toggleGraph } from './index';
 
 export const TOGGLE_GRAPH_LOADING = 'TOGGLE_GRAPH_LOADING';
 
@@ -51,6 +52,7 @@ export function calculateGraph(graphState) {
   return async function(dispatch) {
     dispatch(toggleLoading(true));
     const graph = await layoutWorker(graphState);
+    dispatch(toggleGraph(true));
     dispatch(toggleLoading(false));
     return dispatch(updateGraph(graph));
   };

--- a/src/actions/graph.test.js
+++ b/src/actions/graph.test.js
@@ -18,12 +18,14 @@ describe('graph actions', () => {
       expect(store.getState().loading.graph).toBe(true);
     });
 
-    it('sets loading to false after finishing calculation', () => {
+    it('sets loading to false and graph visibility to true after finishing calculation', () => {
       const store = createStore(reducer, mockState.animals);
       return calculateGraph(getGraphInput(mockState.animals))(
         store.dispatch
       ).then(() => {
-        expect(store.getState().loading.graph).toBe(false);
+        const state = store.getState();
+        expect(state.loading.graph).toBe(false);
+        expect(state.visible.graph).toBe(true);
       });
     });
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -37,6 +37,19 @@ export function toggleExportModal(visible) {
   };
 }
 
+export const TOGGLE_GRAPH = 'TOGGLE_GRAPH';
+
+/**
+ * Toggle graph visible/hidden
+ * @param {boolean} visible Whether graph is shown
+ */
+export function toggleGraph(visible) {
+  return {
+    type: TOGGLE_GRAPH,
+    visible
+  };
+}
+
 export const TOGGLE_TEXT_LABELS = 'TOGGLE_TEXT_LABELS';
 
 /**

--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -1,7 +1,7 @@
 import { getUrl } from '../utils';
 import loadJsonData from '../store/load-data';
 import { preparePipelineState } from '../store/initial-state';
-import { resetData } from './index';
+import { resetData, toggleGraph } from './index';
 
 /**
  * This file contains actions that update the active pipeline, and if loading data
@@ -117,7 +117,7 @@ export function loadPipelineData(pipelineID) {
     if (asyncDataSource) {
       dispatch(toggleLoading(true));
       // Remove the previous graph to show that a new pipeline is being loaded
-      dispatch(resetData(preparePipelineState('json')));
+      dispatch(toggleGraph(false));
       const url = getPipelineUrl({
         main: pipeline.main,
         active: pipelineID

--- a/src/actions/pipelines.test.js
+++ b/src/actions/pipelines.test.js
@@ -186,9 +186,9 @@ describe('pipeline actions', () => {
           ...mockState.animals,
           asyncDataSource: true
         });
-        expect(store.getState().node.ids).not.toHaveLength(0);
+        expect(store.getState().visible.graph).toBe(true);
         loadPipelineData(active)(store.dispatch, store.getState);
-        expect(store.getState().node.ids).toHaveLength(0);
+        expect(store.getState().visible.graph).toBe(false);
       });
 
       it('should set loading to false when complete', async () => {

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -158,6 +158,7 @@ describe('FlowChart', () => {
       nodeActive: expect.any(Object),
       nodeSelected: expect.any(Object),
       nodes: expect.any(Array),
+      visibleGraph: expect.any(Boolean),
       visibleSidebar: expect.any(Boolean)
     };
     expect(mapStateToProps(mockState.animals)).toEqual(expectedResult);

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -448,7 +448,7 @@ export class FlowChart extends Component {
    * Render React elements
    */
   render() {
-    const { chartSize, layers } = this.props;
+    const { chartSize, layers, visibleGraph } = this.props;
     const { outerWidth = 0, outerHeight = 0 } = chartSize;
 
     return (
@@ -462,7 +462,12 @@ export class FlowChart extends Component {
           width={outerWidth}
           height={outerHeight}
           ref={this.svgRef}>
-          <g id="zoom-wrapper" ref={this.wrapperRef}>
+          <g
+            id="zoom-wrapper"
+            className={classnames('pipeline-zoom-wrapper', {
+              'pipeline-zoom-wrapper--hidden': !visibleGraph
+            })}
+            ref={this.wrapperRef}>
             <defs>
               <marker
                 id="pipeline-arrowhead"
@@ -514,6 +519,7 @@ export const mapStateToProps = (state, ownProps) => ({
   nodes: state.graph.nodes || emptyNodes,
   nodeActive: getNodeActive(state),
   nodeSelected: getNodeSelected(state),
+  visibleGraph: state.visible.graph,
   visibleSidebar: state.visible.sidebar,
   ...ownProps
 });

--- a/src/components/flowchart/styles/flowchart.scss
+++ b/src/components/flowchart/styles/flowchart.scss
@@ -16,10 +16,17 @@
   @media print {
     width: 100%;
     height: auto;
+  }
+}
 
-    #zoom-wrapper {
-      transform: inherit;
-    }
+.pipeline-zoom-wrapper {
+  &--hidden {
+    opacity: 0;
+  }
+
+  @media print {
+    transform: inherit;
+    opacity: 1;
   }
 }
 

--- a/src/components/pipeline-list/index.js
+++ b/src/components/pipeline-list/index.js
@@ -13,12 +13,13 @@ import './pipeline-list.css';
  * @param {string} theme Kedro UI light/dark theme
  */
 export const PipelineList = ({
+  asyncDataSource,
   onUpdateActivePipeline,
   pipeline,
   theme,
   onToggleOpen
 }) => {
-  if (!pipeline.ids.length) {
+  if (!pipeline.ids.length && !asyncDataSource) {
     return null;
   }
   return (
@@ -29,7 +30,9 @@ export const PipelineList = ({
         theme={theme}
         width={null}
         onChanged={onUpdateActivePipeline}
-        defaultText={pipeline.name[pipeline.active]}>
+        defaultText={
+          pipeline.name[pipeline.active] || 'No pipelines available'
+        }>
         {pipeline.ids.map(id => (
           <MenuOption
             key={`pipeline-${id}`}
@@ -43,6 +46,7 @@ export const PipelineList = ({
 };
 
 export const mapStateToProps = state => ({
+  asyncDataSource: state.asyncDataSource,
   pipeline: state.pipeline,
   theme: state.theme
 });

--- a/src/components/pipeline-list/index.js
+++ b/src/components/pipeline-list/index.js
@@ -13,13 +13,12 @@ import './pipeline-list.css';
  * @param {string} theme Kedro UI light/dark theme
  */
 export const PipelineList = ({
-  asyncDataSource,
   onUpdateActivePipeline,
   pipeline,
   theme,
   onToggleOpen
 }) => {
-  if (!pipeline.ids.length && !asyncDataSource) {
+  if (!pipeline.ids.length) {
     return null;
   }
   return (
@@ -44,7 +43,6 @@ export const PipelineList = ({
 };
 
 export const mapStateToProps = state => ({
-  asyncDataSource: state.asyncDataSource,
   pipeline: state.pipeline,
   theme: state.theme
 });

--- a/src/components/pipeline-list/index.js
+++ b/src/components/pipeline-list/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import classnames from 'classnames';
 import { connect } from 'react-redux';
 import Dropdown from '@quantumblack/kedro-ui/lib/components/dropdown';
 import MenuOption from '@quantumblack/kedro-ui/lib/components/menu-option';
@@ -23,14 +24,17 @@ export const PipelineList = ({
     return null;
   }
   return (
-    <div className="pipeline-list">
+    <div
+      className={classnames('pipeline-list', {
+        'pipeline-list--disabled': !pipeline.ids.length
+      })}>
       <Dropdown
         onOpened={() => onToggleOpen(true)}
         onClosed={() => onToggleOpen(false)}
         theme={theme}
         width={null}
         onChanged={onUpdateActivePipeline}
-        defaultText={pipeline.name[pipeline.active] || ''}>
+        defaultText={pipeline.name[pipeline.active] || 'Default'}>
         {pipeline.ids.map(id => (
           <MenuOption
             key={`pipeline-${id}`}

--- a/src/components/pipeline-list/index.js
+++ b/src/components/pipeline-list/index.js
@@ -30,9 +30,7 @@ export const PipelineList = ({
         theme={theme}
         width={null}
         onChanged={onUpdateActivePipeline}
-        defaultText={
-          pipeline.name[pipeline.active] || 'No pipelines available'
-        }>
+        defaultText={pipeline.name[pipeline.active] || ''}>
         {pipeline.ids.map(id => (
           <MenuOption
             key={`pipeline-${id}`}

--- a/src/components/pipeline-list/index.js
+++ b/src/components/pipeline-list/index.js
@@ -13,12 +13,13 @@ import './pipeline-list.css';
  * @param {string} theme Kedro UI light/dark theme
  */
 export const PipelineList = ({
+  asyncDataSource,
   onUpdateActivePipeline,
   pipeline,
   theme,
   onToggleOpen
 }) => {
-  if (!pipeline.ids.length) {
+  if (!pipeline.ids.length && !asyncDataSource) {
     return null;
   }
   return (
@@ -43,6 +44,7 @@ export const PipelineList = ({
 };
 
 export const mapStateToProps = state => ({
+  asyncDataSource: state.asyncDataSource,
   pipeline: state.pipeline,
   theme: state.theme
 });

--- a/src/components/pipeline-list/pipeline-list.scss
+++ b/src/components/pipeline-list/pipeline-list.scss
@@ -2,6 +2,15 @@
 @import '../../styles/variables';
 
 .pipeline-list {
+  &--disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+
+    > * {
+      pointer-events: none;
+    }
+  }
+
   .kui-dropdown {
     display: block;
     border: none;

--- a/src/components/pipeline-list/pipeline-list.test.js
+++ b/src/components/pipeline-list/pipeline-list.test.js
@@ -33,6 +33,7 @@ describe('PipelineList', () => {
 
   it('maps state to props', () => {
     expect(mapStateToProps(mockState.animals)).toEqual({
+      asyncDataSource: expect.any(Boolean),
       pipeline: {
         active: expect.any(String),
         main: expect.any(String),

--- a/src/components/pipeline-list/pipeline-list.test.js
+++ b/src/components/pipeline-list/pipeline-list.test.js
@@ -33,7 +33,6 @@ describe('PipelineList', () => {
 
   it('maps state to props', () => {
     expect(mapStateToProps(mockState.animals)).toEqual({
-      asyncDataSource: expect.any(Boolean),
       pipeline: {
         active: expect.any(String),
         main: expect.any(String),

--- a/src/reducers/visible.js
+++ b/src/reducers/visible.js
@@ -1,4 +1,5 @@
 import {
+  TOGGLE_GRAPH,
   TOGGLE_EXPORT_MODAL,
   TOGGLE_LAYERS,
   TOGGLE_SIDEBAR,
@@ -7,6 +8,12 @@ import {
 
 function visibleReducer(visibleState = {}, action) {
   switch (action.type) {
+    case TOGGLE_GRAPH: {
+      return Object.assign({}, visibleState, {
+        graph: action.visible
+      });
+    }
+
     case TOGGLE_EXPORT_MODAL: {
       return Object.assign({}, visibleState, {
         exportModal: action.visible

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -18,6 +18,7 @@ export const createInitialState = () => ({
     pipeline: false
   },
   visible: {
+    graph: true,
     labelBtn: true,
     layerBtn: true,
     exportBtn: true,


### PR DESCRIPTION
## Description

This PR resolves an issue that arose as of #296, which introduced a loading flicker when switching pipeline with async-loaded data, because the pipeline would momentarily disappear then reappear:

![pipeline-shift](https://user-images.githubusercontent.com/1155816/98274013-d5eda000-1f8a-11eb-9b3d-bb9db3b29d43.gif)

To address this issue, I've implemented the following changes:

1. Don't hide the pipeline selector when loading asynchronously. Now, if loading async, the selector will be visible at all times, even when empty.
2. Change the default pipeline selector text to 'Default'. This makes the loading effect more pleasant.
3. Hide the graph (via opacity) when switching pipeline. Now, instead of resetting the entire pipeline, a new action toggles the opacity on the graph container, so that we don't need to rerender everything in the meantime. This should be less disruptive and more performant, but it required adding a new action.
4. Set the pipeline selector to 'disabled' when there are no pipelines in the dataset.

## Development notes

The only icky thing is that the action to hide the graph needs to be toggled on in the pipeline loading action, and toggled off in the graph calculation selector, otherwise it will be shown before it's ready. However I don't foresee this being a problem.

The disabled state for the pipeline selector is a superficial change that only applies to mouse, not keyboard. I'll need to fix this properly in a subsequent update to Kedro-UI.

## QA notes

Set to async loading mode (i.e. data=json), and toggle between pipelines. The selector should stay put, and the graph should hide while the new pipeline loads.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
