### PR TITLE
Disable internal CSS in exported SVGs to fix error

### DIFF
--- a/src/components/export-modal/export-graph.js
+++ b/src/components/export-modal/export-graph.js
@@ -50,7 +50,7 @@ const exportGraph = ({ format, theme, graphSize, mockFn }) => {
   clone.prepend(style);
 
   // Download SVG/PNG
-  download(clone, 'kedro-pipeline', { css: 'internal' });
+  download(clone, 'kedro-pipeline');
 
   // Delete cloned SVG
   svg.parentNode.removeChild(clone);

--- a/src/components/export-modal/export-graph.js
+++ b/src/components/export-modal/export-graph.js
@@ -51,6 +51,7 @@ const exportGraph = ({ format, theme, graphSize, mockFn }) => {
 
   // Download SVG/PNG
   download(clone, 'kedro-pipeline');
+  // @TODO: Replace third { css: 'internal' } argument when CORS issue is fixed
 
   // Delete cloned SVG
   svg.parentNode.removeChild(clone);


### PR DESCRIPTION
## Description

Due to a browser CORS rule, stylesheet cssRules cannot be read from external stylesheets, meaning that the google webfont stylesheet throws an error and breaks when exporting images.

I have [an open PR on svg-crowbar to fix this issue](https://github.com/cy6erskunk/svg-crowbar/pull/276), but in the meantime I am temporarily disabling this feature to prevent the error. This will signficantly increase exported SVG filesizes, but it will at least work without throwing an error.

## Development notes

I've temporarily changed this line. Once the linked PR is merged, I will revert this change, but will probably set it so that it uses `css: 'internal'` for SVGs only, and will use `css: 'inline'` for PNGs.

## QA notes

Export SVGs/PNGs

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
