### PR TITLE
Update SVG-Crowbar to fix errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26160,9 +26160,9 @@
       }
     },
     "svg-crowbar": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/svg-crowbar/-/svg-crowbar-0.6.3.tgz",
-      "integrity": "sha512-BtR0PTun5WiXgAximf0cZDA5m28+WpDKuwCa7U3yhxrznewSwEfk5D/YSBJakK7fWX5lNKLHmSSHjFVdcR6k6g=="
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/svg-crowbar/-/svg-crowbar-0.6.5.tgz",
+      "integrity": "sha512-3vQn7XoIxRa4cSCOgCiwlc3vEj17+ruc83FOO7QO2jPwbPwxOw1ynpMlgXmWUxBC0DKQMFgHFZyMsfMCIhY0Jw=="
     },
     "svg-parser": {
       "version": "2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26160,9 +26160,9 @@
       }
     },
     "svg-crowbar": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/svg-crowbar/-/svg-crowbar-0.6.0.tgz",
-      "integrity": "sha512-vkYwZbSUVZRqJ3KBQvzsDJaliMJL3fFmpdIUb2On1AV82qx9a6r4ZaHuAPa8wg2U+/9QhOGUXLpupj9D1n5koA=="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/svg-crowbar/-/svg-crowbar-0.6.3.tgz",
+      "integrity": "sha512-BtR0PTun5WiXgAximf0cZDA5m28+WpDKuwCa7U3yhxrznewSwEfk5D/YSBJakK7fWX5lNKLHmSSHjFVdcR6k6g=="
     },
     "svg-parser": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "reselect": "^4.0.0",
     "seedrandom": "^3.0.5",
     "snyk": "^1.369.2",
-    "svg-crowbar": "^0.6.3",
+    "svg-crowbar": "^0.6.5",
     "what-input": "^5.2.10"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "reselect": "^4.0.0",
     "seedrandom": "^3.0.5",
     "snyk": "^1.369.2",
-    "svg-crowbar": "^0.6.0",
+    "svg-crowbar": "^0.6.3",
     "what-input": "^5.2.10"
   },
   "peerDependencies": {

--- a/src/components/export-modal/export-graph.js
+++ b/src/components/export-modal/export-graph.js
@@ -21,9 +21,13 @@ const exportGraph = ({ format, theme, graphSize, mockFn }) => {
   clone.classList.add('kedro', `kui-theme--${theme}`, 'pipeline-graph--export');
 
   // Reset zoom/translate
-  let width = graphSize.width + graphSize.marginx * 2;
-  let height = graphSize.height + graphSize.marginy * 2;
-  clone.setAttribute('viewBox', `0 0 ${width} ${height}`);
+  let width, height;
+  const hasGraph = graphSize.width && graphSize.height;
+  if (hasGraph) {
+    width = graphSize.width + graphSize.marginx * 2;
+    height = graphSize.height + graphSize.marginy * 2;
+    clone.setAttribute('viewBox', `0 0 ${width} ${height}`);
+  }
   clone.querySelector('#zoom-wrapper').removeAttribute('transform');
 
   // Impose a maximum size on PNGs because otherwise they break when downloading
@@ -32,8 +36,10 @@ const exportGraph = ({ format, theme, graphSize, mockFn }) => {
     width = Math.min(width, maxWidth);
     height = Math.min(height, maxWidth * (height / width));
   }
-  clone.setAttribute('width', width);
-  clone.setAttribute('height', height);
+  if (hasGraph) {
+    clone.setAttribute('width', width);
+    clone.setAttribute('height', height);
+  }
 
   const style = document.createElement('style');
   if (format === 'svg') {

--- a/src/components/export-modal/export-graph.js
+++ b/src/components/export-modal/export-graph.js
@@ -22,7 +22,7 @@ const exportGraph = ({ format, theme, graphSize, mockFn }) => {
 
   // Reset zoom/translate
   let width, height;
-  const hasGraph = graphSize.width && graphSize.height;
+  const hasGraph = isFinite(graphSize.width) && isFinite(graphSize.height);
   if (hasGraph) {
     width = graphSize.width + graphSize.marginx * 2;
     height = graphSize.height + graphSize.marginy * 2;

--- a/src/components/export-modal/export-graph.js
+++ b/src/components/export-modal/export-graph.js
@@ -50,8 +50,8 @@ const exportGraph = ({ format, theme, graphSize, mockFn }) => {
   clone.prepend(style);
 
   // Download SVG/PNG
-  download(clone, 'kedro-pipeline');
-  // @TODO: Replace third { css: 'internal' } argument when CORS issue is fixed
+  const options = format === 'svg' ? { css: 'internal' } : undefined;
+  download(clone, 'kedro-pipeline', options);
 
   // Delete cloned SVG
   svg.parentNode.removeChild(clone);


### PR DESCRIPTION
## Description

We were originally using SVG-Crowbar v0.6.0, but started experiencing a critical CORS error with internal CSS in exported images, which was patched in #337. This PR updates the dependency version and reverts the patch.

## Development notes

SVG-Crowbar v0.6.3 [fixes the CORS issue](https://github.com/cy6erskunk/svg-crowbar/pull/276), so we can revert the fix in #337.
However v0.6.2 introduced [a call stack size error](cy6erskunk/svg-crowbar#278) when exporting PNGs, which was resolved in v0.6.4.
However, v0.6.4 introduced [an issue with PNG cropping](cy6erskunk/svg-crowbar#75) that has been resolved in 0.6.5.
So in summary, we have now updated to v0.6.5 now that all of these errors have been resolved.

I've also added a small fix for console errors when exporting a null graph. If the graph doesn't exist and graphSize is empty, which can happen if the graph is still loading/rendering, or if all the filters are applied, then NaN console errors will be thrown. This commit prevents these errors.

## QA notes

You will need to update/install the SVG-Crowbar dependency to test this fix.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
