### PR TITLE
Fix icon-button tooltips on mobile

### DIFF
--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -60,6 +60,7 @@
   transform: translateX(1em);
   visibility: hidden;
   opacity: 0;
+  transition: opacity 0.15s, transform 0.15s, visibility 0.15s;
 
   @media (min-width: $sidebar-width-breakpoint) {
     right: auto;
@@ -74,6 +75,7 @@
     transform: translateX(0);
     visibility: visible;
     opacity: 1;
+    transition: none;
   }
 
   &::after {

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -52,15 +52,12 @@
   position: absolute;
   top: 50%;
   left: 50%;
+  display: none;
   margin-top: -1.2em;
   margin-left: 1.6em;
   padding: 0.5em 0.7em;
   font-size: 1.4em;
   white-space: nowrap;
-  transform: translateX(-1em);
-  visibility: hidden;
-  opacity: 0;
-  transition: opacity 0.15s, transform 0.15s, visibility 0.15s;
 
   @media (max-width: $sidebar-width-breakpoint) {
     .pipeline-sidebar--visible & {
@@ -68,16 +65,12 @@
       left: auto;
       margin-right: 1.6em;
       margin-left: auto;
-      transform: translateX(1em);
     }
   }
 
   .pipeline-icon-toolbar__button:hover &,
   [data-whatinput='keyboard'] .pipeline-icon-toolbar__button:focus & {
-    transform: translateX(0);
-    visibility: visible;
-    opacity: 1;
-    transition: none;
+    display: inline-block;
   }
 
   &::after {

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -51,15 +51,23 @@
 
   position: absolute;
   top: 50%;
-  left: 50%;
+  right: 50%;
   margin-top: -1.2em;
-  margin-left: 1.6em;
+  margin-right: 1.6em;
   padding: 0.5em 0.7em;
   font-size: 1.4em;
   white-space: nowrap;
-  transform: translateX(-1em);
+  transform: translateX(1em);
   visibility: hidden;
   opacity: 0;
+
+  @media (min-width: $sidebar-width-breakpoint) {
+    right: auto;
+    left: 50%;
+    margin-right: auto;
+    margin-left: 1.6em;
+    transform: translateX(-1em);
+  }
 
   .pipeline-icon-toolbar__button:hover &,
   [data-whatinput='keyboard'] .pipeline-icon-toolbar__button:focus & {
@@ -73,12 +81,19 @@
 
     position: absolute;
     top: calc(50% - #{$triangle-size});
-    left: -$triangle-size + 0.5;
+    right: -$triangle-size + 0.5;
     width: 0;
     height: 0;
-    border-color: transparent var(--color-bg-alt) transparent transparent;
+    border-color: transparent transparent transparent var(--color-bg-alt);
     border-style: solid;
-    border-width: $triangle-size $triangle-size $triangle-size 0;
+    border-width: $triangle-size 0 $triangle-size $triangle-size;
     content: '';
+
+    @media (min-width: $sidebar-width-breakpoint) {
+      right: auto;
+      left: -$triangle-size + 0.5;
+      border-color: transparent var(--color-bg-alt) transparent transparent;
+      border-width: $triangle-size $triangle-size $triangle-size 0;
+    }
   }
 }

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -51,23 +51,25 @@
 
   position: absolute;
   top: 50%;
-  right: 50%;
+  left: 50%;
   margin-top: -1.2em;
-  margin-right: 1.6em;
+  margin-left: 1.6em;
   padding: 0.5em 0.7em;
   font-size: 1.4em;
   white-space: nowrap;
-  transform: translateX(1em);
+  transform: translateX(-1em);
   visibility: hidden;
   opacity: 0;
   transition: opacity 0.15s, transform 0.15s, visibility 0.15s;
 
-  @media (min-width: $sidebar-width-breakpoint) {
-    right: auto;
-    left: 50%;
-    margin-right: auto;
-    margin-left: 1.6em;
-    transform: translateX(-1em);
+  @media (max-width: $sidebar-width-breakpoint) {
+    .pipeline-sidebar--visible & {
+      right: 50%;
+      left: auto;
+      margin-right: 1.6em;
+      margin-left: auto;
+      transform: translateX(1em);
+    }
   }
 
   .pipeline-icon-toolbar__button:hover &,
@@ -83,19 +85,21 @@
 
     position: absolute;
     top: calc(50% - #{$triangle-size});
-    right: -$triangle-size + 0.5;
+    left: -$triangle-size + 0.5;
     width: 0;
     height: 0;
-    border-color: transparent transparent transparent var(--color-bg-alt);
+    border-color: transparent var(--color-bg-alt) transparent transparent;
     border-style: solid;
-    border-width: $triangle-size 0 $triangle-size $triangle-size;
+    border-width: $triangle-size $triangle-size $triangle-size 0;
     content: '';
 
-    @media (min-width: $sidebar-width-breakpoint) {
-      right: auto;
-      left: -$triangle-size + 0.5;
-      border-color: transparent var(--color-bg-alt) transparent transparent;
-      border-width: $triangle-size $triangle-size $triangle-size 0;
+    @media (max-width: $sidebar-width-breakpoint) {
+      .pipeline-sidebar--visible & {
+        right: -$triangle-size + 0.5;
+        left: auto;
+        border-color: transparent transparent transparent var(--color-bg-alt);
+        border-width: $triangle-size 0 $triangle-size $triangle-size;
+      }
     }
   }
 }

--- a/src/components/minimap/index.js
+++ b/src/components/minimap/index.js
@@ -334,9 +334,7 @@ export class MiniMap extends Component {
 
     return (
       <div
-        className={classnames('pipeline-minimap-container', {
-          'pipeline-minimap-container--visible': this.props.visible
-        })}
+        className="pipeline-minimap-container"
         style={this.props.visible ? transformStyle : {}}>
         <div
           className="pipeline-minimap kedro"

--- a/src/components/minimap/index.js
+++ b/src/components/minimap/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import classnames from 'classnames';
 import 'd3-transition';
 import { interpolate } from 'd3-interpolate';
 import { select, event } from 'd3-selection';

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -52,7 +52,7 @@
 
 .pipeline-toolbar {
   position: relative;
-  z-index: 1;
+  z-index: 2;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/1155816/103702826-ae24b380-4f9e-11eb-8388-7b623729d732.png)


- Make the tooltips display on the left side when the sidebar is full-screen width and open
- Fix icon-button tooltip transition
- Remove unused class

## Development notes

I also removed a class that wasn't being used for anything, and probably was left over from when the minimap had a fixed width.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
