### PR TITLE
[KED-2409] Update docs to remind on compatibility of Kedro-Viz 3.8.0 with Kedro 0.17

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,8 @@ npm run lib
 
 #### Launch a development server with a real Kedro project
 
+> **Note**: It's likely that Kedro-viz 3.8.0 and later versions will not work with projects created with older versions of Kedro (0.16.0). Please consider migrating your project to Kedro 0.17.0 before your development against the latest version of Kedro-viz. 
+
 Before launching a development server with a real Kedro project, you'd need to have [Python](https://www.python.org/)(>=3.6, <3.9) and Kedro installed. We strongly recommend setting up [conda](https://docs.conda.io/en/latest/) to manage your Python versions and virtual environments. You can visit Kedro's guide for installing [conda](https://kedro.readthedocs.io/en/latest/02_get_started/01_prerequisites.html#conda) and [how to get started with Kedro](https://kedro.readthedocs.io/en/latest/02_get_started/02_install.html) for more information.
 
 After setting up Python and Kedro, you will need to have a Kedro project setup. If you don't have any existing Kedro project, you can create a new one with the `spaceflights` example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ npm run lib
 
 #### Launch a development server with a real Kedro project
 
-> **Note**: Kedro-Viz>=3.8.0 will not work with projects created with Kedro<=0.16.6. Please consider migrating your project to Kedro>=0.17.0 before your development against the latest version of Kedro-Viz. 
+> **Note**: Kedro-Viz>=3.8.0 will not work with projects created with Kedro<=0.16.6. Please consider migrating your project to Kedro>=0.17.0 before you develop against the latest version of Kedro-Viz. 
 
 Before launching a development server with a real Kedro project, you'd need to have [Python](https://www.python.org/)(>=3.6, <3.9) and Kedro installed. We strongly recommend setting up [conda](https://docs.conda.io/en/latest/) to manage your Python versions and virtual environments. You can visit Kedro's guide for installing [conda](https://kedro.readthedocs.io/en/latest/02_get_started/01_prerequisites.html#conda) and [how to get started with Kedro](https://kedro.readthedocs.io/en/latest/02_get_started/02_install.html) for more information.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ npm run lib
 
 #### Launch a development server with a real Kedro project
 
-> **Note**: Kedro-viz 3.8.0 and later versions will not work with projects created with Kedro<=0.16.6. Please consider migrating your project to Kedro>=0.17.0 before your development against the latest version of Kedro-viz. 
+> **Note**: Kedro-viz>=3.8.0 will not work with projects created with Kedro<=0.16.6. Please consider migrating your project to Kedro>=0.17.0 before your development against the latest version of Kedro-viz. 
 
 Before launching a development server with a real Kedro project, you'd need to have [Python](https://www.python.org/)(>=3.6, <3.9) and Kedro installed. We strongly recommend setting up [conda](https://docs.conda.io/en/latest/) to manage your Python versions and virtual environments. You can visit Kedro's guide for installing [conda](https://kedro.readthedocs.io/en/latest/02_get_started/01_prerequisites.html#conda) and [how to get started with Kedro](https://kedro.readthedocs.io/en/latest/02_get_started/02_install.html) for more information.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ npm run lib
 
 #### Launch a development server with a real Kedro project
 
-> **Note**: It's likely that Kedro-viz 3.8.0 and later versions will not work with projects created with older versions of Kedro (0.16.0). Please consider migrating your project to Kedro 0.17.0 before your development against the latest version of Kedro-viz. 
+> **Note**: Kedro-viz 3.8.0 and later versions will not work with projects created with Kedro<=0.16.6. Please consider migrating your project to Kedro>=0.17.0 before your development against the latest version of Kedro-viz. 
 
 Before launching a development server with a real Kedro project, you'd need to have [Python](https://www.python.org/)(>=3.6, <3.9) and Kedro installed. We strongly recommend setting up [conda](https://docs.conda.io/en/latest/) to manage your Python versions and virtual environments. You can visit Kedro's guide for installing [conda](https://kedro.readthedocs.io/en/latest/02_get_started/01_prerequisites.html#conda) and [how to get started with Kedro](https://kedro.readthedocs.io/en/latest/02_get_started/02_install.html) for more information.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ npm run lib
 
 #### Launch a development server with a real Kedro project
 
-> **Note**: Kedro-viz>=3.8.0 will not work with projects created with Kedro<=0.16.6. Please consider migrating your project to Kedro>=0.17.0 before your development against the latest version of Kedro-viz. 
+> **Note**: Kedro-Viz>=3.8.0 will not work with projects created with Kedro<=0.16.6. Please consider migrating your project to Kedro>=0.17.0 before your development against the latest version of Kedro-Viz. 
 
 Before launching a development server with a real Kedro project, you'd need to have [Python](https://www.python.org/)(>=3.6, <3.9) and Kedro installed. We strongly recommend setting up [conda](https://docs.conda.io/en/latest/) to manage your Python versions and virtual environments. You can visit Kedro's guide for installing [conda](https://kedro.readthedocs.io/en/latest/02_get_started/01_prerequisites.html#conda) and [how to get started with Kedro](https://kedro.readthedocs.io/en/latest/02_get_started/02_install.html) for more information.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 > For in-depth development and usage notes, see the [Contribution Guidelines](https://github.com/quantumblacklabs/kedro-viz/blob/main/CONTRIBUTING.md).
 
+> It's likely that Kedro-viz 3.8.0 and later versions will not work with projects created with older versions of Kedro (0.16.0). Please migrate your project to Kedro 0.17.0 before installation of the latest version of Kedro-viz.
+
 ### As a Kedro Python plugin
 
 Kedro-Viz is available as a Python plugin named `kedro-viz`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 > For in-depth development and usage notes, see the [Contribution Guidelines](https://github.com/quantumblacklabs/kedro-viz/blob/main/CONTRIBUTING.md).
 
-> It's likely that Kedro-viz 3.8.0 and later versions will not work with projects created with older versions of Kedro (0.16.0). Please migrate your project to Kedro 0.17.0 before installation of the latest version of Kedro-viz.
+> It's likely that Kedro-viz 3.8.0 and later versions will not work with projects created with older versions of Kedro<=0.16.6. Please migrate your project to Kedro>=0.17.0 before installation of the latest version of Kedro-viz.
 
 ### As a Kedro Python plugin
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 > For in-depth development and usage notes, see the [Contribution Guidelines](https://github.com/quantumblacklabs/kedro-viz/blob/main/CONTRIBUTING.md).
 
-> It's likely that Kedro-viz 3.8.0 and later versions will not work with projects created with older versions of Kedro<=0.16.6. Please migrate your project to Kedro>=0.17.0 before installation of the latest version of Kedro-viz.
+> It's likely that Kedro-viz>=3.8.0 will not work with projects created with older versions of Kedro<=0.16.6. Please migrate your project to Kedro>=0.17.0 before installation of the latest version of Kedro-viz.
 
 ### As a Kedro Python plugin
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 > For in-depth development and usage notes, see the [Contribution Guidelines](https://github.com/quantumblacklabs/kedro-viz/blob/main/CONTRIBUTING.md).
 
-> It's likely that Kedro-viz>=3.8.0 will not work with projects created with older versions of Kedro<=0.16.6. Please migrate your project to Kedro>=0.17.0 before installation of the latest version of Kedro-viz.
+> It's likely that Kedro-Viz>=3.8.0 will not work with projects created with older versions of Kedro<=0.16.6. Please migrate your project to Kedro>=0.17.0 before installation of the latest version of Kedro-Viz.
 
 ### As a Kedro Python plugin
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,6 +28,8 @@ Please follow the established format:
 
 ## Major features and improvements
 
+Please note that release >=3.8.0 will not work with projects created with older versions of Kedro<=0.16.6. Please migrate your project to Kedro>=0.17.0 before installation of the latest version of Kedro-viz.
+
 - Finish the new node metadata side panel, which allows you to switch between different modular pipelines. This feature is no longer hidden behind a flag, and the 'meta' flag has been removed. (#293, #309, #312, #320, #321, #326, #295, #329, #333)
 - Enable the new graphing layout algorithm by default, and remove the 'newgraph' feature flag. If necessary, you can still revert back to the old layout algorithm by enabling the 'oldgraph' flag. (#334, #335)
 - Add experimental flagged feature to allow lazy-loading of sidebar node-list rows on scroll. This improves performance by not forcing the app to render the entire node-list on larger graphs. This feature is disabled by default, but can be enabled using the 'lazy' feature flag. (#307)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,7 +28,7 @@ Please follow the established format:
 
 ## Major features and improvements
 
-Please note that release >=3.8.0 will not work with projects created with older versions of Kedro<=0.16.6. Please migrate your project to Kedro>=0.17.0 before installation of the latest version of Kedro-viz.
+Please note that release >=3.8.0 will not work with projects created with older versions of Kedro<=0.16.6. Please migrate your project to Kedro>=0.17.0 before installation of the latest version of Kedro-Viz.
 
 - Finish the new node metadata side panel, which allows you to switch between different modular pipelines. This feature is no longer hidden behind a flag, and the 'meta' flag has been removed. (#293, #309, #312, #320, #321, #326, #295, #329, #333)
 - Enable the new graphing layout algorithm by default, and remove the 'newgraph' feature flag. If necessary, you can still revert back to the old layout algorithm by enabling the 'oldgraph' flag. (#334, #335)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,7 +28,7 @@ Please follow the established format:
 
 ## Major features and improvements
 
-Please note that release >=3.8.0 will not work with projects created with older versions of Kedro<=0.16.6. Please migrate your project to Kedro>=0.17.0 before installation of the latest version of Kedro-Viz.
+Please note that release >=3.8.0 will not work with projects created with older versions of Kedro<=0.16.6. Please migrate your project to Kedro>=0.17.0 before you install the latest version of Kedro-Viz.
 
 - Finish the new node metadata side panel, which allows you to switch between different modular pipelines. This feature is no longer hidden behind a flag, and the 'meta' flag has been removed. (#293, #309, #312, #320, #321, #326, #295, #329, #333)
 - Enable the new graphing layout algorithm by default, and remove the 'newgraph' feature flag. If necessary, you can still revert back to the old layout algorithm by enabling the 'oldgraph' flag. (#334, #335)


### PR DESCRIPTION
## Description

Related ticket: https://jira.quantumblack.com/browse/KED-2409

This ticket is raised given the imcompatibility issues experienced by Go, which raises the need to update our docs to remind our users of compatibility issues and to update to the latest version of Kedro to install and run the latest version of Kedro-Viz. 

## Development notes

I have updated both the readme and the contributing docs. 

## QA notes
N/A

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
