### PR TITLE
[KED-2184] Add 'private' flag prop

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -23,11 +23,13 @@ export const flags = {
   newgraph: {
     description: 'Improved graphing algorithm',
     default: false,
+    private: false,
     icon: '📈'
   },
   meta: {
     description: 'Show the metadata panel',
     default: false,
+    private: false,
     icon: '🔮'
   }
 };

--- a/src/utils/flags.js
+++ b/src/utils/flags.js
@@ -66,6 +66,9 @@ export const getFlagsMessage = flagsEnabled => {
     let info = 'Experimental features 🏄‍♂️\n';
 
     allNames.forEach(name => {
+      if (flagsConfig[name].private) {
+        return;
+      }
       const isEnabled = flagsEnabled[name];
       const status = isEnabled ? 'Enabled' : 'Disabled';
       const statusIcon = isEnabled ? '🟢' : '⚪️';

--- a/src/utils/flags.test.js
+++ b/src/utils/flags.test.js
@@ -20,7 +20,7 @@ jest.mock('../config', () => ({
     },
     privateflag: {
       description: 'private flag description',
-      default: false,
+      default: true,
       private: true,
       icon: '🙊'
     }
@@ -80,7 +80,7 @@ describe('flags', () => {
   it('Flags.defaults returns an object mapping flag defaults', () => {
     expect(Flags.defaults()).toEqual({
       [testFlagName]: false,
-      [privateFlagName]: false
+      [privateFlagName]: true
     });
   });
 });

--- a/src/utils/flags.test.js
+++ b/src/utils/flags.test.js
@@ -22,7 +22,7 @@ jest.mock('../config', () => ({
       description: 'private flag description',
       default: false,
       private: true,
-      icon: '🐵'
+      icon: '🙊'
     }
   }
 }));

--- a/src/utils/flags.test.js
+++ b/src/utils/flags.test.js
@@ -1,7 +1,13 @@
 import { Flags, getFlagsFromUrl, getFlagsMessage } from './flags';
 
 const testFlagName = 'testflag';
+const privateFlagName = 'privateflag';
 const testFlagDescription = 'testflag description';
+const privateFlagDescription = 'private flag description';
+const flagsEnabled = {
+  [testFlagName]: true,
+  [privateFlagName]: true
+};
 
 jest.mock('../config', () => ({
   ...jest.requireActual('../config'),
@@ -9,7 +15,14 @@ jest.mock('../config', () => ({
     testflag: {
       description: 'testflag description',
       default: false,
+      private: false,
       icon: '🤖'
+    },
+    privateflag: {
+      description: 'private flag description',
+      default: false,
+      private: true,
+      icon: '🐵'
     }
   }
 }));
@@ -48,11 +61,11 @@ describe('flags', () => {
   });
 
   it('getFlagsMessage outputs a message describing flags', () => {
-    expect(
-      getFlagsMessage({
-        [testFlagName]: true
-      }).includes(testFlagDescription)
-    ).toBe(true);
+    expect(getFlagsMessage(flagsEnabled)).toContain(testFlagDescription);
+  });
+
+  it('getFlagsMessage does not include private flags', () => {
+    expect(getFlagsMessage(flagsEnabled)).not.toContain(privateFlagDescription);
   });
 
   it('Flags.isDefined returns true if flag defined else false', () => {
@@ -61,10 +74,13 @@ describe('flags', () => {
   });
 
   it('Flags.names returns list of defined flags names', () => {
-    expect(Flags.names()).toEqual([testFlagName]);
+    expect(Flags.names()).toEqual([testFlagName, privateFlagName]);
   });
 
   it('Flags.defaults returns an object mapping flag defaults', () => {
-    expect(Flags.defaults()).toEqual({ [testFlagName]: false });
+    expect(Flags.defaults()).toEqual({
+      [testFlagName]: false,
+      [privateFlagName]: false
+    });
   });
 });


### PR DESCRIPTION
## Description

This will allow allow flags to be block-listed, so that they will not appear in the console flag announcement, and can be used for development only, and not visible to users.

## Development notes

I haven't used it for either of the current flags on the `main` branch, as they're not really private, but we could add it to new branches if we like.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
