### PR TITLE
Fix sidebar border/box-shadow CSS rules

### DIFF
--- a/src/styles/_extends.scss
+++ b/src/styles/_extends.scss
@@ -82,6 +82,6 @@
 
 %sidebar {
   background: var(--color-sidebar-background);
-  border-bottom: var(--color-sidebar-border);
-  box-shadow: var(--color-sidebar-shadow);
+  border-bottom: 1px solid var(--color-sidebar-border);
+  box-shadow: 0 1px 3px var(--color-sidebar-shadow);
 }


### PR DESCRIPTION
## Description

These were broken in #301 when moving this CSS from being a mixin to an extendable class, and converting the colours to CSS custom properties.

## Development notes

These are used on the sidebar and metadata panels. I've simply restored the previous styles without any changes.

## QA notes

Very very faint shadow on the sidebar and metadata panels.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
