### PR TITLE
KED-2266: Error when changing pipeline and hovering nodes in Safari

### DIFF
--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -126,7 +126,11 @@ export const drawNodes = function(changed) {
   const updateNodes = this.el.nodes;
   const enterNodes = this.el.nodes.enter().append('g');
   const exitNodes = this.el.nodes.exit();
-  const allNodes = this.el.nodes.merge(enterNodes).merge(exitNodes);
+  // allNodes includes a further filter to avoid undefined data on Safari
+  const allNodes = this.el.nodes
+    .merge(enterNodes)
+    .merge(exitNodes)
+    .filter(node => Boolean(node));
 
   if (changed('nodes')) {
     enterNodes


### PR DESCRIPTION
## Description

This PR is a quick patch fix for KED-2266 (https://jira.quantumblack.com/browse/KED-2266), which is a bug in loading node data when changing pipelines on safari. 

## Development notes

The problem is caused by a series of `undefined` values within the `allNodes` array ( see below ). 
![image](https://user-images.githubusercontent.com/27775658/99271791-ede0e180-281e-11eb-98ab-4fbe835044c1.png)

While the cause of the issue might be related to the wider setup of the new multiple pipeline feature, a simple patch fix of applying a filter to filter out any `undefined` nodes to the list of aggregated nodes is applied in defining `allNodes` within the draw feature of flowchart. 

I have not included a test given this is just a quick patch fix while we currently don't have any test set up for testing D3 rendering within the draw feature, however it might be worth to look into setting up further tests to test D3 rendering function to capture cases such as this. 

Thank you @bru5 for your help and context on this bug! 

## QA notes

The bug can be reproduced via changing pipelines and hovering on the nodes in the flowchart diagram. I have performed a quick regression test on testing the rendering of the chart on switching between pipelines, but it would be good for ay extra pair of eyes to capture any potential error as well. 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
