### PR TITLE
[KED-2314] Support launching a development server against a real pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,16 @@ This will serve the app at [localhost:4141](http://localhost:4141/), and watch f
 npm run lib
 ```
 
+#### Launch a development server with a real Kedro project
+
+Run the following command:
+
+```bash
+npm run start:api --project_path=<path-to-Kedro-project>
+```
+
+This command will launch a Kedro-Viz server at [localhost:4142](http://localhost:4142) and serve data from a real Kedro pipeline located at the project path supplied to the command.
+
 #### Data sources
 
 Kedro-Viz uses a unique identifier to determine the data source from one of several available sources. You can configure this by appending a query string to the URL, e.g. `http://localhost:4141/?data=random`. Alternatively, you can set it with an environment variable when starting up the dev server:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start:app": "PORT=4141 react-scripts start",
     "start:css": "npm run build:css && node-sass src/ -o src/ --watch --recursive",
     "start:lib": "rm -rf lib && babel src --out-dir lib --copy-files --watch",
+    "start:api": "python package/kedro_viz/server.py \"$npm_config_project_path\"",
     "lib": "npm-run-all -s lib:clean lib:copy lib:webpack lib:babel lib:prune",
     "lib:clean": "rm -rf lib",
     "lib:copy": "cp -rf src lib",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:app": "PORT=4141 react-scripts start",
     "start:css": "npm run build:css && node-sass src/ -o src/ --watch --recursive",
     "start:lib": "rm -rf lib && babel src --out-dir lib --copy-files --watch",
-    "start:api": "python package/kedro_viz/server.py \"$npm_config_project_path\"",
+    "start:api": "python3 package/kedro_viz/server.py \"$npm_config_project_path\"",
     "lib": "npm-run-all -s lib:clean lib:copy lib:webpack lib:babel lib:prune",
     "lib:clean": "rm -rf lib",
     "lib:copy": "cp -rf src lib",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:app": "PORT=4141 react-scripts start",
     "start:css": "npm run build:css && node-sass src/ -o src/ --watch --recursive",
     "start:lib": "rm -rf lib && babel src --out-dir lib --copy-files --watch",
-    "start:api": "python3 package/kedro_viz/server.py \"$npm_config_project_path\"",
+    "start:api": "python package/kedro_viz/server.py \"$npm_config_project_path\"",
     "lib": "npm-run-all -s lib:clean lib:copy lib:webpack lib:babel lib:prune",
     "lib:clean": "rm -rf lib",
     "lib:copy": "cp -rf src lib",

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -695,12 +695,18 @@ def _call_viz(
 
 # Launch a develop viz server manually by supplying this server script with a project_path.
 # Strictly used to launch a development server for viz.
+# pylint: disable=invalid-name
 if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser(description="Launch a development viz server")
     parser.add_argument("project_path", help="Path to a Kedro project")
-    parser.add_argument("--host", help="The host of the development server", default="localhost")
-    parser.add_argument("--port", help="The port of the development server", default="4142")
+    parser.add_argument(
+        "--host", help="The host of the development server", default="localhost"
+    )
+    parser.add_argument(
+        "--port", help="The port of the development server", default="4142"
+    )
     args = parser.parse_args()
 
     _call_viz(host=args.host, port=args.port, project_path=args.project_path)

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -696,7 +696,7 @@ def _call_viz(
 # Launch a develop viz server manually by supplying this server script with a project_path.
 # Strictly used to launch a development server for viz.
 # pylint: disable=invalid-name
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import argparse
 
     parser = argparse.ArgumentParser(description="Launch a development viz server")

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -691,3 +691,16 @@ def _call_viz(
         if browser and is_localhost:
             webbrowser.open_new("http://{}:{:d}/".format(host, port))
         app.run(host=host, port=port)
+
+
+# Launch a develop viz server manually by supplying this server script with a project_path.
+# Strictly used to launch a development server for viz.
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Launch a development viz server")
+    parser.add_argument("project_path", help="Path to a Kedro project")
+    parser.add_argument("--host", help="The host of the development server", default="localhost")
+    parser.add_argument("--port", help="The port of the development server", default="4142")
+    args = parser.parse_args()
+
+    _call_viz(host=args.host, port=args.port, project_path=args.project_path)


### PR DESCRIPTION
## Description

Support launching a development server against a real Kedro pipeline by adding a `start:api` command to npm. Feel free to add it to the main `npm start` if you'd like :) 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
