### PR TITLE
Fix node-list-row keyboard focus states

### DIFF
--- a/src/components/node-list/node-list-group.js
+++ b/src/components/node-list/node-list-group.js
@@ -38,6 +38,7 @@ export const NodeListGroup = ({
         kind={kind}
         name={name}
         label={`${name} <i>${childCount}</i>`}
+        allUnset={allUnset}
         unset={unset}
         checked={checked}
         visibleIcon={visibleIcon}

--- a/src/components/node-list/node-list-row-list.js
+++ b/src/components/node-list/node-list-row-list.js
@@ -35,6 +35,7 @@ const NodeRowList = ({
         visible={item.visible}
         selected={item.selected}
         unset={item.unset}
+        allUnset={group.allUnset}
         visibleIcon={item.visibleIcon}
         invisibleIcon={item.invisibleIcon}
         onClick={() => onItemClick(item)}
@@ -107,6 +108,7 @@ const NodeRowLazyList = ({
             visible={item.visible}
             selected={item.selected}
             unset={item.unset}
+            allUnset={group.allUnset}
             visibleIcon={item.visibleIcon}
             invisibleIcon={item.invisibleIcon}
             onClick={() => onItemClick(item)}

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -57,7 +57,8 @@ const NodeListRow = memo(
     invisibleIcon = InvisibleIcon
   }) => {
     const VisibilityIcon = checked ? visibleIcon : invisibleIcon;
-    const TextButton = onClick && kind !== 'filter' ? 'button' : 'div';
+    const isButton = onClick && kind !== 'filter';
+    const TextButton = isButton ? 'button' : 'div';
 
     return (
       <Container
@@ -80,7 +81,7 @@ const NodeListRow = memo(
           onClick={onClick}
           onFocus={onMouseEnter}
           onBlur={onMouseLeave}
-          disabled={disabled}
+          disabled={isButton && (disabled || !checked)}
           title={children ? null : name}>
           {type && (
             <NodeIcon

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -55,6 +55,7 @@ const NodeListRow = memo(
     invisibleIcon = InvisibleIcon
   }) => {
     const VisibilityIcon = checked ? visibleIcon : invisibleIcon;
+    const TextButton = onClick ? 'button' : 'div';
 
     return (
       <Container
@@ -72,7 +73,7 @@ const NodeListRow = memo(
         title={name}
         onMouseEnter={visible ? onMouseEnter : null}
         onMouseLeave={visible ? onMouseLeave : null}>
-        <button
+        <TextButton
           className="pipeline-nodelist__row__text"
           onClick={onClick}
           onFocus={onMouseEnter}
@@ -106,7 +107,7 @@ const NodeListRow = memo(
             )}
             dangerouslySetInnerHTML={{ __html: label }}
           />
-        </button>
+        </TextButton>
         {children}
         <label
           htmlFor={id}

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -73,10 +73,7 @@ const NodeListRow = memo(
         onMouseEnter={visible ? onMouseEnter : null}
         onMouseLeave={visible ? onMouseLeave : null}>
         <button
-          className={classnames(
-            'pipeline-nodelist__row__text',
-            `pipeline-nodelist__row__text--kind-${kind}`
-          )}
+          className="pipeline-nodelist__row__text"
           onClick={onClick}
           onFocus={onMouseEnter}
           onBlur={onMouseLeave}
@@ -99,10 +96,14 @@ const NodeListRow = memo(
             />
           )}
           <span
-            className={classnames('pipeline-nodelist__row__label', {
-              'pipeline-nodelist__row__label--faded': faded,
-              'pipeline-nodelist__row__label--disabled': disabled
-            })}
+            className={classnames(
+              'pipeline-nodelist__row__label',
+              `pipeline-nodelist__row__label--kind-${kind}`,
+              {
+                'pipeline-nodelist__row__label--faded': faded,
+                'pipeline-nodelist__row__label--disabled': disabled
+              }
+            )}
             dangerouslySetInnerHTML={{ __html: label }}
           />
         </button>

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -138,8 +138,7 @@ const NodeListRow = memo(
               {
                 'pipeline-row__toggle-icon--checked': checked,
                 'pipeline-row__toggle-icon--unchecked': !checked,
-                'pipeline-row__toggle-icon--unset': unset,
-                'pipeline-row__toggle-icon--visible': type !== 'tag'
+                'pipeline-row__toggle-icon--unset': unset
               }
             )}
           />

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -20,6 +20,7 @@ const shouldMemo = (prevProps, nextProps) =>
       'active',
       'checked',
       'unset',
+      'allUnset',
       'disabled',
       'faded',
       'visible',
@@ -37,6 +38,7 @@ const NodeListRow = memo(
     active,
     checked,
     unset,
+    allUnset,
     children,
     disabled,
     faded,
@@ -111,15 +113,11 @@ const NodeListRow = memo(
         {children}
         <label
           htmlFor={id}
-          className={classnames(
-            'pipeline-row__toggle',
-            `pipeline-row__toggle--kind-${kind}`,
-            {
-              'pipeline-row__toggle--disabled': disabled,
-              'pipeline-row__toggle--selected': selected,
-              'pipeline-row__toggle--not-tag': type !== 'tag'
-            }
-          )}>
+          className={classnames('pipeline-row__toggle', {
+            'pipeline-row__toggle--disabled': disabled,
+            'pipeline-row__toggle--selected': selected,
+            'pipeline-row__toggle--not-tag': type !== 'tag'
+          })}>
           <input
             id={id}
             className="pipeline-nodelist__row__checkbox"
@@ -136,9 +134,12 @@ const NodeListRow = memo(
               'pipeline-row__toggle-icon',
               `pipeline-row__toggle-icon--kind-${kind}`,
               {
+                'pipeline-row__toggle-icon--parent': Boolean(children),
+                'pipeline-row__toggle-icon--child': !children,
                 'pipeline-row__toggle-icon--checked': checked,
                 'pipeline-row__toggle-icon--unchecked': !checked,
-                'pipeline-row__toggle-icon--unset': unset
+                'pipeline-row__toggle-icon--unset': unset,
+                'pipeline-row__toggle-icon--all-unset': allUnset
               }
             )}
           />

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -57,7 +57,7 @@ const NodeListRow = memo(
     invisibleIcon = InvisibleIcon
   }) => {
     const VisibilityIcon = checked ? visibleIcon : invisibleIcon;
-    const TextButton = onClick ? 'button' : 'div';
+    const TextButton = onClick && kind !== 'filter' ? 'button' : 'div';
 
     return (
       <Container

--- a/src/components/node-list/styles/_filter.scss
+++ b/src/components/node-list/styles/_filter.scss
@@ -35,7 +35,7 @@
 }
 
 // Hide all indicators when all unset
-.pipeline-nodelist__group--all-unset .pipeline-row__toggle--kind-filter {
+.pipeline-nodelist__group--all-unset .pipeline-row__toggle--kind-filter > * {
   opacity: 0;
 }
 
@@ -43,9 +43,11 @@
 .pipeline-nodelist__group--all-unset
   .pipeline-nodelist__row:hover
   .pipeline-row__toggle--kind-filter {
-  opacity: 0.55;
+  > * {
+    opacity: 0.55;
+  }
 
-  &:hover {
+  &:hover > * {
     opacity: 0.55;
   }
 }
@@ -60,25 +62,25 @@
 
 .pipeline-row__toggle-icon--kind-filter {
   // Fade indicator when unchecked or unset
-  &.pipeline-row__toggle-icon--unchecked,
-  &.pipeline-row__toggle-icon--unset {
+  &.pipeline-row__toggle-icon--unchecked > *,
+  &.pipeline-row__toggle-icon--unset > * {
     // condition 2: semi-bright indicator when checked but not hovered
     opacity: 0.55;
   }
 
   // brighten up indicator when hovering over toggle all tag button
   &.pipeline-row__toggle-icon--unchecked {
-    .pipeline-row-toggle-icon-visible:hover & {
+    .pipeline-row-toggle-icon-visible:hover & > * {
       opacity: 1;
     }
   }
 
-  &.pipeline-row__toggle-icon--checked {
+  &.pipeline-row__toggle-icon--checked > * {
     // condition 3: Bright indicator when checked but not hovered
     opacity: 0.75;
 
     // condition 4: Brightest indicator when checked and hovered on the entire row
-    .pipeline-nodelist__row--visible:hover & {
+    .pipeline-nodelist__row--visible:hover & > * {
       opacity: 1;
     }
   }

--- a/src/components/node-list/styles/_filter.scss
+++ b/src/components/node-list/styles/_filter.scss
@@ -17,20 +17,20 @@
 }
 
 // Fade row text when unchecked
-.pipeline-nodelist__row--unchecked .pipeline-nodelist__row__text--kind-filter {
+.pipeline-nodelist__row--unchecked .pipeline-nodelist__row__label--kind-filter {
   opacity: 0.55;
 }
 
 // Brighter row text when unchecked and hovered
 .pipeline-nodelist__row--unchecked:hover
-  .pipeline-nodelist__row__text--kind-filter {
+  .pipeline-nodelist__row__label--kind-filter {
   opacity: 0.8;
 }
 
 // Bright row text when all unset
 .pipeline-nodelist__group--all-unset
   .pipeline-nodelist__row--unchecked
-  .pipeline-nodelist__row__text--kind-filter {
+  .pipeline-nodelist__row__label--kind-filter {
   opacity: 1;
 }
 

--- a/src/components/node-list/styles/_filter.scss
+++ b/src/components/node-list/styles/_filter.scss
@@ -3,6 +3,31 @@
 @import '../../../styles/variables';
 @import './variables';
 
+//--- Text label ---//
+
+.pipeline-nodelist__row--unchecked {
+  // Fade row text when unchecked
+  .pipeline-nodelist__row__label--kind-filter {
+    opacity: 0.55;
+  }
+
+  // Brighter row text when unchecked and hovered
+  &:hover {
+    .pipeline-nodelist__row__label--kind-filter {
+      opacity: 0.8;
+    }
+  }
+
+  // Bright row text when all unset
+  .pipeline-nodelist__group--all-unset & {
+    .pipeline-nodelist__row__label--kind-filter {
+      opacity: 1;
+    }
+  }
+}
+
+//--- Toggle icon fills and strokes ---//
+
 .pipeline-row__toggle-icon--kind-filter {
   &.pipeline-row__toggle-icon--checked {
     fill: var(--color-nodelist-filter-indicator-on);
@@ -14,74 +39,89 @@
     fill: none;
     stroke: var(--color-nodelist-filter-indicator-off);
   }
-}
 
-// Fade row text when unchecked
-.pipeline-nodelist__row--unchecked .pipeline-nodelist__row__label--kind-filter {
-  opacity: 0.55;
-}
-
-// Brighter row text when unchecked and hovered
-.pipeline-nodelist__row--unchecked:hover
-  .pipeline-nodelist__row__label--kind-filter {
-  opacity: 0.8;
-}
-
-// Bright row text when all unset
-.pipeline-nodelist__group--all-unset
-  .pipeline-nodelist__row--unchecked
-  .pipeline-nodelist__row__label--kind-filter {
-  opacity: 1;
-}
-
-// Hide all indicators when all unset
-.pipeline-nodelist__group--all-unset .pipeline-row__toggle--kind-filter > * {
-  opacity: 0;
-}
-
-// Show indicator when all unset and row hovered
-.pipeline-nodelist__group--all-unset
-  .pipeline-nodelist__row:hover
-  .pipeline-row__toggle--kind-filter {
-  > * {
-    opacity: 0.55;
-  }
-
-  &:hover > * {
-    opacity: 0.55;
+  .pipeline-nodelist__row:hover &.pipeline-row__toggle-icon--all-unset,
+  [data-whatintent='keyboard'] .pipeline-nodelist__row__checkbox:focus + &,
+  &.pipeline-row__toggle-icon--parent {
+    fill: $color-primary;
+    stroke: $color-primary;
   }
 }
 
-// Show unchecked indicators as solid blue when all unset
-.pipeline-nodelist__group--all-unset
-  .pipeline-nodelist__row:hover
-  .pipeline-row__toggle-icon--kind-filter {
-  fill: $color-primary;
-  stroke: $color-primary;
-}
+//--- Toggle icon opacities ---//
+
+/*
+ Parent (toggle all tags):
+ | row-hover | icon-hover | checked | opacity | ID |
+ |    🚫     |     🚫      |    🚫   |    0    | 0  |
+ |    ✅     |     🚫      |    🚫   |   0.3   | 1  |
+ |    ✅     |     ✅      |    🚫   |   0.55  | 2  |
+ |    🚫     |     🚫      |    ✅   |   0.55  | 2  |
+ |    ✅     |     ✅      |    ✅   |   0.75  | 3  |
+
+ Child (individual tag):
+ | row-hover | checked | opacity | ID |
+ |    🚫     |    🚫    |    0    | 0  |
+ |    ✅     |    🚫    |   0.3   | 1  |
+ |    🚫     |    ✅    |   0.55  | 2  |
+ |    ✅     |    ✅    |   0.75  | 3  |
+ */
+
+$icon-opacity-0: 0;
+$icon-opacity-1: 0.3;
+$icon-opacity-2: 0.55;
+$icon-opacity-3: 0.75;
 
 .pipeline-row__toggle-icon--kind-filter {
-  // Fade indicator when unchecked or unset
-  &.pipeline-row__toggle-icon--unchecked > *,
-  &.pipeline-row__toggle-icon--unset > * {
-    // condition 2: semi-bright indicator when checked but not hovered
-    opacity: 0.55;
+  // Change opacity on child elements instead, in order to maintain 100% opacity
+  // outline on parent SVG element on keyboard focus
+  > * {
+    opacity: $icon-opacity-1;
   }
 
-  // brighten up indicator when hovering over toggle all tag button
-  &.pipeline-row__toggle-icon--unchecked {
-    .pipeline-row-toggle-icon-visible:hover & > * {
-      opacity: 1;
+  &.pipeline-row__toggle-icon--all-unset {
+    > * {
+      opacity: $icon-opacity-0;
     }
   }
 
-  &.pipeline-row__toggle-icon--checked > * {
-    // condition 3: Bright indicator when checked but not hovered
-    opacity: 0.75;
+  .pipeline-nodelist__row:hover & {
+    > * {
+      opacity: $icon-opacity-1;
+    }
+  }
 
-    // condition 4: Brightest indicator when checked and hovered on the entire row
-    .pipeline-nodelist__row--visible:hover & > * {
-      opacity: 1;
+  .pipeline-nodelist__row:hover & {
+    &.pipeline-row__toggle-icon--parent:hover {
+      > * {
+        opacity: $icon-opacity-2;
+      }
+    }
+  }
+
+  &.pipeline-row__toggle-icon--checked {
+    > * {
+      opacity: $icon-opacity-2;
+    }
+  }
+
+  .pipeline-nodelist__row:hover & {
+    &.pipeline-row__toggle-icon--child {
+      &.pipeline-row__toggle-icon--checked {
+        > * {
+          opacity: $icon-opacity-3;
+        }
+      }
+    }
+  }
+
+  .pipeline-nodelist__row & {
+    &.pipeline-row__toggle-icon--parent:hover {
+      &.pipeline-row__toggle-icon--checked {
+        > * {
+          opacity: $icon-opacity-3;
+        }
+      }
     }
   }
 }

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -174,15 +174,26 @@
   padding: $toggle-icon-padding;
   border-radius: 50%;
 
+  // Change opacity on the SVG's child elements instead, in order to
+  // maintain 100% opacity outline on parent SVG on keyboard focus
   > * {
     opacity: 0;
   }
 }
 
-// this class enables the 'eye' icon of nodes to be visible on hover of the nodes
-.pipeline-row__toggle-icon--kind-toggle {
-  .pipeline-nodelist__row:hover & > * {
-    opacity: 0.55;
+.pipeline-nodelist__row:hover {
+  .pipeline-row__toggle-icon--kind-toggle {
+    > * {
+      opacity: 0.55;
+    }
+  }
+}
+
+.pipeline-nodelist__row {
+  .pipeline-row__toggle-icon--kind-toggle:hover {
+    > * {
+      opacity: 1;
+    }
   }
 }
 
@@ -195,18 +206,11 @@
     > * {
       opacity: 0.55;
     }
-  }
-}
 
-.pipeline-nodelist__row__checkbox:focus + .pipeline-row__toggle-icon--checked {
-  [data-whatintent='keyboard'] & > * {
-    opacity: 1;
-  }
-}
-
-// Hover states for non-filter type icons
-.pipeline-nodelist__row {
-  .pipeline-row__toggle-icon--kind-toggle:hover > * {
-    opacity: 1;
+    &--checked {
+      > * {
+        opacity: 1;
+      }
+    }
   }
 }

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -205,8 +205,8 @@
 }
 
 // Hover states for non-filter type icons
-.pipeline-row__toggle-icon--visible:hover {
-  .pipeline-nodelist__row & > * {
+.pipeline-nodelist__row {
+  .pipeline-row__toggle-icon--kind-toggle:hover > * {
     opacity: 1;
   }
 }

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -37,7 +37,7 @@
   height: $row-icon-size;
   fill: var(--color-text);
 
-  &--disabled {
+  &--disabled > * {
     opacity: 0.1;
   }
 }
@@ -46,11 +46,11 @@
   margin-right: $row-icon-margin;
   margin-left: -1em;
 
-  &--nested {
+  &--nested > * {
     opacity: 0.3;
   }
 
-  &--faded {
+  &--faded > * {
     opacity: 0.2;
   }
 
@@ -58,9 +58,11 @@
   &--selected,
   .pipeline-nodelist__row--visible:hover &,
   [data-whatintent='keyboard'] .pipeline-nodelist__row__text:focus & {
-    opacity: 1;
+    > * {
+      opacity: 1;
+    }
 
-    &--faded {
+    &--faded > * {
       opacity: 0.55;
     }
   }
@@ -171,12 +173,15 @@
   height: $toggle-icon-size;
   padding: $toggle-icon-padding;
   border-radius: 50%;
-  opacity: 0;
+
+  > * {
+    opacity: 0;
+  }
 }
 
 // this class enables the 'eye' icon of nodes to be visible on hover of the nodes
 .pipeline-row__toggle-icon--kind-toggle {
-  .pipeline-nodelist__row:hover & {
+  .pipeline-nodelist__row:hover & > * {
     opacity: 0.55;
   }
 }
@@ -186,19 +191,22 @@
 
   [data-whatintent='keyboard'] & {
     box-shadow: 0 0 0 3px $color-link inset;
-    opacity: 0.55;
+
+    > * {
+      opacity: 0.55;
+    }
   }
 }
 
 .pipeline-nodelist__row__checkbox:focus + .pipeline-row__toggle-icon--checked {
-  [data-whatintent='keyboard'] & {
+  [data-whatintent='keyboard'] & > * {
     opacity: 1;
   }
 }
 
 // Hover states for non-filter type icons
 .pipeline-row__toggle-icon--visible:hover {
-  .pipeline-nodelist__row & {
+  .pipeline-nodelist__row & > * {
     opacity: 1;
   }
 }


### PR DESCRIPTION
## Description

1. Previously, hidden icons would stay hidden when focused with a keyboard, or would stay semi-transparent when partly faded, which would make their outline difficult to make out. By moving the opacity changes to the SVG children (e.g. path/rect elements), the blue outlines on the parent remain visible at 100% opacity even when the child element has reduced opacity. I've used `> *` on this to select only the immediate children and keep the rule agnostic as to element type.
2. For tag rows, there were two focusable elements that did the same thing on click (a button and a checkbox input). The button was also present on parent rows (e.g. category titles), but did nothing. I've removed the button where it does nothing or is otherwise superfluous, and replaced it with a div.
3. I've refactored a lot of the CSS to make the rules easier to read, mostly by making them indented using Sass, because the long lines of run-on rules were getting difficult to read and I think breaking them up in this way actually makes them easier to parse.

## Development notes

See commit titles + descriptions for a detailed breakdown of changes.

## QA notes

Please check the hover/focus/checked/unchecked/toggle-all styles for the node and tag lists, both with lazy-loading turned on/off (`?lazy=0`). I've tried to keep things working more or less as before, so please compare to the demo branch. The only major difference is that tabbing through the list on a keyboard will skip over unused/superfluous buttons.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
