### PR TITLE
[KED-2331] Fix missing indicators Chrome zoom bug

### DIFF
--- a/src/components/icons/indicator-off.js
+++ b/src/components/icons/indicator-off.js
@@ -5,6 +5,7 @@ export default ({ className }) => (
     className={className}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24">
-    <rect x="8.5" y="9" width="5" height="5" rx="1" strokeWidth="2" />
+    {/* Note: some strokeWidth values fail when zoomed in Chrome e.g. 2 */}
+    <rect x="8.5" y="9" width="5" height="5" rx="1" strokeWidth="1.9" />
   </svg>
 );


### PR DESCRIPTION
## Description

Avoids missing tag indicators when zoomed in Chrome.

## Development notes

There appears to be a Chrome rendering issue with SVG strokes when zoomed. 

The workaround here is to change the `strokeWidth` (slightly) of the icon to a value that doesn't fail when zoomed.

A comment was added to make note of this.

## QA notes

First check out the main branch and open the demo in Chrome. Select a few random tags. Then zoom the browser in and out a few steps until some of the unselected tag indicators disappear.

Then switch to the fix branch and confirm this no longer happens.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
