### PR TITLE
Add graceful fallback response for API calls

### DIFF
--- a/src/store/load-data.js
+++ b/src/store/load-data.js
@@ -2,16 +2,25 @@ import { json } from 'd3-fetch';
 import { getUrl } from '../utils';
 
 /**
- * Asynchronously load and parse data from json file using d3-fetch
+ * Asynchronously load and parse data from json file using d3-fetch.
+ * Throws an error if the request for `main` fails.
+ * For requests other than `main`, returns the given or default fallback response.
  * @param {string} path JSON file location. Defaults to main data url from config.js
+ * @param {object} fallback The fallback response object on request failure. Default `{}`.
  * @return {function} A promise that will return when the file is loaded and parsed
  */
-const loadJsonData = (path = getUrl('main')) =>
+const loadJsonData = (path = getUrl('main'), fallback = {}) =>
   json(path).catch(() => {
     const fullPath = `/public${path.substr(1)}`;
-    throw new Error(
-      `Unable to load data from ${path}. If you're running Kedro-Viz as a standalone (e.g. for JavaScript development), please check that you have placed a data file at ${fullPath}.`
-    );
+
+    // For main route throw a user error
+    if (path === getUrl('main')) {
+      throw new Error(
+        `Unable to load data from ${path}. If you're running Kedro-Viz as a standalone (e.g. for JavaScript development), please check that you have placed a data file at ${fullPath}.`
+      );
+    }
+
+    return new Promise(resolve => resolve(fallback));
   });
 
 export default loadJsonData;


### PR DESCRIPTION
## Description

This PR adds an explicit fallback response to avoid page crashing errors on failed API requests, such that the app can handle them more gracefully. For the `main` API route, the previous behaviour remains for compatibility.

## Development notes

An example use case is to avoid page crashes when loading JSON files in place of a real API, without needing to export all of the files for each possible API request. In practice this then allows the metadata panel to be used with a single `main` JSON file for testing while falling back gracefully for missing data. 

All request errors are still visible in the console logs as normal, we could potentially add more information through an additional `console.error` if needed. Later on if needed, we could also add an `error` flag to the fallback response.

We could also consider extending this behaviour to the `main` route too, but for now it remains a special case to retain the previous behaviour (an informative error), avoiding this being a breaking change for that route.

## QA notes

Using a `public/main` JSON test file, test all features that use API requests (first load, pipeline select, metadata panel).

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
