### PR TITLE
[KED-2182]Replace newgraph feature flag with a new 'oldgraph' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The following flags are available to toggle experimental features:
 - `oldgraph` - From release v3.8.0. Display old version of graph (dagre algorithm) without improved graphing algorithm. (default `false`)
 - `meta` - From release v3.7.0. Show node metadata panel on click. (default `false`)
 
-Please note that the `newgraph` flag is replaced by the `oldgraph` flag from release v3.8.0 onwards, where setting it as `true` would display the graph without the improved graphing algorithm, and vice versa. 
+Note that newgraph has been removed from v3.8.0 onwards and is now the default functionality. Should there be issues with your project, see the oldgraph flag above.
 
 ### Setting flags
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,10 @@ As a JavaScript React component, the project is designed to be used in two diffe
 
 The following flags are available to toggle experimental features:
 
-- `newgraph` - From release v3.4.0. Improved graphing algorithm. (default `false`)
+- `oldgraph` - From release v3.8.0. Display old version of graph without improved graphing algorithm. (default `false`)
 - `meta` - From release v3.7.0. Show node metadata panel on click. (default `false`)
+
+Please note that the `newgraph` flag is replaced by the `oldgraph` flag from release v3.8.0 onwards and would not be in use anymore. 
 
 ### Setting flags
 

--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ The following flags are available to toggle experimental features:
 - `oldgraph` - From release v3.8.0. Display old version of graph without improved graphing algorithm. (default `false`)
 - `meta` - From release v3.7.0. Show node metadata panel on click. (default `false`)
 
-Please note that the `newgraph` flag is replaced by the `oldgraph` flag from release v3.8.0 onwards and would not be in use anymore. 
+Please note that the `newgraph` flag is replaced by the `oldgraph` flag from release v3.8.0 onwards, where setting it as `true` would display the graph without the improved graphing algorithm, and vice versa. 
 
 ### Setting flags
 
 To enable or disable a flagged feature, add the flag as a parameter with the value `true` or `false` to the end of the URL in your browser when running Kedro-Viz, e.g.
 
-`http://localhost:4141/?data=demo&newgraph=true`
+`http://localhost:4141/?data=demo&oldgraph=true`
 
 The setting you provide persists for all sessions on your machine, until you change it.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ As a JavaScript React component, the project is designed to be used in two diffe
 
 The following flags are available to toggle experimental features:
 
-- `oldgraph` - From release v3.8.0. Display old version of graph without improved graphing algorithm. (default `false`)
+- `oldgraph` - From release v3.8.0. Display old version of graph (dagre algorithm) without improved graphing algorithm. (default `false`)
 - `meta` - From release v3.7.0. Show node metadata panel on click. (default `false`)
 
 Please note that the `newgraph` flag is replaced by the `oldgraph` flag from release v3.8.0 onwards, where setting it as `true` would display the graph without the improved graphing algorithm, and vice versa. 

--- a/src/actions/graph.js
+++ b/src/actions/graph.js
@@ -28,13 +28,13 @@ export function updateGraph(graph) {
 }
 
 /**
- * Choose which layout engine to use based on the newgraph flag
+ * Choose which layout engine to use based on the oldgraph flag
  * @param {Object} instance Worker parent instance
  * @param {Object} state A subset of main state
  * @return {function} Promise function
  */
 const chooseLayout = (instance, state) =>
-  state.newgraph ? instance.graphNew(state) : instance.graphDagre(state);
+  state.oldgraph ? instance.graphDagre(state) : instance.graphNew(state);
 
 // Prepare new layout worker
 const layoutWorker = preventWorkerQueues(worker, chooseLayout);

--- a/src/actions/graph.test.js
+++ b/src/actions/graph.test.js
@@ -46,7 +46,7 @@ describe('graph actions', () => {
       });
     });
 
-    it('uses new graph if the oldgraph flag is set to false', () => {
+    it('uses new graph by default if the oldgraph flag is not set', () => {
       const state = reducer(mockState.animals, changeFlag('oldgraph', false));
       const store = createStore(reducer, state);
       return calculateGraph(getGraphInput(state))(store.dispatch).then(() => {
@@ -54,7 +54,7 @@ describe('graph actions', () => {
       });
     });
 
-    it('uses dagre if the flag is not set', () => {
+    it('uses dagre if the oldgraph flag is set to true', () => {
       const state = reducer(mockState.animals, changeFlag('oldgraph', true));
       const store = createStore(reducer, state);
       return calculateGraph(getGraphInput(state))(store.dispatch).then(() => {

--- a/src/actions/graph.test.js
+++ b/src/actions/graph.test.js
@@ -37,7 +37,7 @@ describe('graph actions', () => {
       return calculateGraph(getGraphInput(state))(store.dispatch).then(() => {
         expect(store.getState().graph).toEqual(
           expect.objectContaining({
-            newgraph: expect.any(Boolean),
+            oldgraph: expect.any(Boolean),
             nodes: expect.any(Array),
             edges: expect.any(Array),
             size: expect.any(Object)
@@ -46,19 +46,19 @@ describe('graph actions', () => {
       });
     });
 
-    it('uses newgraph if the flag is set', () => {
-      const state = reducer(mockState.animals, changeFlag('newgraph', true));
+    it('uses new graph if the oldgraph flag is set to false', () => {
+      const state = reducer(mockState.animals, changeFlag('oldgraph', false));
       const store = createStore(reducer, state);
       return calculateGraph(getGraphInput(state))(store.dispatch).then(() => {
-        expect(store.getState().graph.newgraph).toBe(true);
+        expect(store.getState().graph.oldgraph).toBe(false);
       });
     });
 
     it('uses dagre if the flag is not set', () => {
-      const state = reducer(mockState.animals, changeFlag('newgraph', false));
+      const state = reducer(mockState.animals, changeFlag('oldgraph', true));
       const store = createStore(reducer, state);
       return calculateGraph(getGraphInput(state))(store.dispatch).then(() => {
-        expect(store.getState().graph.newgraph).toBe(false);
+        expect(store.getState().graph.oldgraph).toBe(true);
       });
     });
   });

--- a/src/config.js
+++ b/src/config.js
@@ -22,7 +22,7 @@ export const chartMinWidth = 1200;
 export const flags = {
   oldgraph: {
     description:
-      'display older version of graph without improved graphing algorithm',
+      'display older version of graph (dagre algorithm) without improved graphing algorithm',
     default: false,
     private: false,
     icon: '📈'

--- a/src/config.js
+++ b/src/config.js
@@ -20,8 +20,9 @@ export const chartMinWidth = 1200;
 
 // Remember to update the 'Flags' section in the README when updating these:
 export const flags = {
-  newgraph: {
-    description: 'Improved graphing algorithm',
+  oldgraph: {
+    description:
+      'display older version of graph without improved graphing algorithm',
     default: false,
     private: false,
     icon: '📈'

--- a/src/config.js
+++ b/src/config.js
@@ -21,8 +21,7 @@ export const chartMinWidth = 1200;
 // Remember to update the 'Flags' section in the README when updating these:
 export const flags = {
   oldgraph: {
-    description:
-      'display older version of graph (dagre algorithm) without improved graphing algorithm',
+    description: 'Use older Dagre graphing algorithm',
     default: false,
     private: false,
     icon: '📈'

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -5,7 +5,7 @@ import { getVisibleLayerIDs } from './disabled';
 import { getVisibleMetaSidebar } from '../selectors/metadata';
 import { sidebarWidth, metaSidebarWidth } from '../config';
 
-const getNewgraphFlag = state => state.flags.newgraph;
+const getOldgraphFlag = state => state.flags.oldgraph;
 const getVisibleSidebar = state => state.visible.sidebar;
 const getFontLoaded = state => state.fontLoaded;
 
@@ -18,14 +18,14 @@ export const getGraphInput = createSelector(
     getVisibleNodes,
     getVisibleEdges,
     getVisibleLayerIDs,
-    getNewgraphFlag,
+    getOldgraphFlag,
     getFontLoaded
   ],
-  (nodes, edges, layers, newgraph, fontLoaded) => {
+  (nodes, edges, layers, oldgraph, fontLoaded) => {
     if (!fontLoaded) {
       return null;
     }
-    return { nodes, edges, layers, newgraph, fontLoaded };
+    return { nodes, edges, layers, oldgraph, fontLoaded };
   }
 );
 

--- a/src/selectors/layout.test.js
+++ b/src/selectors/layout.test.js
@@ -12,7 +12,7 @@ describe('Selectors', () => {
           nodes: expect.any(Array),
           edges: expect.any(Array),
           layers: expect.any(Array),
-          newgraph: expect.any(Boolean),
+          oldgraph: expect.any(Boolean),
           fontLoaded: expect.any(Boolean)
         })
       );

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -62,7 +62,7 @@ export const getClickedNodeMetaData = createSelector(
       runCommand: getRunCommand(node)
     };
 
-    // Note: node.sources node.targets require newgraph enabled
+    // Note: node.sources node.targets require oldgraph enabled
     if (node.sources && node.targets) {
       metadata.inputs = node.sources
         .map(edge => nodes[edge.source])

--- a/src/store/initial-state.test.js
+++ b/src/store/initial-state.test.js
@@ -78,7 +78,7 @@ describe('prepareNonPipelineState', () => {
     // In this case, location.href is not provided
     expect(prepareNonPipelineState({ data: animals })).toMatchObject({
       flags: {
-        newgraph: expect.any(Boolean)
+        oldgraph: expect.any(Boolean)
       }
     });
   });

--- a/src/utils/graph/index.js
+++ b/src/utils/graph/index.js
@@ -2,7 +2,7 @@ import dagre from 'dagre';
 import { graph } from './graph';
 
 /**
- * Calculate chart layout with experimental newgraph algorithm
+ * Calculate chart layout with experimental new graphing algorithm
  * This is an extremely expensive operation so we want it to run as infrequently
  * as possible, and keep it separate from other properties (like node.active)
  * which don't affect layout.
@@ -12,7 +12,7 @@ export const graphNew = ({ nodes, edges, layers }) => {
   return {
     ...result,
     size: { ...result.size, marginx: 100, marginy: 100 },
-    newgraph: true
+    oldgraph: false
   };
 };
 
@@ -52,6 +52,6 @@ export const graphDagre = ({ nodes, edges, layers }) => {
     }),
     edges: graph.edges().map(id => graph.edge(id)),
     size: graph.graph(),
-    newgraph: false
+    oldgraph: true
   };
 };

--- a/src/utils/state.mock.js
+++ b/src/utils/state.mock.js
@@ -23,7 +23,7 @@ export const prepareState = props => {
     () => updateFontLoaded(true),
     // Precalculate graph layout:
     state => {
-      const layout = state.flags.newgraph ? graphNew : graphDagre;
+      const layout = state.flags.oldgraph ? graphDagre : graphNew;
       const graph = layout(getGraphInput(state));
       return updateGraph(graph);
     }


### PR DESCRIPTION
## Description

related ticket: https://jira.quantumblack.com/browse/KED-2182

This PR replaces the `newgraph` flag to the new `oldgraph` flag, where on setting it as 'true' will display the previous version of the graph (Dagre graphing algorithm). 

## Development notes

The following have been done:

1. Renamed the 'newgraph' flag as 'oldgraph' and set the default to false
2. Update all instances of `newgraph` to `oldgraph` within the codebase and update the logic if neccesary
3. Update tests
4. update readme docs (@richardwestenra @yetudada let me know what you think about the description of the renaming of the flag in the docs)

## QA notes

This feature can be tested by triggering the 'oldgraph' flag to true. Please note that you will need to clear your localstorage before testing this feature as sometimes the browser would not pick up the new flag setting ( depending on the version of your browser.) 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
