### PR TITLE
[KED-2210] Repeatedly attempt dependency installs on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
     steps:
       - run:
           name: Install Node dependencies
-          command: npm ci
+          command: node tools/ci.js
 
   test_lib_transpilation:
     steps:

--- a/tools/ci.js
+++ b/tools/ci.js
@@ -1,0 +1,28 @@
+const { execSync } = require('child_process');
+
+/**
+ * Running `npm ci` fails about 5% of the time on Windows in CircleCI.
+ * This appears to be an issue with the 'fsevents' subdependency:
+ * https://github.com/fsevents/fsevents/issues/301
+ *
+ * Attempts to fix it have failed, so this workaround instructs CircleCI to try
+ * repeatedly to install dependencies, and only stop after 5 failed attempts.
+ */
+
+const maxAttempts = 5;
+
+for (let i = 1; i <= maxAttempts; i++) {
+  try {
+    console.log(`Installing dependencies, attempt ${i} of ${maxAttempts}...`);
+    console.log('$ npm ci');
+    execSync(`npm ci`, { stdio: 'inherit' });
+    break;
+  } catch (e) {
+    if (i === maxAttempts) {
+      throw new Error(e);
+    } else {
+      console.log(`Attempt ${i} failed.`);
+      console.error(e);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Running `npm ci` tends to fail about 5% of the time on Windows in CircleCI. This appears to be [an issue with the 'fsevents' subdependency](https://github.com/fsevents/fsevents/issues/301).

Attempts to fix it have failed, so this workaround instructs CircleCI to try repeatedly to install dependencies, and only stop after 5 failed attempts. That way, I figure that if at first it doesn't succeed, it should work on subsequent attempts. If after 5 attempts it still hasn't succeeded, then there is probably a deeper underlying issue and it should throw an error.

## Development notes

I've used a NodeJS script because that seemed easiest.

## QA notes

I've [set up a branch running this on CircleCI every ten minutes](https://app.circleci.com/pipelines/github/quantumblacklabs/kedro-viz?branch=fix%2Fwindows-npm-ci-test), to test it out. [You can see it working in this run](https://app.circleci.com/pipelines/github/quantumblacklabs/kedro-viz/3054/workflows/fbe8af90-854e-4cc8-8fc7-8225a20ebfdf/jobs/9923) - the first install attempt failed, but the second one succeeded! 🙌 

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
