### PR TITLE
[KED-2307] Disable Python 3.6/3.7 jobs in daily CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,9 +318,9 @@ workflows:
               only:
                 - main
     jobs:
-      - build_36
-      - build_37
+      # - build_36
+      # - build_37
       - build_38
-      - win_build_36
-      - win_build_37
+      # - win_build_36
+      # - win_build_37
       - win_build_38


### PR DESCRIPTION
## Description

These were already disabled in the regular commit-triggered 'build' workflow in #305 but they're still causing the CI status badge to show as failing on main due to the nightly cron task.

## Development notes

This should hopefully just be a temporary change.

## QA notes

n/a

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
