### PR TITLE
HOTFIX: Fix sidebar height bug in Safari

### DIFF
--- a/src/components/node-list/styles/node-list.scss
+++ b/src/components/node-list/styles/node-list.scss
@@ -52,6 +52,7 @@
 }
 
 .pipeline-nodelist-scrollbars {
+  flex-grow: 1;
   min-height: 400px;
 
   &:after {


### PR DESCRIPTION
## Description

The height of the scrollbars element collapses in Safari. This PR fixes it
![image](https://user-images.githubusercontent.com/1155816/98960922-e5299c00-24fc-11eb-9649-d55811523049.png)

## Development notes

flex-grow: 1

## QA notes

Check sidebar height across different browsers

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
