### PR TITLE
[KED-2165] Remove get_project_context()

### DIFF
--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -648,7 +648,7 @@ def _call_viz(
         try:
             project_path = project_path or Path.cwd()
 
-            if KEDRO_VERSION.match(">=0.17.0"):
+            if KEDRO_VERSION.match(">=0.17.0"):  # pragma: no cover
                 from kedro.framework.session import KedroSession
                 from kedro.framework.startup import (  # pylint: disable=no-name-in-module,import-error
                     _get_project_metadata,

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -650,7 +650,9 @@ def _call_viz(
 
             if KEDRO_VERSION.match(">=0.17.0"):
                 from kedro.framework.session import KedroSession
-                from kedro.framework.startup import _get_project_metadata
+                from kedro.framework.startup import (  # pylint: disable=no-name-in-module,import-error
+                    _get_project_metadata,
+                )
 
                 package_name = _get_project_metadata(project_path).package_name
                 session_kwargs = dict(
@@ -659,8 +661,10 @@ def _call_viz(
                     env=env,
                     save_on_close=False,
                 )
-                with KedroSession.create(**session_kwargs) as session:
-                    context = session.load_context()
+                with KedroSession.create(  # pylint: disable=unexpected-keyword-arg
+                    **session_kwargs
+                ) as session:
+                    context = session.load_context()  # pylint: disable=no-member
                     pipelines = _get_pipelines_from_context(context, pipeline_name)
             else:
                 context = load_context(project_path=project_path, env=env)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -280,7 +280,7 @@ def _sort_layers(
 
 def _construct_layer_mapping():
     if _CATALOG.layers is None:
-        return {ds_name: None for ds_name in getattr(_CATALOG, "_data_sets")}
+        return {ds_name: None for ds_name in _CATALOG._data_sets}
 
     dataset_to_layer = {}
     for layer, dataset_names in _CATALOG.layers.items():
@@ -661,9 +661,9 @@ def _call_viz(
                     env=env,
                     save_on_close=False,
                 )
-                with KedroSession.create(  # pylint: disable=unexpected-keyword-arg
+                session = KedroSession.create(  # pylint: disable=unexpected-keyword-arg
                     **session_kwargs
-                ) as session:
+                )
                     context = session.load_context()  # pylint: disable=no-member
                     pipelines = _get_pipelines_from_context(context, pipeline_name)
             else:

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -664,8 +664,8 @@ def _call_viz(
                 session = KedroSession.create(  # pylint: disable=unexpected-keyword-arg
                     **session_kwargs
                 )
-                    context = session.load_context()  # pylint: disable=no-member
-                    pipelines = _get_pipelines_from_context(context, pipeline_name)
+                context = session.load_context()  # pylint: disable=no-member
+                pipelines = _get_pipelines_from_context(context, pipeline_name)
             else:
                 context = load_context(project_path=project_path, env=env)
                 pipelines = _get_pipelines_from_context(context, pipeline_name)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -46,6 +46,8 @@ import kedro
 import requests
 from flask import Flask, abort, jsonify, send_from_directory
 from IPython.core.display import HTML, display
+from kedro.framework.cli.utils import KedroCliError
+from kedro.framework.context import KedroContextError, load_context
 from kedro.io import AbstractDataSet, DataCatalog, DataSetNotFoundError
 from kedro.pipeline.node import Node
 from semver import VersionInfo
@@ -54,13 +56,6 @@ from toposort import toposort_flatten
 from kedro_viz.utils import wait_for
 
 KEDRO_VERSION = VersionInfo.parse(kedro.__version__)
-
-if KEDRO_VERSION.match(">=0.16.0"):
-    from kedro.framework.cli.utils import KedroCliError
-    from kedro.framework.context import load_context
-else:
-    from kedro.cli.utils import KedroCliError  # pragma: no cover
-    from kedro.context import load_context  # pragma: no cover
 
 _VIZ_PROCESSES = {}  # type: Dict[int, multiprocessing.Process]
 
@@ -183,15 +178,9 @@ def _load_from_file(load_file: str) -> dict:
 
 
 def _get_pipelines_from_context(context, pipeline_name) -> Dict[str, "Pipeline"]:
-    if KEDRO_VERSION.match(">=0.15.2"):
-        if pipeline_name:
-            return {pipeline_name: context._get_pipeline(name=pipeline_name)}
-        return context.pipelines
-
-    # Kedro 0.15.0 or 0.15.1
     if pipeline_name:
-        raise KedroCliError(ERROR_PIPELINE_FLAG_NOT_SUPPORTED)
-    return {_DEFAULT_KEY: context.pipeline}
+        return {pipeline_name: context._get_pipeline(name=pipeline_name)}
+    return context.pipelines
 
 
 def _sort_layers(
@@ -290,20 +279,12 @@ def _sort_layers(
 
 
 def _construct_layer_mapping():
-    if hasattr(_CATALOG, "layers"):  # kedro>=0.16.0
-        if _CATALOG.layers is None:
-            return {ds_name: None for ds_name in getattr(_CATALOG, "_data_sets")}
+    if _CATALOG.layers is None:
+        return {ds_name: None for ds_name in getattr(_CATALOG, "_data_sets")}
 
-        dataset_to_layer = {}
-        for layer, dataset_names in _CATALOG.layers.items():
-            dataset_to_layer.update(
-                {dataset_name: layer for dataset_name in dataset_names}
-            )
-    else:
-        dataset_to_layer = {
-            ds_name: getattr(ds_obj, "_layer", None)
-            for ds_name, ds_obj in _CATALOG._data_sets.items()
-        }
+    dataset_to_layer = {}
+    for layer, dataset_names in _CATALOG.layers.items():
+        dataset_to_layer.update({dataset_name: layer for dataset_name in dataset_names})
 
     return dataset_to_layer
 
@@ -375,7 +356,7 @@ def format_pipeline_data(
     pipeline_key: str,
     pipeline: "Pipeline",  # noqa: F821
     nodes: Dict[str, dict],
-    node_dependencies: Dict[str, dict],
+    node_dependencies: Dict[str, Set[str]],
     tags: Set[str],
     edges_list: List[dict],
     nodes_list: List[dict],
@@ -664,16 +645,26 @@ def _call_viz(
 
         _DATA = _load_from_file(load_file)
     else:
-        if KEDRO_VERSION.match(">=0.16.0"):
-            from kedro.framework.context import KedroContextError
-        else:
-            # pylint: disable=no-name-in-module,import-error
-            from kedro.context import KedroContextError
-
         try:
             project_path = project_path or Path.cwd()
-            context = load_context(project_path=project_path, env=env)
-            pipelines = _get_pipelines_from_context(context, pipeline_name)
+
+            if KEDRO_VERSION.match(">=0.17.0"):
+                from kedro.framework.session import KedroSession
+                from kedro.framework.startup import _get_project_metadata
+
+                package_name = _get_project_metadata(project_path).package_name
+                session_kwargs = dict(
+                    package_name=package_name,
+                    project_path=project_path,
+                    env=env,
+                    save_on_close=False,
+                )
+                with KedroSession.create(**session_kwargs) as session:
+                    context = session.load_context()
+                    pipelines = _get_pipelines_from_context(context, pipeline_name)
+            else:
+                context = load_context(project_path=project_path, env=env)
+                pipelines = _get_pipelines_from_context(context, pipeline_name)
         except KedroContextError:
             raise KedroCliError(ERROR_PROJECT_ROOT)
 

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,4 +1,4 @@
 semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
 Flask>=1.0, <2.0
-kedro>=0.15.0
+kedro>=0.16.0
 ipython>=7.0.0, <8.0

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -525,36 +525,6 @@ def test_pipeline_flag_non_existent(cli_runner):
     assert "Failed to find the pipeline." in result.output
 
 
-def test_viz_kedro15(mocker, cli_runner):
-    """Test that running viz in Kedro 0.15.0."""
-    mocker.patch("kedro_viz.server.KEDRO_VERSION", VersionInfo.parse("0.15.0"))
-    mocker.patch("kedro_viz.server.load_context")
-    result = cli_runner.invoke(server.commands, "viz")
-    assert result.exit_code == 0, result.output
-
-
-def test_viz_kedro15_pipeline_flag(mocker, cli_runner):
-    """Test that running viz with `--pipeline` flag in Kedro 0.15.0."""
-    mocker.patch("kedro_viz.server.KEDRO_VERSION", VersionInfo.parse("0.15.0"))
-    mocker.patch("kedro_viz.server.load_context")
-    result = cli_runner.invoke(server.commands, ["viz", "--pipeline", "ds"])
-    assert "`--pipeline` flag was provided" in result.output
-
-
-def test_viz_kedro15_invalid(mocker, cli_runner):
-    """Test that running viz in Kedro 0.15.0,
-    and it is outside of a Kedro project root."""
-    from kedro.context import (  # pylint: disable=import-outside-toplevel,no-name-in-module,import-error
-        KedroContextError,
-    )
-
-    mocker.patch("kedro_viz.server.KEDRO_VERSION", VersionInfo.parse("0.15.0"))
-    mocker.patch("kedro_viz.server.load_context", side_effect=KedroContextError)
-
-    result = cli_runner.invoke(server.commands, "viz")
-    assert "Could not find a Kedro project root." in result.output
-
-
 def test_viz_stacktrace(mocker, cli_runner):
     """Test that in the case of a generic exception,
     the stacktrace is printed."""
@@ -751,24 +721,6 @@ def pipeline():
 
 
 @pytest.fixture
-def old_catalog_with_layers():
-    data_sets = {
-        "bob_in": PickleDataSet("raw.csv"),
-        "params:key": MemoryDataSet("value"),
-        "result": PickleDataSet("final.csv"),
-    }
-    setattr(data_sets["bob_in"], "_layer", "raw")
-    setattr(data_sets["result"], "_layer", "final")
-    catalog = DataCatalog(data_sets=data_sets)
-    try:
-        catalog.__dict__.pop("layers")
-    except KeyError:
-        pass
-
-    return catalog
-
-
-@pytest.fixture
 def new_catalog_with_layers():
     data_sets = {
         "bob_in": PickleDataSet("raw.csv"),
@@ -781,14 +733,6 @@ def new_catalog_with_layers():
     setattr(catalog, "layers", layers)
 
     return catalog
-
-
-def test_format_pipelines_data_legacy(pipeline, old_catalog_with_layers, mocker):
-    mocker.patch("kedro_viz.server._CATALOG", old_catalog_with_layers)
-    result = format_pipelines_data(pipeline)
-    result_file_path = Path(__file__).parent / "test-format.json"
-    json_data = json.loads(result_file_path.read_text())
-    assert json_data == result
 
 
 def test_format_pipelines_data(pipeline, new_catalog_with_layers, mocker):

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -180,7 +180,10 @@ def client():
     return client
 
 
-@pytest.mark.usefixtures("patched_load_context")
+_USE_PATCHED_CONTEXT = pytest.mark.usefixtures("patched_load_context")
+
+
+@_USE_PATCHED_CONTEXT
 def test_set_port(cli_runner,):
     """Check that port argument is correctly handled."""
     result = cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
@@ -189,7 +192,7 @@ def test_set_port(cli_runner,):
     server.webbrowser.open_new.assert_called_with("http://127.0.0.1:8000/")
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_set_ip(cli_runner):
     """Check that host argument is correctly handled."""
     result = cli_runner.invoke(server.commands, ["viz", "--host", "0.0.0.0"])
@@ -198,7 +201,7 @@ def test_set_ip(cli_runner):
     server.webbrowser.open_new.assert_called_with("http://0.0.0.0:4141/")
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_no_browser(cli_runner):
     """Check that call to open browser is not performed when `--no-browser`
     argument is specified.
@@ -216,7 +219,7 @@ def test_viz_does_not_need_to_specify_project_path(cli_runner, patched_load_cont
     patched_load_context.assert_called_once_with(project_path=Path.cwd(), env=None)
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_no_browser_if_not_localhost(cli_runner):
     """Check that call to open browser is not performed when host
     is not the local host.
@@ -249,7 +252,7 @@ def test_load_file_outside_kedro_project(cli_runner, tmp_path):
     assert result.exit_code == 0, result.output
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_save_file(cli_runner, tmp_path):
     """Check that running with `--save-file` flag saves pipeline JSON file in a specified path.
     """
@@ -289,7 +292,7 @@ def test_root_endpoint(client):
     assert "Kedro Viz" in response.data.decode()
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_nodes_endpoint(cli_runner, client):
     """Test `/api/main` endpoint is functional and returns a valid JSON."""
     cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
@@ -299,7 +302,7 @@ def test_nodes_endpoint(cli_runner, client):
     assert data == EXPECTED_PIPELINE_DATA
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_pipelines_endpoint(cli_runner, client):
     """Test `/api/pipelines` endpoint is functional and returns a valid JSON."""
     cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
@@ -328,7 +331,7 @@ def test_pipelines_endpoint(cli_runner, client):
     assert data["tags"] == EXPECTED_PIPELINE_DATA["tags"]
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_pipelines_endpoint_invalid_pipeline_id(cli_runner, client):
     """Test `/api/pipelines/invalid_id` endpoint returns an empty JSON."""
     cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
@@ -338,7 +341,7 @@ def test_pipelines_endpoint_invalid_pipeline_id(cli_runner, client):
     assert data["error"] == "404 Not Found: Invalid pipeline ID."
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_node_metadata_endpoint_task(cli_runner, client, mocker, tmp_path):
     """Test `/api/nodes/task_id` endpoint is functional and returns a valid JSON."""
     project_root = "project_root"
@@ -362,7 +365,7 @@ def test_node_metadata_endpoint_task(cli_runner, client, mocker, tmp_path):
     assert data["docstring"] == inspect.getdoc(salmon)
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_node_metadata_endpoint_task_missing_docstring(
     cli_runner, client, mocker, tmp_path
 ):
@@ -388,7 +391,7 @@ def test_node_metadata_endpoint_task_missing_docstring(
     assert "docstring" not in data
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_node_metadata_endpoint_data_input(cli_runner, client, tmp_path):
     """Test `/api/nodes/data_id` endpoint is functional and returns a valid JSON."""
     cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
@@ -399,7 +402,7 @@ def test_node_metadata_endpoint_data_input(cli_runner, client, tmp_path):
     assert data["type"] == f"{PickleDataSet.__module__}.{PickleDataSet.__qualname__}"
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_node_metadata_endpoint_data_output(cli_runner, client, tmp_path):
     """Test `/api/nodes/data_id` endpoint is functional and returns a valid empty JSON."""
     cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
@@ -410,7 +413,7 @@ def test_node_metadata_endpoint_data_output(cli_runner, client, tmp_path):
     assert not data
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_node_metadata_endpoint_data_kedro15(cli_runner, client, tmp_path, mocker):
     """Test `/api/nodes/data_id` endpoint is functional and returns a valid JSON
     with Kedro 0.15.*.
@@ -425,7 +428,7 @@ def test_node_metadata_endpoint_data_kedro15(cli_runner, client, tmp_path, mocke
     assert data["type"] == f"{PickleDataSet.__module__}.{PickleDataSet.__qualname__}"
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_node_metadata_endpoint_parameters(cli_runner, client):
     """Test `/api/nodes/param_id` endpoint is functional and returns an empty JSON."""
     cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
@@ -436,7 +439,7 @@ def test_node_metadata_endpoint_parameters(cli_runner, client):
     assert data == {"parameters": "value"}
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_node_metadata_endpoint_param_prefix(cli_runner, client):
     """Test `/api/nodes/param_id` with param prefix endpoint is functional
     and returns an empty JSON.
@@ -449,7 +452,7 @@ def test_node_metadata_endpoint_param_prefix(cli_runner, client):
     assert data == {"parameters": {"rabbit": "value"}}
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_node_metadata_endpoint_invalid(cli_runner, client):
     """Test `/api/nodes/invalid_id` endpoint returns an empty JSON."""
     cli_runner.invoke(server.commands, ["viz", "--port", "8000"])
@@ -460,7 +463,7 @@ def test_node_metadata_endpoint_invalid(cli_runner, client):
     assert data["error"] == "404 Not Found: Invalid node ID."
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_pipeline_flag(cli_runner, client):
     """Test that running viz with `--pipeline` flag will return a correct pipeline."""
     cli_runner.invoke(server.commands, ["viz", "--pipeline", "ds"])
@@ -518,7 +521,7 @@ def test_pipeline_flag(cli_runner, client):
     }
 
 
-@pytest.mark.usefixtures("patched_load_context")
+@_USE_PATCHED_CONTEXT
 def test_pipeline_flag_non_existent(cli_runner):
     """Test that running viz with `--pipeline` flag but the pipeline does not exist."""
     result = cli_runner.invoke(server.commands, ["viz", "--pipeline", "nonexistent"])


### PR DESCRIPTION
## Description

<!-- Why was this PR created? -->
`get_project_context` was kept for compatibility with Kedro 0.14.*.
Now that we no longer support old versions of Kedro (<0.15), we can replace the calls with `load_context()` or `KedroSession.load_context()`. `get_project_context` will also be removed in future major release of Kedro.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

- Dropped support for Kedro 0.15.x. 
- Removed legacy code handling dataset layers (`DataCatalog.layers` is a definite thing from 0.16.x onwards, no need to check for the old way of having the `layer` attribute on the dataset class).
- Removed legacy tests.
- Ignored covered on branch testing 0.17.0 workflow because that version hasn't been released yet. I could probably test with mocking a lot about but it feels a bit redundant given we'll have to remove that once we release. - Tested this branch manually instead, installing kedro from `develop`, and changing the `__version__` to 0.17.0 (as well as `project_version` in `pyproject.toml` in a newly generated kedro project).

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
