### PR TITLE
[KED-2381] Improve responsive zoom approach

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -6,17 +6,15 @@ export const localStorageName = 'KedroViz';
 // across Sass and JavaScript, so they're defined in two places. If you update their
 // value here, please also update their corresponding value in src/styles/_variables.scss
 export const metaSidebarWidth = {
-  breakpoint: 1200,
   open: 400,
   closed: 0
 };
 export const sidebarWidth = {
-  breakpoint: 700,
   open: 400,
   closed: 56
 };
 
-export const chartMinWidth = 1200;
+export const chartMinWidthScale = 0.25;
 
 // Remember to update the 'Flags' section in the README when updating these:
 export const flags = {

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -3,7 +3,7 @@ import { getVisibleNodes } from './nodes';
 import { getVisibleEdges } from './edges';
 import { getVisibleLayerIDs } from './disabled';
 import { getVisibleMetaSidebar } from '../selectors/metadata';
-import { sidebarWidth, metaSidebarWidth } from '../config';
+import { sidebarWidth, metaSidebarWidth, chartMinWidthScale } from '../config';
 
 const getOldgraphFlag = state => state.flags.oldgraph;
 const getVisibleSidebar = state => state.visible.sidebar;
@@ -32,8 +32,8 @@ export const getGraphInput = createSelector(
 /**
  * Calculate the displayed width of a sidebar
  */
-export const getSidebarWidth = (visible, width, { breakpoint, open, closed }) =>
-  visible && width > breakpoint ? open : closed;
+export const getSidebarWidth = (visible, { open, closed }) =>
+  visible ? open : closed;
 
 /**
  * Convert the DOMRect into an Object, mutate some of the properties,
@@ -48,19 +48,14 @@ export const getChartSize = createSelector(
     }
 
     // Get the actual sidebar width
-    const sidebarWidthActual = getSidebarWidth(
-      visibleSidebar,
-      width,
-      sidebarWidth
-    );
+    const sidebarWidthActual = getSidebarWidth(visibleSidebar, sidebarWidth);
     const metaSidebarWidthActual = getSidebarWidth(
-      width,
       visibleMetaSidebar,
       metaSidebarWidth
     );
 
     // Find the resulting space for the chart
-    const chartWidth = width - sidebarWidthActual - metaSidebarWidthActual;
+    let chartWidth = width - sidebarWidthActual - metaSidebarWidthActual;
 
     return {
       left,
@@ -69,6 +64,7 @@ export const getChartSize = createSelector(
       outerHeight: height,
       height,
       width: chartWidth,
+      minWidthScale: chartMinWidthScale,
       sidebarWidth: sidebarWidthActual,
       metaSidebarWidth: metaSidebarWidthActual
     };

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -55,7 +55,7 @@ export const getChartSize = createSelector(
     );
 
     // Find the resulting space for the chart
-    let chartWidth = width - sidebarWidthActual - metaSidebarWidthActual;
+    const chartWidth = width - sidebarWidthActual - metaSidebarWidthActual;
 
     return {
       left,

--- a/src/selectors/layout.test.js
+++ b/src/selectors/layout.test.js
@@ -2,7 +2,7 @@ import { mockState } from '../utils/state.mock';
 import { getChartSize, getSidebarWidth, getGraphInput } from './layout';
 import { updateFontLoaded } from '../actions';
 import reducer from '../reducers';
-import { sidebarBreakpoint, sidebarWidth } from '../config';
+import { sidebarWidth } from '../config';
 
 describe('Selectors', () => {
   describe('getGraphInput', () => {
@@ -25,29 +25,12 @@ describe('Selectors', () => {
   });
 
   describe('getSidebarWidth', () => {
-    const { open, closed } = sidebarWidth;
-
-    describe('if sidebar is visible', () => {
-      it(`reduces the chart width by ${open} on screens wider than ${sidebarBreakpoint}`, () => {
-        expect(getSidebarWidth(true, 1200, sidebarWidth)).toEqual(open);
-        expect(getSidebarWidth(true, 900, sidebarWidth)).toEqual(open);
-      });
-
-      it(`sets sidebar width to ${closed} on screens smaller than ${sidebarBreakpoint}`, () => {
-        expect(getSidebarWidth(true, 480, sidebarWidth)).toEqual(closed);
-        expect(getSidebarWidth(true, 320, sidebarWidth)).toEqual(closed);
-      });
+    it(`if visible is true returns the 'open' width`, () => {
+      expect(getSidebarWidth(true, sidebarWidth)).toEqual(sidebarWidth.open);
     });
 
-    describe('if sidebar is hidden', () => {
-      it(`sets sidebar width to ${closed} on screens wider than ${sidebarBreakpoint}`, () => {
-        expect(getSidebarWidth(false, 1000, sidebarWidth)).toEqual(closed);
-      });
-
-      it(`sets sidebar width to ${closed} on screens smaller than ${sidebarBreakpoint}`, () => {
-        expect(getSidebarWidth(false, 480, sidebarWidth)).toEqual(closed);
-        expect(getSidebarWidth(false, 320, sidebarWidth)).toEqual(closed);
-      });
+    it(`if visble is false returns the 'closed' width`, () => {
+      expect(getSidebarWidth(false, sidebarWidth)).toEqual(sidebarWidth.closed);
     });
   });
 
@@ -76,6 +59,7 @@ describe('Selectors', () => {
         outerWidth: expect.any(Number),
         sidebarWidth: expect.any(Number),
         metaSidebarWidth: expect.any(Number),
+        minWidthScale: expect.any(Number),
         top: expect.any(Number),
         width: expect.any(Number)
       });


### PR DESCRIPTION
## Description

Improves responsive zoom approach to work as follows, in order of precedence

- once, after any graph or sidebar change
  - fit whole graph
  - centre whole graph
  - crop graph when reaching a minimum usable scale
- once, after an element is selected
  - respect the above constraints, and
  - ensure node is clearly visible between panels
  - apply an increased minimum scale
- once, after a browser resize
  - respect all the above constraints
- at any other time
  - allow user pan and zoom freely within extents

## Development notes

This functionality is a usability improvement and is much needed as new sidebars are being added.

A follow up PR will refactor the view system in general now that it is outgrowing its current shape.

## QA notes

Use the above description as a guide for requirements and testing.

Note that some edge cases may not appear to be an 'optimal' view, but none should be broken.

This will include testing in various combinations:

- open / closed sidebar and metadata panel
- resizing the browser to various viewport sizes / aspect ratios
- different graph aspect ratios (square, wide, tall)
- selecting elements on the sidebar and on the chart
- selecting tags and pipelines
- toggling labels

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
