### PR TITLE
[KED-2204] Add support for production `kedro viz` backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "lib"
   ],
   "homepage": ".",
-  "proxy": "http://localhost:4141/",
+  "proxy": "http://localhost:4142/",
   "scripts": {
     "build": "npm run build:css && react-scripts build",
     "build:css": "node-sass src/ -o src/",
     "start": "REACT_APP_DATA_SOURCE=$DATA npm-run-all -p start:css start:app start:lib",
-    "start:app": "PORT=4142 react-scripts start",
+    "start:app": "PORT=4141 react-scripts start",
     "start:css": "npm run build:css && node-sass src/ -o src/ --watch --recursive",
     "start:lib": "rm -rf lib && babel src --out-dir lib --copy-files --watch",
     "lib": "npm-run-all -s lib:clean lib:copy lib:webpack lib:babel lib:prune",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
     "lib"
   ],
   "homepage": ".",
+  "proxy": "http://localhost:4141/",
   "scripts": {
     "build": "npm run build:css && react-scripts build",
     "build:css": "node-sass src/ -o src/",
     "start": "REACT_APP_DATA_SOURCE=$DATA npm-run-all -p start:css start:app start:lib",
-    "start:app": "PORT=4141 react-scripts start",
+    "start:app": "PORT=4142 react-scripts start",
     "start:css": "npm run build:css && node-sass src/ -o src/ --watch --recursive",
     "start:lib": "rm -rf lib && babel src --out-dir lib --copy-files --watch",
     "lib": "npm-run-all -s lib:clean lib:copy lib:webpack lib:babel lib:prune",


### PR DESCRIPTION
## Description

Allows development using data from a production backend server.

## Development notes

Enables a production sever running through `kedro viz --port 4142` to run alongside the dev server through `npm run start`, while forwarding requests to the production API backend.

Adds a dev server [proxy](https://create-react-app.dev/docs/proxying-api-requests-in-development/) to local production servers on `4142`, which activates only for requests that don't respond on the dev server.

## QA notes

To test run `kedro viz --port 4142` inside a Kedro project e.g. the [kedro animal example](https://github.com/921kiyo/kedro-animal/) and then run `npm run start` in the Kedro Viz project and visit http://localhost:4141/. You can also visit the production frontend on `4142` at the same time to compare.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
