### PR TITLE
[KED-2309] Apply the 'meta' flag for requests to the nodes endpoint

### DIFF
--- a/src/actions/nodes.js
+++ b/src/actions/nodes.js
@@ -79,12 +79,7 @@ export function loadNodeData(nodeID) {
 
     dispatch(toggleNodeClicked(nodeID));
 
-    if (
-      asyncDataSource &&
-      nodeID &&
-      !node.fetched[nodeID] &&
-      flags.meta === true
-    ) {
+    if (asyncDataSource && nodeID && !node.fetched[nodeID] && flags.meta) {
       dispatch(toggleNodeDataLoading(true));
       const url = getUrl('nodes', nodeID);
       const nodeData = await loadJsonData(url);

--- a/src/actions/nodes.js
+++ b/src/actions/nodes.js
@@ -75,11 +75,16 @@ export function addNodeMetadata(data) {
  */
 export function loadNodeData(nodeID) {
   return async function(dispatch, getState) {
-    const { asyncDataSource, node } = getState();
+    const { asyncDataSource, node, flags } = getState();
 
     dispatch(toggleNodeClicked(nodeID));
 
-    if (asyncDataSource && nodeID && !node.fetched[nodeID]) {
+    if (
+      asyncDataSource &&
+      nodeID &&
+      !node.fetched[nodeID] &&
+      flags.meta === true
+    ) {
       dispatch(toggleNodeDataLoading(true));
       const url = getUrl('nodes', nodeID);
       const nodeData = await loadJsonData(url);

--- a/src/actions/nodes.test.js
+++ b/src/actions/nodes.test.js
@@ -1,6 +1,7 @@
 import { createStore } from 'redux';
 import reducer from '../reducers';
 import { mockState } from '../utils/state.mock';
+import { changeFlag } from '../actions';
 import {
   TOGGLE_NODE_DATA_LOADING,
   toggleNodeDataLoading,
@@ -42,16 +43,26 @@ describe('node actions', () => {
       jest.resetModules();
     });
 
+    describe('if meta flag is false', () => {
+      it('should not make any API calls if meta is false', () => {
+        const store = createStore(reducer, mockState.json);
+        loadNodeData('parametersID')(store.dispatch, store.getState);
+        expect(store.getState().loading.node).toBe(false);
+      });
+    });
+
     describe('if loading data asynchronously', () => {
       it('should set loading to true immediately', () => {
-        const store = createStore(reducer, mockState.json);
+        const initialstate = reducer(mockState.json, changeFlag('meta', true));
+        const store = createStore(reducer, initialstate);
         expect(store.getState().loading.node).toBe(false);
         loadNodeData('parametersID')(store.dispatch, store.getState);
         expect(store.getState().loading.node).toBe(true);
       });
 
       it('should load the new data, reset the state and added the fetched node id under node.fetched', async () => {
-        const store = createStore(reducer, mockState.json);
+        let initialstate = reducer(mockState.json, changeFlag('meta', true));
+        const store = createStore(reducer, initialstate);
         const node = { id: parametersID };
         await loadNodeData(node.id)(store.dispatch, store.getState);
         const state = store.getState();
@@ -59,7 +70,8 @@ describe('node actions', () => {
       });
 
       it('should dispatch an action with the newly fetched data to update the store', async () => {
-        const store = createStore(reducer, mockState.json);
+        const initialstate = reducer(mockState.json, changeFlag('meta', true));
+        const store = createStore(reducer, initialstate);
         const { dispatch, getState } = store;
         const node = { id: parametersID };
         const storeListener = jest.fn();
@@ -77,14 +89,16 @@ describe('node actions', () => {
       });
 
       it('should set loading to false when complete', async () => {
-        const store = createStore(reducer, mockState.json);
+        const initialstate = reducer(mockState.json, changeFlag('meta', true));
+        const store = createStore(reducer, initialstate);
         const node = { id: parametersID };
         await loadNodeData(node.id)(store.dispatch, store.getState);
         expect(store.getState().loading.node).toBe(false);
       });
 
       it('should do nothing if the Node data is already fetched', async () => {
-        const store = createStore(reducer, mockState.json);
+        const initialstate = reducer(mockState.json, changeFlag('meta', true));
+        const store = createStore(reducer, initialstate);
         const { dispatch, getState } = store;
         const node = { id: parametersID };
         const storeListener = jest.fn();
@@ -107,7 +121,8 @@ describe('node actions', () => {
       });
 
       it('should not make any API calls if there is no nodeID present', async () => {
-        const store = createStore(reducer, mockState.json);
+        const initialstate = reducer(mockState.json, changeFlag('meta', true));
+        const store = createStore(reducer, initialstate);
         const { dispatch, getState, subscribe } = store;
         const node = { id: null };
         const storeListener = jest.fn();

--- a/src/actions/nodes.test.js
+++ b/src/actions/nodes.test.js
@@ -44,7 +44,7 @@ describe('node actions', () => {
     });
 
     describe('if meta flag is false', () => {
-      it('should not make any API calls if meta is false', () => {
+      it('should not make any API calls', () => {
         const store = createStore(reducer, mockState.json);
         loadNodeData('parametersID')(store.dispatch, store.getState);
         expect(store.getState().loading.node).toBe(false);


### PR DESCRIPTION
## Description

related ticket: https://jira.quantumblack.com/browse/KED-2309

this ticket is to hide the calls to the node API endpoint behind the `meta` flag so calls will only be fired when the meta flag is true. 

## Development notes

I had added an extra check for the `meta` field within the `loadNodeData` action, as well as updated the tests to check for this condition.  

## QA notes

Clicking the nodes will not trigger any calls to the nodes endpoint unless the meta flag is true. 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
