### PR TITLE
Quickfix: update naming of docstring field within codebase to match API 

### DIFF
--- a/src/reducers/nodes.js
+++ b/src/reducers/nodes.js
@@ -56,8 +56,8 @@ function nodeReducer(nodeState = {}, action) {
         filepath: Object.assign({}, nodeState.filepath, {
           [id]: data.filepath
         }),
-        docString: Object.assign({}, nodeState.docString, {
-          [id]: data.docString
+        docstring: Object.assign({}, nodeState.docstring, {
+          [id]: data.docstring
         }),
         parameters: Object.assign({}, nodeState.parameters, {
           [id]: data.parameters

--- a/src/reducers/reducers.test.js
+++ b/src/reducers/reducers.test.js
@@ -214,7 +214,7 @@ describe('Reducer', () => {
       const newState = reducer(oldState, loadDataAction);
       expect(newState.node.code[nodeId]).toEqual(node_task.code);
       expect(newState.node.filepath[nodeId]).toEqual(node_task.filepath);
-      expect(newState.node.docString[nodeId]).toEqual(node_task.docString);
+      expect(newState.node.docstring[nodeId]).toEqual(node_task.docstring);
     });
 
     it('should update the right fields in state under node of parameter type', () => {

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -22,7 +22,7 @@ export const createInitialPipelineState = () => ({
     hovered: null,
     fetched: {},
     code: {},
-    docString: {},
+    docstring: {},
     parameters: {},
     filepath: {},
     datasetType: {}
@@ -121,7 +121,7 @@ const addNode = state => node => {
   state.node.tags[id] = node.tags || [];
   // supports for metadata in case it exists on initial load
   state.node.code[id] = node.code;
-  state.node.docString[id] = node.docString;
+  state.node.docstring[id] = node.docstring;
   state.node.parameters[id] = node.parameters;
   state.node.filepath[id] = node.filepath;
   state.node.datasetType[id] = node.datasetType;


### PR DESCRIPTION
## Description

While going through the codebase I realize that the `docstring` field within our codebase was named under JS camel case, which we should follow the python naming within our codebase. 

## Development notes

I have changed the naming of the field from `docString` to `docstring` within our store, reducers and tests.

## QA notes

N/A

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
