### PR TITLE
[KED-2378] Local store of tags

### DIFF
--- a/src/components/node-list/node-list.test.js
+++ b/src/components/node-list/node-list.test.js
@@ -6,6 +6,10 @@ import { getTagData } from '../../selectors/tags';
 import IndicatorPartialIcon from '../icons/indicator-partial';
 
 describe('NodeList', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it('renders without crashing', () => {
     const wrapper = setup.mount(<NodeList />);
     const search = wrapper.find('.pipeline-nodelist-search');

--- a/src/components/node-list/node-list.test.js
+++ b/src/components/node-list/node-list.test.js
@@ -4,6 +4,7 @@ import { mockState, setup } from '../../utils/state.mock';
 import { getNodeData } from '../../selectors/nodes';
 import { getTagData } from '../../selectors/tags';
 import IndicatorPartialIcon from '../icons/indicator-partial';
+import { localStorageName } from '../../config';
 
 describe('NodeList', () => {
   beforeEach(() => {
@@ -302,34 +303,13 @@ describe('NodeList', () => {
       expect(partialIcon(wrapper)).toHaveLength(0);
     });
 
-    it('saves enabled tags in localStorage and ensure that the selected tags remains selected on reload', () => {
-      const { location } = window;
-      delete window.location;
-      window.location = { reload: jest.fn() };
-
+    it('saves enabled tags in localStorage on selecting a tag on node-list', () => {
       const wrapper = setup.mount(<NodeList />);
       changeRows(wrapper, ['Medium'], true);
-      window.location.reload();
-      expect(elements(wrapper)).toEqual([
-        ['shark', true],
-        ['salmon', false],
-        ['trout', false],
-        ['Bear', true],
-        ['Cat', true],
-        ['Elephant', true],
-        ['Giraffe', true],
-        ['Pig', true],
-        ['Weasel', true],
-        ['Dog', false],
-        ['Horse', false],
-        ['Sheep', false],
-        ['Whale', false],
-        ['Parameters', false],
-        ['Params:rabbit', false]
-      ]);
-
-      // reset window.location back to its original value
-      window.location = location;
+      const localStoredValues = JSON.parse(
+        window.localStorage.getItem(localStorageName)
+      );
+      expect(localStoredValues.tag.enabled.medium).toEqual(true);
     });
   });
 

--- a/src/components/node-list/node-list.test.js
+++ b/src/components/node-list/node-list.test.js
@@ -301,6 +301,36 @@ describe('NodeList', () => {
       changeRows(wrapper, ['Large', 'Medium', 'Small'], true);
       expect(partialIcon(wrapper)).toHaveLength(0);
     });
+
+    it('saves enabled tags in localStorage and ensure that the selected tags remains selected on reload', () => {
+      const { location } = window;
+      delete window.location;
+      window.location = { reload: jest.fn() };
+
+      const wrapper = setup.mount(<NodeList />);
+      changeRows(wrapper, ['Medium'], true);
+      window.location.reload();
+      expect(elements(wrapper)).toEqual([
+        ['shark', true],
+        ['salmon', false],
+        ['trout', false],
+        ['Bear', true],
+        ['Cat', true],
+        ['Elephant', true],
+        ['Giraffe', true],
+        ['Pig', true],
+        ['Weasel', true],
+        ['Dog', false],
+        ['Horse', false],
+        ['Sheep', false],
+        ['Whale', false],
+        ['Parameters', false],
+        ['Params:rabbit', false]
+      ]);
+
+      // reset window.location back to its original value
+      window.location = location;
+    });
   });
 
   describe('node list', () => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -38,6 +38,9 @@ const saveStateToLocalStorage = state => {
     layer: {
       visible: state.layer.visible
     },
+    tag: {
+      enabled: state.tag.enabled
+    },
     textLabels: state.textLabels,
     theme: state.theme,
     visible: state.visible,

--- a/src/store/initial-state.test.js
+++ b/src/store/initial-state.test.js
@@ -29,6 +29,19 @@ describe('mergeLocalStorage', () => {
     window.localStorage.clear();
   });
 
+  it('overrides selected tag values in state with localstorage values if provided', () => {
+    const localStorageValues = {
+      tag: { enabled: 'large' }
+    };
+    saveState(localStorageValues);
+    expect(
+      mergeLocalStorage({
+        tag: { enabled: 'large' }
+      })
+    ).toMatchObject(localStorageValues);
+    window.localStorage.clear();
+  });
+
   it('does not add values if localStorage keys do not match state values', () => {
     const extraValues = {
       additional: 1,

--- a/src/store/initial-state.test.js
+++ b/src/store/initial-state.test.js
@@ -17,25 +17,14 @@ describe('mergeLocalStorage', () => {
   it('overrides state values with localstorage values if provided', () => {
     const localStorageValues = {
       textLabels: false,
-      theme: 'light'
+      theme: 'light',
+      tag: { enabled: 'medium' }
     };
     saveState(localStorageValues);
     expect(
       mergeLocalStorage({
         textLabels: true,
-        theme: 'dark'
-      })
-    ).toMatchObject(localStorageValues);
-    window.localStorage.clear();
-  });
-
-  it('overrides selected tag values in state with localstorage values if provided', () => {
-    const localStorageValues = {
-      tag: { enabled: 'large' }
-    };
-    saveState(localStorageValues);
-    expect(
-      mergeLocalStorage({
+        theme: 'dark',
         tag: { enabled: 'large' }
       })
     ).toMatchObject(localStorageValues);


### PR DESCRIPTION
## Description

related ticket: https://jira.quantumblack.com/browse/KED-2378

This ticket enables the app to reload with selected tags by saving the enabled tags in local storage. 

## Development notes

I have added the following:
1. added the new enabled tag field to be saved in localStorage
2. Added a test to specifically ensure the enabled tag field gets stored in localStorage (This test is mainly just to ensure that the object format of tags gets saved in localStorage)
3. Added a test to test the reload of the nodelist to ensure it reloads with the selected tags on page refresh 
4. Ensure the localstorage gets refreshed within the nodelist tests to ensure they are properly tested with the newly added localstorage value

## QA notes

select a few tags, refresh the window, and you should see the selected tags are still selected. 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
