### PR TITLE
[KED-2293] Add batching to tag actions

### DIFF
--- a/src/actions/actions.test.js
+++ b/src/actions/actions.test.js
@@ -114,10 +114,21 @@ describe('actions', () => {
     const active = false;
     const expectedAction = {
       type: TOGGLE_TAG_ACTIVE,
-      tagID,
+      tagIDs: [tagID],
       active
     };
     expect(toggleTagActive(tagID, active)).toEqual(expectedAction);
+  });
+
+  it('should create an action to toggle an array of tags active state on/off', () => {
+    const tagIDs = ['12345', '67890'];
+    const active = false;
+    const expectedAction = {
+      type: TOGGLE_TAG_ACTIVE,
+      tagIDs,
+      active
+    };
+    expect(toggleTagActive(tagIDs, active)).toEqual(expectedAction);
   });
 
   it('should create an action to toggle a tag on/off', () => {
@@ -125,10 +136,21 @@ describe('actions', () => {
     const enabled = false;
     const expectedAction = {
       type: TOGGLE_TAG_FILTER,
-      tagID,
+      tagIDs: [tagID],
       enabled
     };
     expect(toggleTagFilter(tagID, enabled)).toEqual(expectedAction);
+  });
+
+  it('should create an action to toggle an array of tags on/off', () => {
+    const tagIDs = ['12345', '67890'];
+    const enabled = false;
+    const expectedAction = {
+      type: TOGGLE_TAG_FILTER,
+      tagIDs,
+      enabled
+    };
+    expect(toggleTagFilter(tagIDs, enabled)).toEqual(expectedAction);
   });
 
   it('should create an action to toggle the theme', () => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -63,21 +63,6 @@ export function toggleTextLabels(textLabels) {
   };
 }
 
-export const TOGGLE_TAG_FILTER = 'TOGGLE_TAG_FILTER';
-
-/**
- * Toggle a tag on/off
- * @param {string} tagID Tag id
- * @param {Boolean} enabled True if tag is enabled
- */
-export function toggleTagFilter(tagID, enabled) {
-  return {
-    type: TOGGLE_TAG_FILTER,
-    tagID,
-    enabled
-  };
-}
-
 export const TOGGLE_SIDEBAR = 'TOGGLE_SIDEBAR';
 
 /**

--- a/src/actions/tags.js
+++ b/src/actions/tags.js
@@ -1,14 +1,14 @@
 export const TOGGLE_TAG_ACTIVE = 'TOGGLE_TAG_ACTIVE';
 
 /**
- * Toggle a tag's highlighting on/off
- * @param {string} tagID Tag id
- * @param {Boolean} active True if tag is active
+ * Toggle a tag's highlighting on/off (or array of tags)
+ * @param {string|Array} tagIDs Tag id(s)
+ * @param {Boolean} active True if tag(s) active
  */
-export function toggleTagActive(tagID, active) {
+export function toggleTagActive(tagIDs, active) {
   return {
     type: TOGGLE_TAG_ACTIVE,
-    tagID,
+    tagIDs: Array.isArray(tagIDs) ? tagIDs : [tagIDs],
     active
   };
 }
@@ -16,14 +16,14 @@ export function toggleTagActive(tagID, active) {
 export const TOGGLE_TAG_FILTER = 'TOGGLE_TAG_FILTER';
 
 /**
- * Toggle a tag on/off
- * @param {string} tagID Tag id
- * @param {Boolean} enabled True if tag is enabled
+ * Toggle a tag's filtering on/off (or array of tags)
+ * @param {string|Array} tagIDs Tag id(s)
+ * @param {Boolean} enabled True if tag(s) enabled
  */
-export function toggleTagFilter(tagID, enabled) {
+export function toggleTagFilter(tagIDs, enabled) {
   return {
     type: TOGGLE_TAG_FILTER,
-    tagID,
+    tagIDs: Array.isArray(tagIDs) ? tagIDs : [tagIDs],
     enabled
   };
 }

--- a/src/components/node-list/index.js
+++ b/src/components/node-list/index.js
@@ -98,7 +98,7 @@ const NodeListProvider = ({
       const tagItems = items[type] || [];
       const someTagSet = tagItems.some(tagItem => !tagItem.unset);
       const allTagsValue = someTagSet ? undefined : true;
-      tagItems.forEach(tag => onToggleTagFilter(tag.id, allTagsValue));
+      onToggleTagFilter(tagItems.map(tag => tag.id), allTagsValue);
     } else {
       onToggleTypeDisabled(type, checked);
     }
@@ -112,10 +112,10 @@ const NodeListProvider = ({
 
     if (shouldResetTags) {
       // Unset all tags
-      tags.forEach(tag => onToggleTagFilter(tag.id, undefined));
+      onToggleTagFilter(tags.map(tag => tag.id), undefined);
     } else {
       // Toggle the tag
-      onToggleTagFilter(tagItem.id, !wasChecked);
+      onToggleTagFilter([tagItem.id], !wasChecked);
     }
 
     // Reset node selection
@@ -161,11 +161,11 @@ export const mapStateToProps = state => ({
 });
 
 export const mapDispatchToProps = dispatch => ({
-  onToggleTagActive: (tagID, active) => {
-    dispatch(toggleTagActive(tagID, active));
+  onToggleTagActive: (tagIDs, active) => {
+    dispatch(toggleTagActive(tagIDs, active));
   },
-  onToggleTagFilter: (tagID, enabled) => {
-    dispatch(toggleTagFilter(tagID, enabled));
+  onToggleTagFilter: (tagIDs, enabled) => {
+    dispatch(toggleTagFilter(tagIDs, enabled));
   },
   onToggleTypeDisabled: (typeID, disabled) => {
     dispatch(toggleTypeDisabled(typeID, disabled));

--- a/src/reducers/reducers.test.js
+++ b/src/reducers/reducers.test.js
@@ -120,7 +120,7 @@ describe('Reducer', () => {
     it('should toggle the given tag active', () => {
       const newState = reducer(mockState.animals, {
         type: TOGGLE_TAG_ACTIVE,
-        tagID: 'huge',
+        tagIDs: ['huge'],
         active: true
       });
       expect(newState.tag.active).toEqual({ huge: true });
@@ -131,7 +131,7 @@ describe('Reducer', () => {
     it('should disable a given tag', () => {
       const newState = reducer(mockState.animals, {
         type: TOGGLE_TAG_FILTER,
-        tagID: 'small',
+        tagIDs: ['small'],
         enabled: true
       });
       expect(newState.tag.enabled).toEqual({ small: true });
@@ -212,9 +212,7 @@ describe('Reducer', () => {
       const loadDataAction = { type: ADD_NODE_METADATA, data };
       const oldState = mockState.json;
       const newState = reducer(oldState, loadDataAction);
-      expect(newState.node.code[nodeId]).toEqual(
-        node_task.code
-      );
+      expect(newState.node.code[nodeId]).toEqual(node_task.code);
       expect(newState.node.codeLocation[nodeId]).toEqual(
         node_task.code_location
       );

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -1,30 +1,28 @@
 import { TOGGLE_TAG_ACTIVE, TOGGLE_TAG_FILTER } from '../actions/tags';
 
-const activeChanges = action =>
-  action.tagIDs.reduce((result, tagID) => {
-    result[tagID] = action.active;
-    return result;
-  }, {});
-
-const enabledChanges = action =>
-  action.tagIDs.reduce((result, tagID) => {
-    result[tagID] = action.enabled;
-    return result;
-  }, {});
-
 function tagReducer(tagState = {}, action) {
   const updateState = newState => Object.assign({}, tagState, newState);
+
+  /**
+   * Batch update tags from an array of tag IDs
+   * @param {string} key Tag action value prop
+   */
+  const batchChanges = key =>
+    action.tagIDs.reduce((result, tagID) => {
+      result[tagID] = action[key];
+      return result;
+    }, {});
 
   switch (action.type) {
     case TOGGLE_TAG_ACTIVE: {
       return updateState({
-        active: Object.assign({}, tagState.active, activeChanges(action))
+        active: Object.assign({}, tagState.active, batchChanges('active'))
       });
     }
 
     case TOGGLE_TAG_FILTER: {
       return updateState({
-        enabled: Object.assign({}, tagState.enabled, enabledChanges(action))
+        enabled: Object.assign({}, tagState.enabled, batchChanges('enabled'))
       });
     }
 

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -1,22 +1,30 @@
 import { TOGGLE_TAG_ACTIVE, TOGGLE_TAG_FILTER } from '../actions/tags';
 
+const activeChanges = action =>
+  action.tagIDs.reduce((result, tagID) => {
+    result[tagID] = action.active;
+    return result;
+  }, {});
+
+const enabledChanges = action =>
+  action.tagIDs.reduce((result, tagID) => {
+    result[tagID] = action.enabled;
+    return result;
+  }, {});
+
 function tagReducer(tagState = {}, action) {
   const updateState = newState => Object.assign({}, tagState, newState);
 
   switch (action.type) {
     case TOGGLE_TAG_ACTIVE: {
       return updateState({
-        active: Object.assign({}, tagState.active, {
-          [action.tagID]: action.active
-        })
+        active: Object.assign({}, tagState.active, activeChanges(action))
       });
     }
 
     case TOGGLE_TAG_FILTER: {
       return updateState({
-        enabled: Object.assign({}, tagState.enabled, {
-          [action.tagID]: action.enabled
-        })
+        enabled: Object.assign({}, tagState.enabled, enabledChanges(action))
       });
     }
 

--- a/src/selectors/tags.test.js
+++ b/src/selectors/tags.test.js
@@ -1,6 +1,6 @@
 import { mockState } from '../utils/state.mock';
 import { getTagData, getTagCount } from './tags';
-import { toggleTagFilter } from '../actions';
+import { toggleTagFilter } from '../actions/tags';
 import reducer from '../reducers';
 
 const getTagIDs = state => state.tag.ids;


### PR DESCRIPTION
## Description

Adds batching to tag actions, reducing their overhead when applying filters in the sidebar.

## Development notes

Tag actions now accept an array of ids as well as a single id.

## QA notes

Tag filtering should be tested, expecting no changes in behaviour.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
