### PR TITLE
[KED-2144] Scrolling on Kedro-Viz throws errors when pipeline is empty

### DIFF
--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -189,6 +189,22 @@ describe('FlowChart', () => {
       type: 'UPDATE_ZOOM'
     });
   });
+
+  it('will not perform zoom operations for Infinity zoom values', () => {
+    const dispatch = jest.fn();
+
+    const zoom = { scale: 1, x: Infinity, y: Infinity };
+    mapDispatchToProps(dispatch).onUpdateZoom(zoom);
+    expect(dispatch.mock.calls.length).toEqual(1);
+  });
+
+  it('will not perform zoom operations for NaN zoom values', () => {
+    const dispatch = jest.fn();
+
+    const zoom = { scale: 1, x: NaN, y: NaN };
+    mapDispatchToProps(dispatch).onUpdateZoom(zoom);
+    expect(dispatch.mock.calls.length).toEqual(1);
+  });
 });
 
 describe('map dispatch props to async actions', () => {

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -189,22 +189,6 @@ describe('FlowChart', () => {
       type: 'UPDATE_ZOOM'
     });
   });
-
-  it('will not perform zoom operations for Infinity zoom values', () => {
-    const dispatch = jest.fn();
-
-    const zoom = { scale: 1, x: Infinity, y: Infinity };
-    mapDispatchToProps(dispatch).onUpdateZoom(zoom);
-    expect(dispatch.mock.calls.length).toEqual(1);
-  });
-
-  it('will not perform zoom operations for NaN zoom values', () => {
-    const dispatch = jest.fn();
-
-    const zoom = { scale: 1, x: NaN, y: NaN };
-    mapDispatchToProps(dispatch).onUpdateZoom(zoom);
-    expect(dispatch.mock.calls.length).toEqual(1);
-  });
 });
 
 describe('map dispatch props to async actions', () => {

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -216,44 +216,41 @@ export class FlowChart extends Component {
           [width + margin + metaSidebarWidth / scale, height + margin]
         ]);
 
-        // checks to ensure there are valid x and y values before performing zoom operations
-        if (
-          event.transform.x !== Infinity &&
-          event.transform.y !== Infinity &&
-          !isNaN(event.transform.x) &&
-          !isNaN(event.transform.y)
-        ) {
-          // Transform the <g> that wraps the chart
-          this.el.wrapper.attr('transform', event.transform);
+        // Ensure valid x and y values before performing zoom operations
+        if (!isFinite(x) || !isFinite(y) || isNaN(x) || isNaN(y)) {
+          return;
+        }
 
-          // Apply animating class to zoom wrapper
-          this.el.wrapper.classed(
-            'pipeline-flowchart__zoom-wrapper--animating',
-            true
-          );
+        // Transform the <g> that wraps the chart
+        this.el.wrapper.attr('transform', event.transform);
 
-          // Update layer label y positions
-          if (this.el.layerNames) {
-            this.el.layerNames.style('transform', d => {
-              const ty = y + (d.y + d.height / 2) * scale;
-              return `translateY(${ty}px)`;
-            });
-          }
+        // Apply animating class to zoom wrapper
+        this.el.wrapper.classed(
+          'pipeline-flowchart__zoom-wrapper--animating',
+          true
+        );
 
-          // Hide the tooltip so it doesn't get misaligned to its node
-          this.hideTooltip();
-
-          // Share the applied zoom state with other components
-          this.props.onUpdateZoom({
-            scale,
-            x,
-            y,
-            applied: true,
-            transition: false,
-            minScale,
-            maxScale
+        // Update layer label y positions
+        if (this.el.layerNames) {
+          this.el.layerNames.style('transform', d => {
+            const ty = y + (d.y + d.height / 2) * scale;
+            return `translateY(${ty}px)`;
           });
         }
+
+        // Hide the tooltip so it doesn't get misaligned to its node
+        this.hideTooltip();
+
+        // Share the applied zoom state with other components
+        this.props.onUpdateZoom({
+          scale,
+          x,
+          y,
+          applied: true,
+          transition: false,
+          minScale,
+          maxScale
+        });
       })
       // When zoom ends
       .on('end', () => {

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -217,7 +217,14 @@ export class FlowChart extends Component {
         ]);
 
         // Transform the <g> that wraps the chart
-        this.el.wrapper.attr('transform', event.transform);
+        if (
+          event.transform.x !== Infinity &&
+          event.transform.y !== Infinity &&
+          !isNaN(event.transform.x) &&
+          !isNaN(event.transform.y)
+        ) {
+          this.el.wrapper.attr('transform', event.transform);
+        }
 
         // Apply animating class to zoom wrapper
         this.el.wrapper.classed(

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -224,35 +224,35 @@ export class FlowChart extends Component {
           !isNaN(event.transform.y)
         ) {
           this.el.wrapper.attr('transform', event.transform);
-        }
 
-        // Apply animating class to zoom wrapper
-        this.el.wrapper.classed(
-          'pipeline-flowchart__zoom-wrapper--animating',
-          true
-        );
+          // Apply animating class to zoom wrapper
+          this.el.wrapper.classed(
+            'pipeline-flowchart__zoom-wrapper--animating',
+            true
+          );
 
-        // Update layer label y positions
-        if (this.el.layerNames) {
-          this.el.layerNames.style('transform', d => {
-            const ty = y + (d.y + d.height / 2) * scale;
-            return `translateY(${ty}px)`;
+          // Update layer label y positions
+          if (this.el.layerNames) {
+            this.el.layerNames.style('transform', d => {
+              const ty = y + (d.y + d.height / 2) * scale;
+              return `translateY(${ty}px)`;
+            });
+          }
+
+          // Hide the tooltip so it doesn't get misaligned to its node
+          this.hideTooltip();
+
+          // Share the applied zoom state with other components
+          this.props.onUpdateZoom({
+            scale,
+            x,
+            y,
+            applied: true,
+            transition: false,
+            minScale,
+            maxScale
           });
         }
-
-        // Hide the tooltip so it doesn't get misaligned to its node
-        this.hideTooltip();
-
-        // Share the applied zoom state with other components
-        this.props.onUpdateZoom({
-          scale,
-          x,
-          y,
-          applied: true,
-          transition: false,
-          minScale,
-          maxScale
-        });
       })
       // When zoom ends
       .on('end', () => {

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -200,6 +200,12 @@ export class FlowChart extends Component {
       // When zoom changes
       .on('zoom', () => {
         const { k: scale, x, y } = event.transform;
+
+        // Ensure valid x and y values before performing zoom operations
+        if (!isFinite(x) || !isFinite(y) || isNaN(x) || isNaN(y)) {
+          return;
+        }
+
         const [
           minScale = 0,
           maxScale = Infinity
@@ -215,11 +221,6 @@ export class FlowChart extends Component {
           [-sidebarWidth / scale - margin, -margin],
           [width + margin + metaSidebarWidth / scale, height + margin]
         ]);
-
-        // Ensure valid x and y values before performing zoom operations
-        if (!isFinite(x) || !isFinite(y) || isNaN(x) || isNaN(y)) {
-          return;
-        }
 
         // Transform the <g> that wraps the chart
         this.el.wrapper.attr('transform', event.transform);

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -216,13 +216,14 @@ export class FlowChart extends Component {
           [width + margin + metaSidebarWidth / scale, height + margin]
         ]);
 
-        // Transform the <g> that wraps the chart
+        // checks to ensure there are valid x and y values before performing zoom operations
         if (
           event.transform.x !== Infinity &&
           event.transform.y !== Infinity &&
           !isNaN(event.transform.x) &&
           !isNaN(event.transform.y)
         ) {
+          // Transform the <g> that wraps the chart
           this.el.wrapper.attr('transform', event.transform);
 
           // Apply animating class to zoom wrapper


### PR DESCRIPTION
## Description

related PR: https://jira.quantumblack.com/browse/KED-2144

This PR mainly tackles the errors in the console that was caused by users scrolling on the graph on an empty pipeline. 

## Development notes

The error are caused by the values of `event.transform` being `Infinity` or `NaN` on zoom when the pipeline is empty (i.e edges and nodes are an empty array). 

I have added checks on the `event` object to filter out the cases of `Infinity` or `NaN` values for both `event.transform.x` and `event.transform.y` before calling the `transform` attribute for `this.el.wrapper`, as well as other operations and actions to update the zoom values within the `flowchart` component. 

I have also added tests to check against those 2 cases to detect any breaking changes in the future. 

## QA notes

On loading Kedro-viz with an empty pipeline, the errors should not occur under the console on scrolling / changing the zoom for the flowchart graph. 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
