### PR TITLE
[KED 2282]Investigate the root cause of nodes being undefined in Safari

### DIFF
--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -114,7 +114,7 @@ export const drawNodes = function(changed) {
   } = this.props;
 
   // we need to cater for the case of change in nodeActive to ensure safari's gabage collector would not overwrite non active pipeline nodes as 'undefined'
-  if (changed('nodes', 'nodeActive')) {
+  if (changed('nodes')) {
     this.el.nodes = this.el.nodeGroup
       .selectAll('.pipeline-node')
       .data(nodes, node => node.id);

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -131,7 +131,7 @@ export const drawNodes = function(changed) {
   const allNodes = this.el.nodes
     .merge(enterNodes)
     .merge(exitNodes)
-    .filter(node => Boolean(node));
+    .filter(node => typeof node !== 'undefined');
 
   if (changed('nodes')) {
     enterNodes

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -113,7 +113,8 @@ export const drawNodes = function(changed) {
     nodes
   } = this.props;
 
-  if (changed('nodes')) {
+  // we need to cater for the case of change in nodeActive to ensure safari's gabage collector would not overwrite non active pipeline nodes as 'undefined'
+  if (changed('nodes', 'nodeActive')) {
     this.el.nodes = this.el.nodeGroup
       .selectAll('.pipeline-node')
       .data(nodes, node => node.id);

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -113,7 +113,6 @@ export const drawNodes = function(changed) {
     nodes
   } = this.props;
 
-  // we need to cater for the case of change in nodeActive to ensure safari's gabage collector would not overwrite non active pipeline nodes as 'undefined'
   if (changed('nodes')) {
     this.el.nodes = this.el.nodeGroup
       .selectAll('.pipeline-node')
@@ -127,7 +126,7 @@ export const drawNodes = function(changed) {
   const updateNodes = this.el.nodes;
   const enterNodes = this.el.nodes.enter().append('g');
   const exitNodes = this.el.nodes.exit();
-  // allNodes includes a further filter to avoid undefined data on Safari
+  // Filter out undefined nodes on Safari
   const allNodes = this.el.nodes
     .merge(enterNodes)
     .merge(exitNodes)


### PR DESCRIPTION
## Description

Related ticket: https://jira.quantumblack.com/browse/KED-2272

This ticket is mainly investigate the root cause of the bug that caused the app to break un safari. The bug is first reported during regression testing of the latest release, and can be reproduced by changing pipelines and hovering over the nodes on the graph. 

## Development notes

While the fix is a very simple fix, the bulk of the work lies in the investigation of the problem behind the current setup of the flowchart component in relation to how safari works under the hood. ( note: this bug does not appear on chrome).

On trying to reproduce the bug, One thing I notice is that the bug is triggered not by changing pipelines, but by simply hovering over the graph on any selected pipeline - the bug will still be triggered by continuously hovering over the nodes on the graph while remaining on the same pipeline. ( one thing to note: this bug happens on a 'spontaneous' manner and does not happen on every try which suggests the root cause is very likely related to how safari works underneath the hood)

The main cause of the bug are `undefined` data within `allNodes` in the `drawNodes` function ( see below screenshot)
![image](https://user-images.githubusercontent.com/27775658/99697803-f9831100-2a87-11eb-8455-15e36b23ab8d.png)

In investigating the the reason behind the undefined element, one thing to note is that this error is trigged within the if statement that checks against 5 changing props: `nodes`, `nodesActive`, `nodeSelected`, `centralNode` and `linkedNodes`. ( code ref: `if (changed('nodes', 'nodeActive', 'nodeSelected', 'centralNode', 'linkedNodes'))`) . Further investigation leads to the initial discovery that this bug is only triggered under when there are changes in the following 3 props: `nodeActive`, `centralNode` and `linkedNodes` i.e this bug is only triggered purely by the 'hover' action over the nodes on the graph. 

In logging out and comparing the `linkedNodes` props as well as `allNodes` field  ( see below), it surfaces the main root cause of the problem - only the nodes that exists in the `linkedNodes` are persisted in memory under `allNodes` (i.e nodes of the currently selected pipeline), while the nodes from other pipelines are overwritten by `undefined`. 

log of `linkedNodes` values:
![image](https://user-images.githubusercontent.com/27775658/99702957-69949580-2a8e-11eb-9524-2854b1f23e68.png)

log of allNodes ( which is array of all ref instances of all nodes across all pipelines):
![image](https://user-images.githubusercontent.com/27775658/99706438-f6415280-2a92-11eb-9dee-dedae5b176cd.png)


This suggests a huge difference in the garbage collector between chrome and Safari, in that safari's garbage collector might have interpreted the nodes of non-selected pipeline as 'non-reachable' objects and had cleared out the information of those nodes within the `allNodes` array, hence those fields being re-assigned as `undefined` in memory. ( further details can be further dig down through the rabbit hole of browser tech as safari most likely adopts the ' tracing GC' approach: https://en.wikipedia.org/wiki/Tracing_garbage_collection )

The above can be fixed by ensuring that `this.el.nodes` gets properly reassigned the entire set of nodes whenever there are any changes in the `nodeActive` prop (i.e whenever there is hovering of the nodes) so that allNodes would be freshly propagated with all nodes data rather than relying on the data in memory. This is done so by adding in an extra condition to include the change in the `nodeActive` prop as part of the condition in the assignment of `this.el.nodes` within `drawNodes`. 

Further regression tests have been performed to ensure that this bug does not happen while it does not break anything else in the app. There is no impact on app performance as well, although it might be worth to further test / consider situations where there are 50+ pipelines.

This also suggest that we could perhaps consider refactoring the `drawNodes` function so that, instead of taking in nodes across pipelines under `this.el.nodes`, we would only reference the existing set of nodes under the selected pipeline within the `drawNodes` function. 

I have kept the last patch fix (the filter of `underfined` items within the definition of `allNodes`) as a further check to ensure that this bug would not happen, but theoretically this is not needed with the current implementation of the nodes reassignment. 

Thanks to @bru5 for discovering the bug and all your help and discussion on this issue!

## QA notes

To test this feature, you can also take out the patch fix ( the `filter` operation under `allNodes` assignment on line 134. 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
