### PR TITLE
Fix node-list-row line-height regression

### DIFF
--- a/src/components/node-list/styles/_row-label.scss
+++ b/src/components/node-list/styles/_row-label.scss
@@ -11,6 +11,7 @@
   color: inherit;
   font-size: inherit;
   font-family: inherit;
+  line-height: 1.6;
   letter-spacing: inherit;
   text-align: inherit;
   background: none;


### PR DESCRIPTION
## Description

This was broken in #355: The line-height of the button element was different from the div, which caused a small height difference.

## Development notes

Before: 
![image](https://user-images.githubusercontent.com/1155816/106279251-05cbdd00-6234-11eb-8116-194a0f8a5129.png)

After:
![image](https://user-images.githubusercontent.com/1155816/106279276-11b79f00-6234-11eb-84cc-7d1122c476db.png)


## QA notes

Compare to https://quantumblacklabs.github.io/kedro-viz/ to spot the difference

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
