### PR TITLE
Fix CSS custom properties

### DIFF
--- a/src/components/node-list/styles/_variables.scss
+++ b/src/components/node-list/styles/_variables.scss
@@ -17,10 +17,10 @@ $row-offset-right: $row-padding-x + $row-icon-size + $row-icon-margin;
 $row-active-light: darken($color-bg-light-3, 3%);
 $row-selected-light: darken($color-bg-light-3, 8%);
 $filter-indicator-on-light: $color-primary;
-$filter-indicator-off-light: rgba($color-light, 0.55);
+$filter-indicator-off-light: rgba(black, 0.55);
 
 // Dark:
 $row-active-dark: lighten($color-bg-dark-3, 3%);
 $row-selected-dark: lighten($color-bg-dark-3, 8%);
 $filter-indicator-on-dark: $color-primary;
-$filter-indicator-off-dark: rgba($color-dark, 0.45);
+$filter-indicator-off-dark: rgba(white, 0.45);

--- a/src/components/node-list/styles/node-list.scss
+++ b/src/components/node-list/styles/node-list.scss
@@ -78,7 +78,7 @@
     background: linear-gradient(
       0deg,
       var(--nodelist-bg-transparent) 0%,
-      var(--color-bg-3, 1) 100%
+      var(--color-bg-3) 100%
     );
     content: '';
   }


### PR DESCRIPTION
## Description

Fixes a couple of regressions introduced in #301

## Development notes

1. Fix invalid syntax in gradient colour - I had left in a `, 1` when converting from `rgba` to `var`.
2. Invert filter-indicator-off colours - I'd gotten these confused because the light colours were suppose to be used on the dark themes and vice versa

## QA notes

Fixes node-list tag icon colours on inactive tags when another tag is active

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
