### PR TITLE
Temporarily disable py36 and py37 as required steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,11 +300,11 @@ workflows:
       - win_build_38
       - deploy_demo:
           requires:
-            - build_36
-            - build_37
+            # - build_36
+            # - build_37
             - build_38
-            - win_build_36
-            - win_build_37
+            # - win_build_36
+            # - win_build_37
             - win_build_38
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,11 +292,11 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_36
-      - build_37
+      # - build_36
+      # - build_37
       - build_38
-      - win_build_36
-      - win_build_37
+      # - win_build_36
+      # - win_build_37
       - win_build_38
       - deploy_demo:
           requires:


### PR DESCRIPTION
## Description

py36 and py37 builds are failing on CircleCI for reasons unrelated to FE changes. Disabling them as required steps for now.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
