### PR TITLE
[KED-2421] Reformat all JavaScript in /src with Prettier

### DIFF
--- a/src/actions/actions.test.js
+++ b/src/actions/actions.test.js
@@ -17,7 +17,7 @@ import {
   toggleTextLabels,
   toggleTheme,
   updateChartSize,
-  updateFontLoaded
+  updateFontLoaded,
 } from '../actions';
 import {
   TOGGLE_NODE_CLICKED,
@@ -25,13 +25,13 @@ import {
   TOGGLE_NODE_HOVERED,
   toggleNodeClicked,
   toggleNodesDisabled,
-  toggleNodeHovered
+  toggleNodeHovered,
 } from '../actions/nodes';
 import {
   TOGGLE_TAG_ACTIVE,
   TOGGLE_TAG_FILTER,
   toggleTagActive,
-  toggleTagFilter
+  toggleTagFilter,
 } from '../actions/tags';
 import { TOGGLE_TYPE_DISABLED, toggleTypeDisabled } from '../actions/node-type';
 
@@ -39,7 +39,7 @@ describe('actions', () => {
   it('should create an action to reset pipeline data', () => {
     const expectedAction = {
       type: RESET_DATA,
-      data: animals
+      data: animals,
     };
     expect(resetData(animals)).toEqual(expectedAction);
   });
@@ -48,7 +48,7 @@ describe('actions', () => {
     const visible = false;
     const expectedAction = {
       type: TOGGLE_LAYERS,
-      visible
+      visible,
     };
     expect(toggleLayers(visible)).toEqual(expectedAction);
   });
@@ -57,7 +57,7 @@ describe('actions', () => {
     const visible = false;
     const expectedAction = {
       type: TOGGLE_EXPORT_MODAL,
-      visible
+      visible,
     };
     expect(toggleExportModal(visible)).toEqual(expectedAction);
   });
@@ -66,7 +66,7 @@ describe('actions', () => {
     const visible = false;
     const expectedAction = {
       type: TOGGLE_SIDEBAR,
-      visible
+      visible,
     };
     expect(toggleSidebar(visible)).toEqual(expectedAction);
   });
@@ -75,7 +75,7 @@ describe('actions', () => {
     const nodeClicked = '12367890';
     const expectedAction = {
       type: TOGGLE_NODE_CLICKED,
-      nodeClicked
+      nodeClicked,
     };
     expect(toggleNodeClicked(nodeClicked)).toEqual(expectedAction);
   });
@@ -84,7 +84,7 @@ describe('actions', () => {
     const nodeHovered = '12367890';
     const expectedAction = {
       type: TOGGLE_NODE_HOVERED,
-      nodeHovered
+      nodeHovered,
     };
     expect(toggleNodeHovered(nodeHovered)).toEqual(expectedAction);
   });
@@ -95,7 +95,7 @@ describe('actions', () => {
     const expectedAction = {
       type: TOGGLE_NODES_DISABLED,
       nodeIDs,
-      isDisabled
+      isDisabled,
     };
     expect(toggleNodesDisabled(nodeIDs, isDisabled)).toEqual(expectedAction);
   });
@@ -104,7 +104,7 @@ describe('actions', () => {
     const textLabels = false;
     const expectedAction = {
       type: TOGGLE_TEXT_LABELS,
-      textLabels
+      textLabels,
     };
     expect(toggleTextLabels(textLabels)).toEqual(expectedAction);
   });
@@ -115,7 +115,7 @@ describe('actions', () => {
     const expectedAction = {
       type: TOGGLE_TAG_ACTIVE,
       tagIDs: [tagID],
-      active
+      active,
     };
     expect(toggleTagActive(tagID, active)).toEqual(expectedAction);
   });
@@ -126,7 +126,7 @@ describe('actions', () => {
     const expectedAction = {
       type: TOGGLE_TAG_ACTIVE,
       tagIDs,
-      active
+      active,
     };
     expect(toggleTagActive(tagIDs, active)).toEqual(expectedAction);
   });
@@ -137,7 +137,7 @@ describe('actions', () => {
     const expectedAction = {
       type: TOGGLE_TAG_FILTER,
       tagIDs: [tagID],
-      enabled
+      enabled,
     };
     expect(toggleTagFilter(tagID, enabled)).toEqual(expectedAction);
   });
@@ -148,7 +148,7 @@ describe('actions', () => {
     const expectedAction = {
       type: TOGGLE_TAG_FILTER,
       tagIDs,
-      enabled
+      enabled,
     };
     expect(toggleTagFilter(tagIDs, enabled)).toEqual(expectedAction);
   });
@@ -157,7 +157,7 @@ describe('actions', () => {
     const theme = 'light';
     const expectedAction = {
       type: TOGGLE_THEME,
-      theme
+      theme,
     };
     expect(toggleTheme(theme)).toEqual(expectedAction);
   });
@@ -168,7 +168,7 @@ describe('actions', () => {
     const expectedAction = {
       type: TOGGLE_TYPE_DISABLED,
       typeID,
-      disabled
+      disabled,
     };
     expect(toggleTypeDisabled(typeID, disabled)).toEqual(expectedAction);
   });
@@ -181,11 +181,11 @@ describe('actions', () => {
       outerHeight: 40,
       width: 50,
       height: 60,
-      navOffset: 70
+      navOffset: 70,
     };
     const expectedAction = {
       type: UPDATE_CHART_SIZE,
-      chartSize
+      chartSize,
     };
     expect(updateChartSize(chartSize)).toEqual(expectedAction);
   });
@@ -194,7 +194,7 @@ describe('actions', () => {
     const fontLoaded = true;
     const expectedAction = {
       type: UPDATE_FONT_LOADED,
-      fontLoaded
+      fontLoaded,
     };
     expect(updateFontLoaded(fontLoaded)).toEqual(expectedAction);
   });
@@ -203,7 +203,7 @@ describe('actions', () => {
     const expectedAction = {
       type: CHANGE_FLAG,
       name: 'testFlag',
-      value: true
+      value: true,
     };
     expect(changeFlag('testFlag', true)).toEqual(expectedAction);
   });

--- a/src/actions/graph.js
+++ b/src/actions/graph.js
@@ -10,7 +10,7 @@ export const TOGGLE_GRAPH_LOADING = 'TOGGLE_GRAPH_LOADING';
 export function toggleLoading(loading) {
   return {
     type: TOGGLE_GRAPH_LOADING,
-    loading
+    loading,
   };
 }
 
@@ -23,7 +23,7 @@ export const UPDATE_GRAPH_LAYOUT = 'UPDATE_GRAPH_LAYOUT';
 export function updateGraph(graph) {
   return {
     type: UPDATE_GRAPH_LAYOUT,
-    graph
+    graph,
   };
 }
 
@@ -49,7 +49,7 @@ export function calculateGraph(graphState) {
   if (!graphState) {
     return updateGraph(graphState);
   }
-  return async function(dispatch) {
+  return async function (dispatch) {
     dispatch(toggleLoading(true));
     const graph = await layoutWorker(graphState);
     dispatch(toggleGraph(true));

--- a/src/actions/graph.test.js
+++ b/src/actions/graph.test.js
@@ -40,7 +40,7 @@ describe('graph actions', () => {
             oldgraph: expect.any(Boolean),
             nodes: expect.any(Array),
             edges: expect.any(Array),
-            size: expect.any(Object)
+            size: expect.any(Object),
           })
         );
       });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -7,7 +7,7 @@ export const RESET_DATA = 'RESET_DATA';
 export function resetData(data) {
   return {
     type: RESET_DATA,
-    data
+    data,
   };
 }
 
@@ -20,7 +20,7 @@ export const TOGGLE_LAYERS = 'TOGGLE_LAYERS';
 export function toggleLayers(visible) {
   return {
     type: TOGGLE_LAYERS,
-    visible
+    visible,
   };
 }
 
@@ -33,7 +33,7 @@ export const TOGGLE_EXPORT_MODAL = 'TOGGLE_EXPORT_MODAL';
 export function toggleExportModal(visible) {
   return {
     type: TOGGLE_EXPORT_MODAL,
-    visible
+    visible,
   };
 }
 
@@ -46,7 +46,7 @@ export const TOGGLE_GRAPH = 'TOGGLE_GRAPH';
 export function toggleGraph(visible) {
   return {
     type: TOGGLE_GRAPH,
-    visible
+    visible,
   };
 }
 
@@ -59,7 +59,7 @@ export const TOGGLE_TEXT_LABELS = 'TOGGLE_TEXT_LABELS';
 export function toggleTextLabels(textLabels) {
   return {
     type: TOGGLE_TEXT_LABELS,
-    textLabels
+    textLabels,
   };
 }
 
@@ -72,7 +72,7 @@ export const TOGGLE_SIDEBAR = 'TOGGLE_SIDEBAR';
 export function toggleSidebar(visible) {
   return {
     type: TOGGLE_SIDEBAR,
-    visible
+    visible,
   };
 }
 
@@ -85,7 +85,7 @@ export const TOGGLE_THEME = 'TOGGLE_THEME';
 export function toggleTheme(theme) {
   return {
     type: TOGGLE_THEME,
-    theme
+    theme,
   };
 }
 
@@ -98,7 +98,7 @@ export const UPDATE_CHART_SIZE = 'UPDATE_CHART_SIZE';
 export function updateChartSize(chartSize) {
   return {
     type: UPDATE_CHART_SIZE,
-    chartSize
+    chartSize,
   };
 }
 
@@ -111,7 +111,7 @@ export const UPDATE_ZOOM = 'UPDATE_ZOOM';
 export function updateZoom(zoom) {
   return {
     type: UPDATE_ZOOM,
-    zoom
+    zoom,
   };
 }
 
@@ -124,7 +124,7 @@ export const UPDATE_FONT_LOADED = 'UPDATE_FONT_LOADED';
 export function updateFontLoaded(fontLoaded) {
   return {
     type: UPDATE_FONT_LOADED,
-    fontLoaded
+    fontLoaded,
   };
 }
 
@@ -137,7 +137,7 @@ export const TOGGLE_MINIMAP = 'TOGGLE_MINIMAP';
 export function toggleMiniMap(visible) {
   return {
     type: TOGGLE_MINIMAP,
-    visible
+    visible,
   };
 }
 
@@ -152,6 +152,6 @@ export function changeFlag(name, value) {
   return {
     type: CHANGE_FLAG,
     name,
-    value
+    value,
   };
 }

--- a/src/actions/node-type.js
+++ b/src/actions/node-type.js
@@ -9,6 +9,6 @@ export function toggleTypeDisabled(typeID, disabled) {
   return {
     type: TOGGLE_TYPE_DISABLED,
     typeID,
-    disabled
+    disabled,
   };
 }

--- a/src/actions/nodes.js
+++ b/src/actions/nodes.js
@@ -10,7 +10,7 @@ export const TOGGLE_NODE_CLICKED = 'TOGGLE_NODE_CLICKED';
 export function toggleNodeClicked(nodeClicked) {
   return {
     type: TOGGLE_NODE_CLICKED,
-    nodeClicked
+    nodeClicked,
   };
 }
 
@@ -25,7 +25,7 @@ export function toggleNodesDisabled(nodeIDs, isDisabled) {
   return {
     type: TOGGLE_NODES_DISABLED,
     nodeIDs,
-    isDisabled
+    isDisabled,
   };
 }
 
@@ -38,7 +38,7 @@ export const TOGGLE_NODE_HOVERED = 'TOGGLE_NODE_HOVERED';
 export function toggleNodeHovered(nodeHovered) {
   return {
     type: TOGGLE_NODE_HOVERED,
-    nodeHovered
+    nodeHovered,
   };
 }
 
@@ -51,7 +51,7 @@ export const TOGGLE_NODE_DATA_LOADING = 'TOGGLE_NODE_DATA_LOADING';
 export function toggleNodeDataLoading(loading) {
   return {
     type: TOGGLE_NODE_DATA_LOADING,
-    loading
+    loading,
   };
 }
 
@@ -64,7 +64,7 @@ export const ADD_NODE_METADATA = 'ADD_NODE_METADATA';
 export function addNodeMetadata(data) {
   return {
     type: ADD_NODE_METADATA,
-    data
+    data,
   };
 }
 
@@ -74,7 +74,7 @@ export function addNodeMetadata(data) {
  * @return {function} A promise that resolves when the data is loaded
  */
 export function loadNodeData(nodeID) {
-  return async function(dispatch, getState) {
+  return async function (dispatch, getState) {
     const { asyncDataSource, node } = getState();
 
     dispatch(toggleNodeClicked(nodeID));

--- a/src/actions/nodes.test.js
+++ b/src/actions/nodes.test.js
@@ -7,7 +7,7 @@ import {
   toggleNodeDataLoading,
   loadNodeData,
   addNodeMetadata,
-  ADD_NODE_METADATA
+  ADD_NODE_METADATA,
 } from './nodes';
 import node_parameters from '../utils/data/node_parameters.mock.json';
 
@@ -21,7 +21,7 @@ describe('node actions', () => {
       const data = { id: 'abc123', data: { parameters: { test: 'test' } } };
       const expectedAction = {
         type: ADD_NODE_METADATA,
-        data
+        data,
       };
       expect(addNodeMetadata(data)).toEqual(expectedAction);
     });
@@ -32,7 +32,7 @@ describe('node actions', () => {
       const loading = true;
       const expectedAction = {
         type: TOGGLE_NODE_DATA_LOADING,
-        loading
+        loading,
       };
       expect(toggleNodeDataLoading(loading)).toEqual(expectedAction);
     });
@@ -67,7 +67,7 @@ describe('node actions', () => {
         const { dispatch, getState } = store;
         const node = { id: parametersID };
         const storeListener = jest.fn();
-        const logDispatch = action => {
+        const logDispatch = (action) => {
           storeListener(action);
           return dispatch(action);
         };
@@ -76,7 +76,7 @@ describe('node actions', () => {
 
         expect(storeListener.mock.calls[2][0]).toEqual({
           type: ADD_NODE_METADATA,
-          data: { id: node.id, data: node_parameters }
+          data: { id: node.id, data: node_parameters },
         });
       });
 
@@ -94,7 +94,7 @@ describe('node actions', () => {
         const { dispatch, getState } = store;
         const node = { id: parametersID };
         const storeListener = jest.fn();
-        const logDispatch = action => {
+        const logDispatch = (action) => {
           storeListener(action);
           return dispatch(action);
         };
@@ -108,7 +108,7 @@ describe('node actions', () => {
 
         expect(storeListener.mock.calls[4][0]).toEqual({
           nodeClicked: parametersID,
-          type: 'TOGGLE_NODE_CLICKED'
+          type: 'TOGGLE_NODE_CLICKED',
         });
       });
 

--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -29,7 +29,7 @@ export const UPDATE_ACTIVE_PIPELINE = 'UPDATE_ACTIVE_PIPELINE';
 export function updateActivePipeline(pipeline) {
   return {
     type: UPDATE_ACTIVE_PIPELINE,
-    pipeline
+    pipeline,
   };
 }
 
@@ -42,7 +42,7 @@ export const TOGGLE_PIPELINE_LOADING = 'TOGGLE_PIPELINE_LOADING';
 export function toggleLoading(loading) {
   return {
     type: TOGGLE_PIPELINE_LOADING,
-    loading
+    loading,
   };
 }
 
@@ -50,7 +50,7 @@ export function toggleLoading(loading) {
  * Determine where to load data from
  * @param {object} pipeline Pipeline state
  */
-export const getPipelineUrl = pipeline => {
+export const getPipelineUrl = (pipeline) => {
   if (pipeline.active === pipeline.main) {
     return getUrl('main');
   }
@@ -64,7 +64,7 @@ export const getPipelineUrl = pipeline => {
  * @param {object} pipeline Pipeline state
  * @return {boolean} True if another request is needed
  */
-export const requiresSecondRequest = pipeline => {
+export const requiresSecondRequest = (pipeline) => {
   // Pipelines are not present in the data
   if (!pipeline.ids.length || !pipeline.main) return false;
   // There is no active pipeline set
@@ -78,7 +78,7 @@ export const requiresSecondRequest = pipeline => {
  * @return {function} A promise that resolves when the data is loaded
  */
 export function loadInitialPipelineData() {
-  return async function(dispatch, getState) {
+  return async function (dispatch, getState) {
     // Get a copy of the full state from the store
     const state = getState();
     // If data is passed synchronously then this process isn't necessary
@@ -90,7 +90,7 @@ export function loadInitialPipelineData() {
     // in order to obtain the list of pipelines, which is required for determining
     // whether the active pipeline (from localStorage) exists in the data.
     const url = getUrl('main');
-    let newState = await loadJsonData(url).then(data =>
+    let newState = await loadJsonData(url).then((data) =>
       preparePipelineState(data, true)
     );
     // If the active pipeline isn't 'main' then request data from new URL
@@ -109,7 +109,7 @@ export function loadInitialPipelineData() {
  * @return {function} A promise that resolves when the data is loaded
  */
 export function loadPipelineData(pipelineID) {
-  return async function(dispatch, getState) {
+  return async function (dispatch, getState) {
     const { asyncDataSource, pipeline } = getState();
     if (pipelineID && pipelineID === pipeline.active) {
       return;
@@ -120,7 +120,7 @@ export function loadPipelineData(pipelineID) {
       dispatch(toggleGraph(false));
       const url = getPipelineUrl({
         main: pipeline.main,
-        active: pipelineID
+        active: pipelineID,
       });
       const newState = await loadJsonData(url).then(preparePipelineState);
       // Set active pipeline here rather than dispatching two separate actions,

--- a/src/actions/pipelines.test.js
+++ b/src/actions/pipelines.test.js
@@ -10,7 +10,7 @@ import {
   getPipelineUrl,
   requiresSecondRequest,
   loadInitialPipelineData,
-  loadPipelineData
+  loadPipelineData,
 } from './pipelines';
 
 jest.mock('../store/load-data.js');
@@ -21,7 +21,7 @@ describe('pipeline actions', () => {
       const pipeline = 'abc123';
       const expectedAction = {
         type: UPDATE_ACTIVE_PIPELINE,
-        pipeline
+        pipeline,
       };
       expect(updateActivePipeline(pipeline)).toEqual(expectedAction);
     });
@@ -32,7 +32,7 @@ describe('pipeline actions', () => {
       const loading = true;
       const expectedAction = {
         type: TOGGLE_PIPELINE_LOADING,
-        loading
+        loading,
       };
       expect(toggleLoading(loading)).toEqual(expectedAction);
     });
@@ -119,7 +119,7 @@ describe('pipeline actions', () => {
 
       it('should request data from a different dataset if the active pipeline is set', async () => {
         const { pipeline } = mockState.animals;
-        const active = pipeline.ids.find(id => id !== pipeline.main);
+        const active = pipeline.ids.find((id) => id !== pipeline.main);
         saveState({ pipeline: { active } });
         const store = createStore(reducer, mockState.json);
         await loadInitialPipelineData()(store.dispatch, store.getState);
@@ -138,7 +138,7 @@ describe('pipeline actions', () => {
       it("shouldn't make a second data request if the dataset doesn't support pipelines", async () => {
         window.deletePipelines = true; // pass option to load-data mock
         const { pipeline } = mockState.animals;
-        const active = pipeline.ids.find(id => id !== pipeline.main);
+        const active = pipeline.ids.find((id) => id !== pipeline.main);
         saveState({ pipeline: { active } });
         const store = createStore(reducer, mockState.json);
         await loadInitialPipelineData()(store.dispatch, store.getState);
@@ -163,7 +163,7 @@ describe('pipeline actions', () => {
         const { dispatch, getState, subscribe } = store;
         const storeListener = jest.fn();
         const { pipeline } = getState();
-        const newActive = pipeline.ids.find(id => id !== pipeline.active);
+        const newActive = pipeline.ids.find((id) => id !== pipeline.active);
         subscribe(storeListener);
         loadPipelineData(newActive)(dispatch, getState);
         expect(storeListener).toHaveBeenCalledTimes(1);
@@ -184,7 +184,7 @@ describe('pipeline actions', () => {
       it('should hide the current graph before loading the new pipeline', () => {
         const store = createStore(reducer, {
           ...mockState.animals,
-          asyncDataSource: true
+          asyncDataSource: true,
         });
         expect(store.getState().visible.graph).toBe(true);
         loadPipelineData(active)(store.dispatch, store.getState);

--- a/src/actions/tags.js
+++ b/src/actions/tags.js
@@ -9,7 +9,7 @@ export function toggleTagActive(tagIDs, active) {
   return {
     type: TOGGLE_TAG_ACTIVE,
     tagIDs: Array.isArray(tagIDs) ? tagIDs : [tagIDs],
-    active
+    active,
   };
 }
 
@@ -24,6 +24,6 @@ export function toggleTagFilter(tagIDs, enabled) {
   return {
     type: TOGGLE_TAG_FILTER,
     tagIDs: Array.isArray(tagIDs) ? tagIDs : [tagIDs],
-    enabled
+    enabled,
   };
 }

--- a/src/components/app/app.test.js
+++ b/src/components/app/app.test.js
@@ -11,7 +11,7 @@ import { saveState } from '../../store/helpers';
 import { prepareNonPipelineState } from '../../store/initial-state';
 
 describe('App', () => {
-  const getState = wrapper => wrapper.instance().store.getState();
+  const getState = (wrapper) => wrapper.instance().store.getState();
 
   describe('renders without crashing', () => {
     it('when loading random data', () => {
@@ -72,7 +72,7 @@ describe('App', () => {
   it("resets the active pipeline when data prop is updated, if the active pipeline is not included in the new dataset's list of pipelines", () => {
     // Find a pipeline that is in the first dataset but not the second
     const activePipeline = animals.pipelines.find(
-      pipeline => !demo.pipelines.map(d => d.id).includes(pipeline.id)
+      (pipeline) => !demo.pipelines.map((d) => d.id).includes(pipeline.id)
     );
     const { container, rerender } = render(<App data={animals} />);
     const pipelineDropdown = container.querySelector('.pipeline-list');

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -6,7 +6,7 @@ import { resetData, updateFontLoaded } from '../../actions';
 import { loadInitialPipelineData } from '../../actions/pipelines';
 import Wrapper from '../wrapper';
 import getInitialState, {
-  preparePipelineState
+  preparePipelineState,
 } from '../../store/initial-state';
 import { getFlagsMessage } from '../../utils/flags';
 import '@quantumblack/kedro-ui/lib/styles/app-no-webfont.css';
@@ -58,7 +58,7 @@ class App extends React.Component {
     };
     LoadWebFont({
       active: setFontLoaded,
-      inactive: setFontLoaded
+      inactive: setFontLoaded,
     });
   }
 
@@ -93,8 +93,8 @@ App.propTypes = {
       edges: PropTypes.array.isRequired,
       layers: PropTypes.array,
       nodes: PropTypes.array.isRequired,
-      tags: PropTypes.array
-    })
+      tags: PropTypes.array,
+    }),
   ]),
   /**
    * Specify the theme: Either 'light' or 'dark'.
@@ -109,8 +109,8 @@ App.propTypes = {
     layerBtn: PropTypes.bool,
     exportBtn: PropTypes.bool,
     sidebar: PropTypes.bool,
-    themeBtn: PropTypes.bool
-  })
+    themeBtn: PropTypes.bool,
+  }),
 };
 
 export default App;

--- a/src/components/easter-egg/easter-egg.test.js
+++ b/src/components/easter-egg/easter-egg.test.js
@@ -7,7 +7,7 @@ const keyCodes = [38, 38, 40, 40, 37, 39, 37, 39, 66, 65]; // ↑↑↓↓←→
  * Dispatch a keyboard event
  * @param {number} keyCode
  */
-const dispatchKeyDown = keyCode => {
+const dispatchKeyDown = (keyCode) => {
   const event = new KeyboardEvent('keydown', { keyCode });
   document.dispatchEvent(event);
 };

--- a/src/components/easter-egg/index.js
+++ b/src/components/easter-egg/index.js
@@ -15,7 +15,7 @@ class EasterEgg extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      play: false
+      play: false,
     };
     if (typeof jest === 'undefined') {
       console.info('Konami code is supported');
@@ -59,7 +59,7 @@ class EasterEgg extends React.Component {
     const escape = e.keyCode === 27;
     if (escape && this.state.play) {
       this.setState({
-        play: false
+        play: false,
       });
     }
   }

--- a/src/components/export-modal/export-graph.js
+++ b/src/components/export-modal/export-graph.js
@@ -11,7 +11,7 @@ import downloadSvg, { downloadPng } from 'svg-crowbar';
 const exportGraph = ({ format, theme, graphSize, mockFn }) => {
   const downloadFormats = {
     png: downloadPng,
-    svg: downloadSvg
+    svg: downloadSvg,
   };
   const download = mockFn || downloadFormats[format];
 

--- a/src/components/export-modal/export-graph.test.js
+++ b/src/components/export-modal/export-graph.test.js
@@ -6,7 +6,7 @@ describe('exportGraph', () => {
     width: 1000,
     height: 500,
     marginx: 40,
-    marginy: 40
+    marginy: 40,
   };
 
   beforeEach(() => {

--- a/src/components/export-modal/export-modal.test.js
+++ b/src/components/export-modal/export-modal.test.js
@@ -14,13 +14,13 @@ describe('ExportModal', () => {
         height: expect.any(Number),
         width: expect.any(Number),
         marginx: expect.any(Number),
-        marginy: expect.any(Number)
+        marginy: expect.any(Number),
       }),
       theme: expect.stringMatching(/light|dark/),
       visible: expect.objectContaining({
         exportBtn: expect.any(Boolean),
-        exportModal: expect.any(Boolean)
-      })
+        exportModal: expect.any(Boolean),
+      }),
     };
     expect(mapStateToProps(mockState.animals)).toEqual(expectedResult);
   });

--- a/src/components/export-modal/index.js
+++ b/src/components/export-modal/index.js
@@ -41,19 +41,16 @@ const ExportModal = ({ graphSize, theme, onToggle, visible }) => {
   );
 };
 
-export const mapStateToProps = state => ({
+export const mapStateToProps = (state) => ({
   graphSize: state.graph.size || {},
   visible: state.visible,
-  theme: state.theme
+  theme: state.theme,
 });
 
-export const mapDispatchToProps = dispatch => ({
-  onToggle: value => {
+export const mapDispatchToProps = (dispatch) => ({
+  onToggle: (value) => {
     dispatch(toggleExportModal(value));
-  }
+  },
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ExportModal);
+export default connect(mapStateToProps, mapDispatchToProps)(ExportModal);

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -5,8 +5,8 @@ import { curveBasis, line } from 'd3-shape';
 import { paths as nodeIcons } from '../icons/node-icon';
 
 const lineShape = line()
-  .x(d => d.x)
-  .y(d => d.y)
+  .x((d) => d.x)
+  .y((d) => d.y)
   .curve(curveBasis);
 
 /**
@@ -17,22 +17,22 @@ const matchFloats = /\d+\.\d+/g;
 /**
  * Limits the precision of a float value to one decimal point
  */
-const toSinglePoint = value => parseFloat(value).toFixed(1);
+const toSinglePoint = (value) => parseFloat(value).toFixed(1);
 
 /**
  * Limits the precision of a path string to one decimal point
  */
-const limitPrecision = path => path.replace(matchFloats, toSinglePoint);
+const limitPrecision = (path) => path.replace(matchFloats, toSinglePoint);
 
 /**
  * Render layer bands
  */
-export const drawLayers = function() {
+export const drawLayers = function () {
   const { layers } = this.props;
 
   this.el.layers = this.el.layerGroup
     .selectAll('.pipeline-layer')
-    .data(layers, layer => layer.id);
+    .data(layers, (layer) => layer.id);
 
   const enterLayers = this.el.layers
     .enter()
@@ -44,19 +44,19 @@ export const drawLayers = function() {
   this.el.layers = this.el.layers.merge(enterLayers);
 
   this.el.layers
-    .attr('x', d => d.x)
-    .attr('y', d => d.y)
-    .attr('height', d => d.height)
-    .attr('width', d => d.width);
+    .attr('x', (d) => d.x)
+    .attr('y', (d) => d.y)
+    .attr('height', (d) => d.height)
+    .attr('width', (d) => d.width);
 };
 
 /**
  * Render layer name labels
  */
-export const drawLayerNames = function() {
+export const drawLayerNames = function () {
   const {
     chartSize: { sidebarWidth = 0 },
-    layers
+    layers,
   } = this.props;
 
   this.el.layerNameGroup
@@ -66,7 +66,7 @@ export const drawLayerNames = function() {
 
   this.el.layerNames = this.el.layerNameGroup
     .selectAll('.pipeline-layer-name')
-    .data(layers, layer => layer.id);
+    .data(layers, (layer) => layer.id);
 
   const enterLayerNames = this.el.layerNames
     .enter()
@@ -89,36 +89,36 @@ export const drawLayerNames = function() {
 
   this.el.layerNames = this.el.layerNames.merge(enterLayerNames);
 
-  this.el.layerNames.text(d => d.name).attr('dy', 5);
+  this.el.layerNames.text((d) => d.name).attr('dy', 5);
 };
 
 /**
  * Sets the size and position of the given node rects
  */
-const updateNodeRects = nodeRects =>
+const updateNodeRects = (nodeRects) =>
   nodeRects
-    .attr('width', node => node.width - 5)
-    .attr('height', node => node.height - 5)
-    .attr('x', node => (node.width - 5) / -2)
-    .attr('y', node => (node.height - 5) / -2)
-    .attr('rx', node => (node.type === 'task' ? 0 : node.height / 2));
+    .attr('width', (node) => node.width - 5)
+    .attr('height', (node) => node.height - 5)
+    .attr('x', (node) => (node.width - 5) / -2)
+    .attr('y', (node) => (node.height - 5) / -2)
+    .attr('rx', (node) => (node.type === 'task' ? 0 : node.height / 2));
 
 /**
  * Render node icons and name labels
  */
-export const drawNodes = function(changed) {
+export const drawNodes = function (changed) {
   const {
     centralNode,
     linkedNodes,
     nodeActive,
     nodeSelected,
-    nodes
+    nodes,
   } = this.props;
 
   if (changed('nodes')) {
     this.el.nodes = this.el.nodeGroup
       .selectAll('.pipeline-node')
-      .data(nodes, node => node.id);
+      .data(nodes, (node) => node.id);
   }
 
   if (!this.el.nodes) {
@@ -132,17 +132,20 @@ export const drawNodes = function(changed) {
   const allNodes = this.el.nodes
     .merge(enterNodes)
     .merge(exitNodes)
-    .filter(node => typeof node !== 'undefined');
+    .filter((node) => typeof node !== 'undefined');
 
   if (changed('nodes')) {
     enterNodes
       .attr('tabindex', '0')
       .attr('class', 'pipeline-node')
-      .attr('transform', node => `translate(${node.x}, ${node.y})`)
-      .attr('data-id', node => node.id)
-      .classed('pipeline-node--parameters', node => node.type === 'parameters')
-      .classed('pipeline-node--data', node => node.type === 'data')
-      .classed('pipeline-node--task', node => node.type === 'task')
+      .attr('transform', (node) => `translate(${node.x}, ${node.y})`)
+      .attr('data-id', (node) => node.id)
+      .classed(
+        'pipeline-node--parameters',
+        (node) => node.type === 'parameters'
+      )
+      .classed('pipeline-node--data', (node) => node.type === 'data')
+      .classed('pipeline-node--task', (node) => node.type === 'task')
       .on('click', this.handleNodeClick)
       .on('mouseover', this.handleNodeMouseOver)
       .on('mouseout', this.handleNodeMouseOut)
@@ -162,15 +165,15 @@ export const drawNodes = function(changed) {
     enterNodes
       .append('path')
       .attr('class', 'pipeline-node__icon')
-      .attr('d', node => nodeIcons[node.type]);
+      .attr('d', (node) => nodeIcons[node.type]);
 
     enterNodes
       .append('text')
       .attr('class', 'pipeline-node__text')
-      .text(node => node.name)
+      .text((node) => node.name)
       .attr('text-anchor', 'middle')
       .attr('dy', 5)
-      .attr('dx', node => node.textOffset);
+      .attr('dx', (node) => node.textOffset);
 
     exitNodes
       .transition('exit-nodes')
@@ -188,11 +191,11 @@ export const drawNodes = function(changed) {
     changed('nodes', 'nodeActive', 'nodeSelected', 'centralNode', 'linkedNodes')
   ) {
     allNodes
-      .classed('pipeline-node--active', node => nodeActive[node.id])
-      .classed('pipeline-node--selected', node => nodeSelected[node.id])
+      .classed('pipeline-node--active', (node) => nodeActive[node.id])
+      .classed('pipeline-node--selected', (node) => nodeSelected[node.id])
       .classed(
         'pipeline-node--faded',
-        node => centralNode && !linkedNodes[node.id]
+        (node) => centralNode && !linkedNodes[node.id]
       );
   }
 
@@ -200,7 +203,7 @@ export const drawNodes = function(changed) {
     allNodes
       .transition('update-nodes')
       .duration(this.DURATION)
-      .attr('transform', node => `translate(${node.x}, ${node.y})`)
+      .attr('transform', (node) => `translate(${node.x}, ${node.y})`)
       .on('end', () => {
         try {
           // Sort nodes so tab focus order follows X/Y position
@@ -215,16 +218,16 @@ export const drawNodes = function(changed) {
     updateNodes
       .select('rect')
       .transition('node-rect')
-      .duration(node => (node.showText ? 200 : 600))
+      .duration((node) => (node.showText ? 200 : 600))
       .call(updateNodeRects);
 
     // Performance: icon transitions with CSS on GPU
     allNodes
       .select('.pipeline-node__icon')
-      .style('transition-delay', node => (node.showText ? '0ms' : '200ms'))
+      .style('transition-delay', (node) => (node.showText ? '0ms' : '200ms'))
       .style(
         'transform',
-        node =>
+        (node) =>
           `translate(${node.iconOffset}px, ${-node.iconSize / 2}px) ` +
           `scale(${node.iconSize / 24})`
       );
@@ -232,21 +235,21 @@ export const drawNodes = function(changed) {
     // Performance: text transitions with CSS on GPU
     allNodes
       .select('.pipeline-node__text')
-      .style('transition-delay', node => (node.showText ? '200ms' : '0ms'))
-      .style('opacity', node => (node.showText ? 1 : 0));
+      .style('transition-delay', (node) => (node.showText ? '200ms' : '0ms'))
+      .style('opacity', (node) => (node.showText ? 1 : 0));
   }
 };
 
 /**
  * Render edge lines
  */
-export const drawEdges = function(changed) {
+export const drawEdges = function (changed) {
   const { edges, centralNode, linkedNodes } = this.props;
 
   if (changed('edges')) {
     this.el.edges = this.el.edgeGroup
       .selectAll('.pipeline-edge')
-      .data(edges, edge => edge.id);
+      .data(edges, (edge) => edge.id);
   }
 
   if (!this.el.edges) {
@@ -261,9 +264,11 @@ export const drawEdges = function(changed) {
   if (changed('edges')) {
     enterEdges
       .append('path')
-      .attr('marker-end', d => `url(#pipeline-arrowhead)`);
+      .attr('marker-end', (d) => `url(#pipeline-arrowhead)`);
 
-    enterEdges.attr('data-id', edge => edge.id).attr('class', 'pipeline-edge');
+    enterEdges
+      .attr('data-id', (edge) => edge.id)
+      .attr('class', 'pipeline-edge');
 
     enterEdges
       .attr('opacity', 0)
@@ -284,7 +289,7 @@ export const drawEdges = function(changed) {
       .select('path')
       .transition('update-edges')
       .duration(this.DURATION)
-      .attrTween('d', function(edge) {
+      .attrTween('d', function (edge) {
         // Performance: Limit path precision for parsing & render
         let current = edge.points && limitPrecision(lineShape(edge.points));
         const previous = select(this).attr('d') || current;
@@ -297,7 +302,7 @@ export const drawEdges = function(changed) {
   if (changed('edges', 'centralNode', 'linkedNodes')) {
     allEdges.classed(
       'pipeline-edge--faded',
-      edge =>
+      (edge) =>
         edge &&
         centralNode &&
         (!linkedNodes[edge.source] || !linkedNodes[edge.target])

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -6,9 +6,9 @@ import FlowChart, { mapStateToProps, mapDispatchToProps } from './index';
 import { mockState, setup } from '../../utils/state.mock';
 import { getViewTransform, origin } from '../../utils/view';
 
-const getNodeIDs = state => state.node.ids;
-const getNodeName = state => state.node.name;
-const getLayerIDs = state => state.layer.ids;
+const getNodeIDs = (state) => state.node.ids;
+const getNodeName = (state) => state.node.name;
+const getLayerIDs = (state) => state.layer.ids;
 
 describe('FlowChart', () => {
   it('renders without crashing', () => {
@@ -22,7 +22,9 @@ describe('FlowChart', () => {
     const nodes = wrapper.render().find('.pipeline-node');
     const nodeNames = nodes.map((i, el) => $(el).text()).get();
     const mockNodes = getNodeIDs(mockState.animals);
-    const mockNodeNames = mockNodes.map(d => getNodeName(mockState.animals)[d]);
+    const mockNodeNames = mockNodes.map(
+      (d) => getNodeName(mockState.animals)[d]
+    );
     expect(nodes.length).toEqual(mockNodes.length);
     expect(nodeNames.sort()).toEqual(mockNodeNames.sort());
   });
@@ -66,7 +68,7 @@ describe('FlowChart', () => {
     window.addEventListener = jest.fn((event, cb) => {
       map[event] = cb;
     });
-    window.removeEventListener = jest.fn(event => {
+    window.removeEventListener = jest.fn((event) => {
       delete map[event];
     });
     const wrapper = setup.mount(<FlowChart />);
@@ -104,7 +106,7 @@ describe('FlowChart', () => {
       <FlowChart
         nodeSelected={{
           [mockNodes[0]]: true,
-          [mockNodes[1]]: true
+          [mockNodes[1]]: true,
         }}
       />
     );
@@ -117,7 +119,7 @@ describe('FlowChart', () => {
       <FlowChart
         nodeActive={{
           [mockNodes[0]]: true,
-          [mockNodes[1]]: true
+          [mockNodes[1]]: true,
         }}
       />
     );
@@ -143,7 +145,7 @@ describe('FlowChart', () => {
         tooltip={{
           targetRect: { top: 0, left: 0, width: 10, height: 10 },
           text: 'test tooltip',
-          visible: true
+          visible: true,
         }}
       />
     );
@@ -160,7 +162,7 @@ describe('FlowChart', () => {
         tooltip={{
           targetRect: { top: 0, left: 0, width: 10, height: 10 },
           text: 'test tooltip',
-          visible: false
+          visible: false,
         }}
       />
     );
@@ -182,7 +184,7 @@ describe('FlowChart', () => {
       nodeSelected: expect.any(Object),
       nodes: expect.any(Array),
       visibleGraph: expect.any(Boolean),
-      visibleSidebar: expect.any(Boolean)
+      visibleSidebar: expect.any(Boolean),
     };
     expect(mapStateToProps(mockState.animals)).toEqual(expectedResult);
   });
@@ -193,21 +195,21 @@ describe('FlowChart', () => {
     mapDispatchToProps(dispatch).onToggleNodeHovered('123');
     expect(dispatch.mock.calls[0][0]).toEqual({
       nodeHovered: '123',
-      type: 'TOGGLE_NODE_HOVERED'
+      type: 'TOGGLE_NODE_HOVERED',
     });
 
     const boundingClientRect = { x: 0, y: 0, width: 1000, height: 1000 };
     mapDispatchToProps(dispatch).onUpdateChartSize(boundingClientRect);
     expect(dispatch.mock.calls[1][0]).toEqual({
       chartSize: boundingClientRect,
-      type: 'UPDATE_CHART_SIZE'
+      type: 'UPDATE_CHART_SIZE',
     });
 
     const zoom = { scale: 1, x: 0, y: 0 };
     mapDispatchToProps(dispatch).onUpdateZoom(zoom);
     expect(dispatch.mock.calls[2][0]).toEqual({
       zoom,
-      type: 'UPDATE_ZOOM'
+      type: 'UPDATE_ZOOM',
     });
   });
 });
@@ -222,7 +224,7 @@ describe('map dispatch props to async actions', () => {
     await mapDispatchToProps(store.dispatch).onLoadNodeData('123');
     expect(store.getActions()[0]).toEqual({
       nodeClicked: '123',
-      type: 'TOGGLE_NODE_CLICKED'
+      type: 'TOGGLE_NODE_CLICKED',
     });
   });
 });

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -18,7 +18,7 @@ import {
   getViewTransform,
   setViewTransformExact,
   setViewExtents,
-  getViewExtents
+  getViewExtents,
 } from '../../utils/view';
 import Tooltip from '../tooltip';
 import './styles/flowchart.css';
@@ -31,7 +31,7 @@ export class FlowChart extends Component {
     super(props);
 
     this.state = {
-      tooltip: { visible: false }
+      tooltip: { visible: false },
     };
 
     this.defaultTransform = origin;
@@ -61,7 +61,7 @@ export class FlowChart extends Component {
       container: this.svgRef,
       wrapper: this.wrapperRef,
       onViewChanged: this.onViewChange,
-      onViewEnd: this.onViewChangeEnd
+      onViewEnd: this.onViewChangeEnd,
     });
 
     this.addGlobalEventListeners();
@@ -127,7 +127,9 @@ export class FlowChart extends Component {
    */
   changed(props, objectA, objectB) {
     return (
-      objectA && objectB && props.some(prop => objectA[prop] !== objectB[prop])
+      objectA &&
+      objectB &&
+      props.some((prop) => objectA[prop] !== objectB[prop])
     );
   }
 
@@ -141,12 +143,12 @@ export class FlowChart extends Component {
       edgeGroup: select(this.edgesRef.current),
       nodeGroup: select(this.nodesRef.current),
       layerGroup: select(this.layersRef.current),
-      layerNameGroup: select(this.layerNamesRef.current)
+      layerNameGroup: select(this.layerNamesRef.current),
     };
   }
 
   /**
-   * Update the chart size in state from chart container bounds. 
+   * Update the chart size in state from chart container bounds.
    * This is emulated in tests with a constant fixed size.
    */
   updateChartSize() {
@@ -221,7 +223,7 @@ export class FlowChart extends Component {
 
   /**
    * On every frame of every view transform change (from reset, pan, zoom etc.)
-   * @param {Object} transform The current view transfrom 
+   * @param {Object} transform The current view transfrom
    */
   onViewChange(transform) {
     const { k: scale, x, y } = transform;
@@ -234,7 +236,7 @@ export class FlowChart extends Component {
 
     // Update layer label y positions
     if (this.el.layerNames) {
-      this.el.layerNames.style('transform', d => {
+      this.el.layerNames.style('transform', (d) => {
         const ty = y + (d.y + d.height / 2) * scale;
         return `translateY(${ty}px)`;
       });
@@ -256,7 +258,7 @@ export class FlowChart extends Component {
       transition: false,
       relative: false,
       minScale: extents.scale.minK,
-      maxScale: extents.scale.maxK
+      maxScale: extents.scale.maxK,
     });
   }
 
@@ -285,12 +287,12 @@ export class FlowChart extends Component {
         minX: -sidebarWidth / scale - margin,
         maxX: width + margin + metaSidebarWidth / scale,
         minY: -margin,
-        maxY: height + margin
+        maxY: height + margin,
       },
       scale: {
         minK: this.MIN_SCALE * this.defaultTransform.k,
-        maxK: this.MAX_SCALE
-      }
+        maxK: this.MAX_SCALE,
+      },
     });
   }
 
@@ -337,7 +339,7 @@ export class FlowChart extends Component {
 
     // Use the selected node as focus point
     const focus = centralNode
-      ? nodes.find(node => node.id === centralNode)
+      ? nodes.find((node) => node.id === centralNode)
       : null;
 
     // Find a transform that fits everything in view
@@ -350,7 +352,7 @@ export class FlowChart extends Component {
       objectHeight: graphHeight,
       minScaleX: 0.4,
       minScaleFocus: 0.3,
-      focusOffset: 0.8
+      focusOffset: 0.8,
     });
 
     // Detect first transform
@@ -430,8 +432,8 @@ export class FlowChart extends Component {
         targetRect: event && event.target.getBoundingClientRect(),
         text: node && node.fullName,
         visible: true,
-        ...options
-      }
+        ...options,
+      },
     });
   }
 
@@ -443,8 +445,8 @@ export class FlowChart extends Component {
       this.setState({
         tooltip: {
           ...this.state.tooltip,
-          visible: false
-        }
+          visible: false,
+        },
       });
     }
   }
@@ -470,7 +472,7 @@ export class FlowChart extends Component {
           <g
             id="zoom-wrapper"
             className={classnames('pipeline-zoom-wrapper', {
-              'pipeline-zoom-wrapper--hidden': !visibleGraph
+              'pipeline-zoom-wrapper--hidden': !visibleGraph,
             })}
             ref={this.wrapperRef}>
             <defs>
@@ -498,7 +500,7 @@ export class FlowChart extends Component {
         </svg>
         <ul
           className={classnames('pipeline-flowchart__layer-names', {
-            'pipeline-flowchart__layer-names--visible': layers.length
+            'pipeline-flowchart__layer-names--visible': layers.length,
           })}
           ref={this.layerNamesRef}
         />
@@ -515,7 +517,7 @@ export const chartSizeTestFallback = {
   right: 1280,
   bottom: 1024,
   width: 1280,
-  height: 1024
+  height: 1024,
 };
 
 // Maintain a single reference to support change detection
@@ -536,26 +538,23 @@ export const mapStateToProps = (state, ownProps) => ({
   nodeSelected: getNodeSelected(state),
   visibleGraph: state.visible.graph,
   visibleSidebar: state.visible.sidebar,
-  ...ownProps
+  ...ownProps,
 });
 
 export const mapDispatchToProps = (dispatch, ownProps) => ({
-  onLoadNodeData: nodeClicked => {
+  onLoadNodeData: (nodeClicked) => {
     dispatch(loadNodeData(nodeClicked));
   },
-  onToggleNodeHovered: nodeHovered => {
+  onToggleNodeHovered: (nodeHovered) => {
     dispatch(toggleNodeHovered(nodeHovered));
   },
-  onUpdateChartSize: chartSize => {
+  onUpdateChartSize: (chartSize) => {
     dispatch(updateChartSize(chartSize));
   },
-  onUpdateZoom: transform => {
+  onUpdateZoom: (transform) => {
     dispatch(updateZoom(transform));
   },
-  ...ownProps
+  ...ownProps,
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(FlowChart);
+export default connect(mapStateToProps, mapDispatchToProps)(FlowChart);

--- a/src/components/icon-button/icon-button.test.js
+++ b/src/components/icon-button/icon-button.test.js
@@ -10,7 +10,7 @@ describe('IconButton', () => {
       onClick: () => {},
       icon: MenuIcon,
       labelText: 'Toggle theme',
-      visible: true
+      visible: true,
     });
     expect(wrapper.find('li').length).toBe(1);
     expect(wrapper.find('.pipeline-icon-toolbar__button').length).toBe(1);

--- a/src/components/icon-button/index.js
+++ b/src/components/icon-button/index.js
@@ -16,7 +16,7 @@ const IconButton = ({
   labelText,
   onClick,
   visible,
-  active
+  active,
 }) => {
   const Icon = icon;
 
@@ -27,7 +27,7 @@ const IconButton = ({
         aria-live={ariaLive}
         className={classnames(className, {
           'pipeline-icon-toolbar__button': true,
-          'pipeline-icon-toolbar__button--active': active
+          'pipeline-icon-toolbar__button--active': active,
         })}
         disabled={disabled}
         onClick={onClick}>
@@ -48,7 +48,7 @@ IconButton.propTypes = {
   labelText: PropTypes.string,
   onClick: PropTypes.func,
   visible: PropTypes.bool,
-  active: PropTypes.bool
+  active: PropTypes.bool,
 };
 
 IconButton.defaultProps = {
@@ -59,7 +59,7 @@ IconButton.defaultProps = {
   labelText: null,
   onClick: null,
   visible: true,
-  active: false
+  active: false,
 };
 
 export default IconButton;

--- a/src/components/icons/loading.js
+++ b/src/components/icons/loading.js
@@ -8,7 +8,7 @@ const d =
 const LoadingIcon = ({ className, visible }) => (
   <svg
     className={classnames(className, 'pipeline-loading-icon', {
-      'pipeline-loading-icon--visible': visible
+      'pipeline-loading-icon--visible': visible,
     })}
     viewBox="0 0 200 180">
     <path d={d} />

--- a/src/components/icons/node-icon.js
+++ b/src/components/icons/node-icon.js
@@ -10,7 +10,7 @@ export const paths = {
     'M20 4.2l.2.2L19 5.9c-2.3-1.8-3.8-.9-4.8 3.4h3.1v2h-3.5v.2l-.1.6c-1.2 7.9-4 11-8.3 8l-.2-.1 1.2-1.6c2.5 1.8 4.2.3 5.2-5.9l.2-1v-.2H9.2v-2h3c1.4-6 4.1-8 7.9-5z',
   // sliders icon
   parameters:
-    'M10.2 14v1.5H20v2h-9.8V19H8.3v-1.5H5v-2h3.3V14h2zm7.4-9v1.5H20v2h-2.4V10h-1.8V8.5H5v-2h10.8V5h1.8z'
+    'M10.2 14v1.5H20v2h-9.8V19H8.3v-1.5H5v-2h3.3V14h2zm7.4-9v1.5H20v2h-2.4V10h-1.8V8.5H5v-2h10.8V5h1.8z',
 };
 
 const NodeIcon = ({ className, type }) =>

--- a/src/components/lazy-list/index.js
+++ b/src/components/lazy-list/index.js
@@ -24,7 +24,7 @@ const LazyList = ({
   dispose = false,
   buffer = 0.5,
   onChange,
-  container = element => element?.offsetParent
+  container = (element) => element?.offsetParent,
 }) => {
   // Required browser feature checks
   const supported = typeof window.IntersectionObserver !== 'undefined';
@@ -58,7 +58,7 @@ const LazyList = ({
   const lowerHeight = useMemo(() => height(range[1], total), [
     height,
     range,
-    total
+    total,
   ]);
 
   // Skipped if not enabled or supported
@@ -101,7 +101,7 @@ const LazyList = ({
     const observerOptions = useMemo(
       () => ({
         // Create a threshold point for every item
-        threshold: thresholds(total)
+        threshold: thresholds(total),
       }),
       [total]
     );
@@ -116,7 +116,7 @@ const LazyList = ({
       total,
       itemHeight,
       totalHeight,
-      requestUpdate
+      requestUpdate,
     ]);
   }
 
@@ -135,7 +135,7 @@ const LazyList = ({
         // List must always have the correct height
         height: active ? totalHeight : undefined,
         // List must always pad missing items (upper at least)
-        paddingTop: active ? upperHeight : undefined
+        paddingTop: active ? upperHeight : undefined,
       },
       upperStyle: {
         position: 'absolute',
@@ -143,7 +143,7 @@ const LazyList = ({
         height: upperHeight,
         width: '100%',
         // Upper placeholder must always snap to top edge
-        top: '0'
+        top: '0',
       },
       lowerStyle: {
         position: 'absolute',
@@ -151,8 +151,8 @@ const LazyList = ({
         height: lowerHeight,
         width: '100%',
         // Lower placeholder must always snap to bottom edge
-        bottom: '0'
-      }
+        bottom: '0',
+      },
     }),
     [
       active,
@@ -163,7 +163,7 @@ const LazyList = ({
       lowerRef,
       totalHeight,
       upperHeight,
-      lowerHeight
+      lowerHeight,
     ]
   );
 
@@ -184,7 +184,7 @@ const LazyList = ({
  */
 export const range = (start, end, min, max) => [
   Math.max(Math.min(start, max), min),
-  Math.max(Math.min(end, max), min)
+  Math.max(Math.min(end, max), min),
 ];
 
 /**
@@ -195,7 +195,7 @@ export const range = (start, end, min, max) => [
  */
 export const rangeUnion = (rangeA, rangeB) => [
   Math.min(rangeA[0], rangeB[0]),
-  Math.max(rangeA[1], rangeB[1])
+  Math.max(rangeA[1], rangeB[1]),
 ];
 
 /**
@@ -253,7 +253,7 @@ const visibleRangeOf = (
   // Get the viewport bounds
   const viewport = {
     top: 0,
-    bottom: window.innerHeight || document.documentElement.clientHeight
+    bottom: window.innerHeight || document.documentElement.clientHeight,
   };
 
   // When clip is fully below viewport or element is fully below clip
@@ -279,7 +279,7 @@ const visibleRangeOf = (
  * @param {function} callback The callback
  * @returns {function} The wrapped callback
  */
-const useRequestFrameOnce = callback => {
+const useRequestFrameOnce = (callback) => {
   const request = useRef();
 
   // Allow only a single callback per-frame
@@ -295,7 +295,7 @@ const useRequestFrameOnce = callback => {
  * @param {number} total The total number of thresholds to create
  * @returns {array} The threshold array
  */
-export const thresholds = total =>
+export const thresholds = (total) =>
   total === 0
     ? [0]
     : [...Array.from({ length: total }, (_, i) => i / total), 1];

--- a/src/components/lazy-list/lazy-list.test.js
+++ b/src/components/lazy-list/lazy-list.test.js
@@ -25,7 +25,7 @@ describe('LazyList', () => {
       // Container scrolled half way to desired start item to test
       containerScrollY: itemHeight * visibleStart * 0.5,
       // Viewport scrolled remaining half way to desired start item
-      viewportScrollY: itemHeight * visibleStart * 0.5
+      viewportScrollY: itemHeight * visibleStart * 0.5,
     });
 
     const wrapper = setup.mount(
@@ -34,7 +34,7 @@ describe('LazyList', () => {
         dispose={true}
         height={test.itemHeights}
         total={test.items.length}
-        container={element => element?.parentElement}>
+        container={(element) => element?.parentElement}>
         {test.listRender}
       </LazyList>
     );
@@ -48,7 +48,7 @@ describe('LazyList', () => {
     // Get actual rendered items text
     const actualItemsText = wrapper
       .find('.test-item')
-      .map(element => element.text());
+      .map((element) => element.text());
 
     // Test the items are exactly as expected
     expect(actualItemsText).toEqual(expectedItemsText);
@@ -100,7 +100,7 @@ const setupTest = ({
   viewportHeight,
   viewportScrollY,
   containerHeight,
-  containerScrollY
+  containerScrollY,
 }) => {
   // Generate test data and settings
   const items = Array.from({ length: itemCount }, (_, i) => i);
@@ -118,7 +118,7 @@ const setupTest = ({
     lowerRef,
     listStyle,
     upperStyle,
-    lowerStyle
+    lowerStyle,
   }) => (
     <>
       {/* Scroll container */}
@@ -126,7 +126,7 @@ const setupTest = ({
         style={{
           overflowY: 'scroll',
           height: containerHeight,
-          width: containerWidth
+          width: containerWidth,
         }}>
         {/* List container */}
         <ul
@@ -138,7 +138,7 @@ const setupTest = ({
           {/* Lower placeholder */}
           <li ref={lowerRef} style={lowerStyle} />
           {/* List items in visible range */}
-          {items.slice(start, end).map(i => (
+          {items.slice(start, end).map((i) => (
             <li key={i} className="test-item">
               Item {i}
             </li>
@@ -152,26 +152,26 @@ const setupTest = ({
   window.innerHeight = viewportHeight;
 
   // Emulate RAF with immediate callback
-  window.requestAnimationFrame = cb => cb(0);
+  window.requestAnimationFrame = (cb) => cb(0);
 
   // Emulate IntersectionObserver with immediate callback
-  window.IntersectionObserver = function(cb) {
+  window.IntersectionObserver = function (cb) {
     return {
       observe: () => cb(),
-      disconnect: () => null
+      disconnect: () => null,
     };
   };
 
   // Gets the React instance for a React node
-  const getInstance = node => {
-    const key = Object.keys(node).find(key =>
+  const getInstance = (node) => {
+    const key = Object.keys(node).find((key) =>
       key.startsWith('__reactInternalInstance')
     );
     return node[key];
   };
 
   // Emulate element bounds as if rendered
-  window.Element.prototype.getBoundingClientRect = function() {
+  window.Element.prototype.getBoundingClientRect = function () {
     const instance = getInstance(this);
 
     // Check which element this is (list or container)
@@ -193,7 +193,7 @@ const setupTest = ({
       left: 0,
       right: width,
       width: width,
-      height: height
+      height: height,
     };
   };
 
@@ -202,6 +202,6 @@ const setupTest = ({
     items,
     visibleCount,
     itemHeights,
-    listRender
+    listRender,
   };
 };

--- a/src/components/metadata/index.js
+++ b/src/components/metadata/index.js
@@ -9,7 +9,7 @@ import MetaDataRow from './metadata-row';
 import MetaDataValue from './metadata-value';
 import {
   getVisibleMetaSidebar,
-  getClickedNodeMetaData
+  getClickedNodeMetaData,
 } from '../../selectors/metadata';
 import { toggleNodeClicked } from '../../actions/nodes';
 import './styles/metadata.css';
@@ -102,7 +102,7 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
             <MetaDataValue
               container={'code'}
               className={modifiers('pipeline-metadata__run-command-value', {
-                visible: !showCopied
+                visible: !showCopied,
               })}
               value={metadata.runCommand}
             />
@@ -110,7 +110,7 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
               <>
                 <span
                   className={modifiers('pipeline-metadata__copy-message', {
-                    visible: showCopied
+                    visible: showCopied,
                   })}>
                   Copied to clipboard.
                 </span>
@@ -139,16 +139,13 @@ const MetaData = ({ visible = true, metadata, onToggleNodeSelected }) => {
 export const mapStateToProps = (state, ownProps) => ({
   visible: getVisibleMetaSidebar(state),
   metadata: getClickedNodeMetaData(state),
-  ...ownProps
+  ...ownProps,
 });
 
-export const mapDispatchToProps = dispatch => ({
-  onToggleNodeSelected: nodeID => {
+export const mapDispatchToProps = (dispatch) => ({
+  onToggleNodeSelected: (nodeID) => {
     dispatch(toggleNodeClicked(nodeID));
-  }
+  },
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(MetaData);
+export default connect(mapStateToProps, mapDispatchToProps)(MetaData);

--- a/src/components/metadata/metadata-list.js
+++ b/src/components/metadata/metadata-list.js
@@ -13,7 +13,7 @@ const MetaDataList = ({
   empty = '-',
   inline = true,
   commas = true,
-  limit = false
+  limit = false,
 }) => {
   const [expanded, setExpanded] = useState(false);
   const showValues = !expanded && limit ? values.slice(0, limit) : values;
@@ -24,7 +24,7 @@ const MetaDataList = ({
       <ul
         className={modifiers('pipeline-metadata__value-list', {
           inline,
-          commas
+          commas,
         })}>
         {showValues.map((item, index) => (
           <li key={index}>

--- a/src/components/metadata/metadata-row.js
+++ b/src/components/metadata/metadata-row.js
@@ -16,7 +16,7 @@ const MetaDataRow = ({
   inline = true,
   commas = true,
   limit = false,
-  children
+  children,
 }) => {
   const showList = Array.isArray(value);
 

--- a/src/components/metadata/metadata-value.js
+++ b/src/components/metadata/metadata-value.js
@@ -10,7 +10,7 @@ const MetaDataValue = ({
   className,
   value,
   kind,
-  empty
+  empty,
 }) => (
   <Container
     title={value}

--- a/src/components/metadata/metadata.test.js
+++ b/src/components/metadata/metadata.test.js
@@ -12,7 +12,7 @@ describe('MetaData', () => {
   // Add edge links, can be removed when new graph is default
   addEdgeLinks(mockState.animals.graph.nodes, mockState.animals.graph.edges);
 
-  const mount = props => {
+  const mount = (props) => {
     mockState.animals.node.clicked = props.nodeId;
     return setup.mount(
       <MetaData
@@ -22,10 +22,10 @@ describe('MetaData', () => {
     );
   };
 
-  const textOf = elements => elements.map(element => element.text());
-  const title = wrapper => wrapper.find('.pipeline-metadata__title');
-  const rowIcon = row => row.find('svg.pipeline-metadata__icon');
-  const rowValue = row => row.find('.pipeline-metadata__value');
+  const textOf = (elements) => elements.map((element) => element.text());
+  const title = (wrapper) => wrapper.find('.pipeline-metadata__title');
+  const rowIcon = (row) => row.find('svg.pipeline-metadata__icon');
+  const rowValue = (row) => row.find('.pipeline-metadata__value');
   const rowByLabel = (wrapper, label) =>
     // Using attribute since traversal by sibling not supported
     wrapper.find(`.pipeline-metadata__row[data-label="${label}"]`);
@@ -94,7 +94,7 @@ describe('MetaData', () => {
         'Cat',
         'Dog',
         'Parameters',
-        'Params:rabbit'
+        'Params:rabbit',
       ]);
     });
 
@@ -130,7 +130,7 @@ describe('MetaData', () => {
 
     it('copies run command when button clicked', () => {
       window.navigator.clipboard = {
-        writeText: jest.fn()
+        writeText: jest.fn(),
       };
 
       const wrapper = mount({ nodeId: salmonTaskNodeId });
@@ -195,7 +195,7 @@ describe('MetaData', () => {
 
     it('copies run command when button clicked', () => {
       window.navigator.clipboard = {
-        writeText: jest.fn()
+        writeText: jest.fn(),
       };
 
       const wrapper = mount({ nodeId: catDatasetNodeId });

--- a/src/components/minimap-toolbar/index.js
+++ b/src/components/minimap-toolbar/index.js
@@ -16,7 +16,7 @@ export const MiniMapToolbar = ({
   onToggleMiniMap,
   visible,
   chartZoom,
-  onUpdateChartZoom
+  onUpdateChartZoom,
 }) => {
   const { scale, minScale, maxScale } = chartZoom;
 
@@ -74,24 +74,21 @@ const scaleZoom = ({ scale }, factor) => ({
   scale: scale * (factor || 1),
   applied: false,
   transition: true,
-  reset: factor === 0
+  reset: factor === 0,
 });
 
-export const mapStateToProps = state => ({
+export const mapStateToProps = (state) => ({
   visible: state.visible,
-  chartZoom: getChartZoom(state)
+  chartZoom: getChartZoom(state),
 });
 
-export const mapDispatchToProps = dispatch => ({
-  onToggleMiniMap: value => {
+export const mapDispatchToProps = (dispatch) => ({
+  onToggleMiniMap: (value) => {
     dispatch(toggleMiniMap(value));
   },
-  onUpdateChartZoom: transform => {
+  onUpdateChartZoom: (transform) => {
     dispatch(updateZoom(transform));
-  }
+  },
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(MiniMapToolbar);
+export default connect(mapStateToProps, mapDispatchToProps)(MiniMapToolbar);

--- a/src/components/minimap-toolbar/minimap-toolbar.test.js
+++ b/src/components/minimap-toolbar/minimap-toolbar.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ConnectedMiniMapToolbar, {
   MiniMapToolbar,
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 } from './index';
 import { mockState, setup } from '../../utils/state.mock';
 
@@ -16,7 +16,7 @@ describe('MiniMapToolbar', () => {
     ['.pipeline-minimap-button--map', 'onToggleMiniMap'],
     ['.pipeline-minimap-button--zoom-in', 'onUpdateChartZoom'],
     ['.pipeline-minimap-button--zoom-out', 'onUpdateChartZoom'],
-    ['.pipeline-minimap-button--reset', 'onUpdateChartZoom']
+    ['.pipeline-minimap-button--reset', 'onUpdateChartZoom'],
   ];
 
   test.each(functionCalls)(
@@ -26,14 +26,11 @@ describe('MiniMapToolbar', () => {
       const props = {
         chartZoom: { scale: 1, minScale: 0.5, maxScale: 1.5 },
         visible: { miniMap: false },
-        [callback]: mockFn
+        [callback]: mockFn,
       };
       const wrapper = setup.mount(<MiniMapToolbar {...props} />);
       expect(mockFn.mock.calls.length).toBe(0);
-      wrapper
-        .find(selector)
-        .find('button')
-        .simulate('click');
+      wrapper.find(selector).find('button').simulate('click');
       expect(mockFn.mock.calls.length).toBe(1);
     }
   );
@@ -43,8 +40,8 @@ describe('MiniMapToolbar', () => {
       chartZoom: expect.any(Object),
       visible: expect.objectContaining({
         miniMap: expect.any(Boolean),
-        miniMapBtn: expect.any(Boolean)
-      })
+        miniMapBtn: expect.any(Boolean),
+      }),
     };
     expect(mapStateToProps(mockState.animals)).toEqual(expectedResult);
   });
@@ -53,7 +50,7 @@ describe('MiniMapToolbar', () => {
     const dispatch = jest.fn();
     const expectedResult = {
       onToggleMiniMap: expect.any(Function),
-      onUpdateChartZoom: expect.any(Function)
+      onUpdateChartZoom: expect.any(Function),
     };
     expect(mapDispatchToProps(dispatch)).toEqual(expectedResult);
   });

--- a/src/components/minimap/draw.js
+++ b/src/components/minimap/draw.js
@@ -5,7 +5,7 @@ const viewportMargin = 2;
 /**
  * Render viewport region
  */
-export const drawViewport = function() {
+export const drawViewport = function () {
   const { mapSize } = this.props;
   const { x, y, width, height } = this.getViewport();
 
@@ -14,10 +14,7 @@ export const drawViewport = function() {
   const maxX = Math.min(x + width, mapSize.width - viewportMargin);
   const maxY = Math.min(y + height, mapSize.height - viewportMargin);
 
-  this.el.viewport
-    .enter()
-    .attr('x', 0)
-    .attr('y', 0);
+  this.el.viewport.enter().attr('x', 0).attr('y', 0);
 
   this.el.viewport
     .attr('transform', `translate(${minX}, ${minY})`)
@@ -28,18 +25,18 @@ export const drawViewport = function() {
 /**
  * Render nodes
  */
-export const drawNodes = function() {
+export const drawNodes = function () {
   const {
     centralNode,
     linkedNodes,
     nodeActive,
     nodeSelected,
-    nodes
+    nodes,
   } = this.props;
 
   this.el.nodes = this.el.nodeGroup
     .selectAll('.pipeline-minimap-node')
-    .data(nodes, node => node.id);
+    .data(nodes, (node) => node.id);
 
   const enterNodes = this.el.nodes
     .enter()
@@ -47,7 +44,7 @@ export const drawNodes = function() {
     .attr('class', 'pipeline-minimap-node');
 
   enterNodes
-    .attr('transform', node => `translate(${node.x}, ${node.y})`)
+    .attr('transform', (node) => `translate(${node.x}, ${node.y})`)
     .attr('opacity', 0);
 
   enterNodes.append('rect');
@@ -61,28 +58,28 @@ export const drawNodes = function() {
 
   this.el.nodes = this.el.nodes
     .merge(enterNodes)
-    .attr('data-id', node => node.id)
-    .classed('pipeline-minimap-node--active', node => nodeActive[node.id])
-    .classed('pipeline-minimap-node--selected', node => nodeSelected[node.id])
+    .attr('data-id', (node) => node.id)
+    .classed('pipeline-minimap-node--active', (node) => nodeActive[node.id])
+    .classed('pipeline-minimap-node--selected', (node) => nodeSelected[node.id])
     .classed(
       'pipeline-minimap-node--faded',
-      node => centralNode && !linkedNodes[node.id]
+      (node) => centralNode && !linkedNodes[node.id]
     );
 
   this.el.nodes
     .transition('update-nodes')
     .duration(this.DURATION)
     .attr('opacity', 1)
-    .attr('transform', node => `translate(${node.x}, ${node.y})`)
+    .attr('transform', (node) => `translate(${node.x}, ${node.y})`)
     .end()
     .catch(() => {});
 
   this.el.nodes
     .select('rect')
-    .attr('width', node => node.width - sizeOffset(node))
-    .attr('height', node => node.height - sizeOffset(node))
-    .attr('x', node => (node.width - sizeOffset(node)) / -2)
-    .attr('y', node => (node.height - sizeOffset(node)) / -2);
+    .attr('width', (node) => node.width - sizeOffset(node))
+    .attr('height', (node) => node.height - sizeOffset(node))
+    .attr('x', (node) => (node.width - sizeOffset(node)) / -2)
+    .attr('y', (node) => (node.height - sizeOffset(node)) / -2);
 };
 
-const sizeOffset = node => (node.type === 'task' ? 5 : 16);
+const sizeOffset = (node) => (node.type === 'task' ? 5 : 16);

--- a/src/components/minimap/index.js
+++ b/src/components/minimap/index.js
@@ -12,7 +12,7 @@ import {
   isOrigin,
   viewTransformToFit,
   getViewTransform,
-  setViewTransformExact
+  setViewTransformExact,
 } from '../../utils/view';
 import { drawNodes, drawViewport } from './draw';
 import './styles/minimap.css';
@@ -54,7 +54,7 @@ export class MiniMap extends Component {
     this.view = viewing({
       container: this.svgRef,
       wrapper: this.wrapperRef,
-      allowUserInput: false
+      allowUserInput: false,
     });
 
     this.addGlobalEventListeners();
@@ -70,7 +70,7 @@ export class MiniMap extends Component {
    */
   addGlobalEventListeners() {
     window.addEventListener('wheel', this.onPointerWheelGlobal, {
-      passive: false
+      passive: false,
     });
     window.addEventListener(
       pointerEventName('pointerup'),
@@ -131,7 +131,9 @@ export class MiniMap extends Component {
    */
   changed(props, objectA, objectB) {
     return (
-      objectA && objectB && props.some(prop => objectA[prop] !== objectB[prop])
+      objectA &&
+      objectB &&
+      props.some((prop) => objectA[prop] !== objectB[prop])
     );
   }
 
@@ -143,7 +145,7 @@ export class MiniMap extends Component {
       svg: select(this.svgRef.current),
       wrapper: select(this.wrapperRef.current),
       nodeGroup: select(this.nodesRef.current),
-      viewport: select(this.viewportRef.current)
+      viewport: select(this.viewportRef.current),
     };
   }
 
@@ -173,7 +175,7 @@ export class MiniMap extends Component {
    * Handle pointer down
    * @param {Object} event Event object
    */
-  onPointerDown = event => {
+  onPointerDown = (event) => {
     this.isPointerDown = true;
     this.isPointerInside = true;
 
@@ -184,13 +186,13 @@ export class MiniMap extends Component {
    * Handle pointer wheel
    * @param {Object} event Event object
    */
-  onPointerWheel = event => {
+  onPointerWheel = (event) => {
     // Change zoom based on wheel velocity
     this.props.onUpdateChartZoom({
       relative: true,
       scale: -(event.deltaY || 0) * this.ZOOM_RATE,
       applied: false,
-      transition: false
+      transition: false,
     });
   };
 
@@ -198,7 +200,7 @@ export class MiniMap extends Component {
    * Handle global pointer wheel
    * @param {Object} event Event object
    */
-  onPointerWheelGlobal = event => {
+  onPointerWheelGlobal = (event) => {
     // Prevent window scroll when wheeling on this minimap
     const wasTarget = this.containerRef.current.contains(event.target);
     if (wasTarget) {
@@ -241,7 +243,7 @@ export class MiniMap extends Component {
         scale: chartScale,
         relative: false,
         applied: false,
-        transition: useTransition
+        transition: useTransition,
       });
 
       if (useTransition) {
@@ -272,7 +274,7 @@ export class MiniMap extends Component {
       viewWidth: mapWidth - padding,
       viewHeight: mapHeight - padding,
       objectWidth: graphWidth,
-      objectHeight: graphHeight
+      objectHeight: graphHeight,
     });
 
     // Detect first transform
@@ -311,7 +313,7 @@ export class MiniMap extends Component {
   render() {
     const { width, height } = this.props.mapSize;
     const transformStyle = {
-      transform: `translate(calc(-100% + ${width}px), -100%)`
+      transform: `translate(calc(-100% + ${width}px), -100%)`,
     };
 
     // Add pointer events with back compatibility
@@ -321,7 +323,7 @@ export class MiniMap extends Component {
       [_('onPointerEnter')]: this.onPointerEnter,
       [_('onPointerLeave')]: this.onPointerLeave,
       [_('onPointerDown')]: this.onPointerDown,
-      [_('onPointerMove')]: this.onPointerMove
+      [_('onPointerMove')]: this.onPointerMove,
     };
 
     return (
@@ -366,7 +368,7 @@ const maxWidth = 1.5 * minWidth;
 /**
  * Convert pointer event name to a mouse event name if not supported
  */
-const pointerEventName = event =>
+const pointerEventName = (event) =>
   window.PointerEvent
     ? event
     : event.replace('pointer', 'mouse').replace('Pointer', 'Mouse');
@@ -374,7 +376,7 @@ const pointerEventName = event =>
 /**
  * Gets the map sizing that fits the graph in state
  */
-const getMapSize = state => {
+const getMapSize = (state) => {
   const size = state.graph.size || {};
   const graphWidth = size.width || 0;
   const graphHeight = size.height || 0;
@@ -407,17 +409,14 @@ export const mapStateToProps = (state, ownProps) => ({
   nodeActive: getNodeActive(state),
   nodeSelected: getNodeSelected(state),
   textLabels: state.textLabels,
-  ...ownProps
+  ...ownProps,
 });
 
 export const mapDispatchToProps = (dispatch, ownProps) => ({
-  onUpdateChartZoom: transform => {
+  onUpdateChartZoom: (transform) => {
     dispatch(updateZoom(transform));
   },
-  ...ownProps
+  ...ownProps,
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(MiniMap);
+export default connect(mapStateToProps, mapDispatchToProps)(MiniMap);

--- a/src/components/minimap/minimap.test.js
+++ b/src/components/minimap/minimap.test.js
@@ -3,7 +3,7 @@ import MiniMap, { mapStateToProps, mapDispatchToProps } from './index';
 import { mockState, setup } from '../../utils/state.mock';
 import { getViewTransform, origin } from '../../utils/view';
 
-const getNodeIDs = state => state.node.ids;
+const getNodeIDs = (state) => state.node.ids;
 
 describe('MiniMap', () => {
   it('renders without crashing', () => {
@@ -50,7 +50,7 @@ describe('MiniMap', () => {
     window.addEventListener = jest.fn(
       (event, cb) => (windowEvents[event] = cb)
     );
-    window.removeEventListener = jest.fn(event => delete windowEvents[event]);
+    window.removeEventListener = jest.fn((event) => delete windowEvents[event]);
 
     const wrapper = setup.mount(<MiniMap />);
     expect(() => windowEvents.wheel({ target: null })).not.toThrow();
@@ -63,7 +63,7 @@ describe('MiniMap', () => {
     window.addEventListener = jest.fn(
       (event, cb) => (windowEvents[event] = cb)
     );
-    window.removeEventListener = jest.fn(event => delete windowEvents[event]);
+    window.removeEventListener = jest.fn((event) => delete windowEvents[event]);
     window.PointerEvent = {};
 
     const wrapper = setup.mount(<MiniMap />);
@@ -78,7 +78,7 @@ describe('MiniMap', () => {
     window.addEventListener = jest.fn(
       (event, cb) => (windowEvents[event] = cb)
     );
-    window.removeEventListener = jest.fn(event => delete windowEvents[event]);
+    window.removeEventListener = jest.fn((event) => delete windowEvents[event]);
     window.PointerEvent = null;
 
     const wrapper = setup.mount(<MiniMap />);
@@ -105,7 +105,7 @@ describe('MiniMap', () => {
       scale: expect.any(Number),
       applied: expect.any(Boolean),
       transition: expect.any(Boolean),
-      relative: expect.any(Boolean)
+      relative: expect.any(Boolean),
     });
   });
 
@@ -124,7 +124,7 @@ describe('MiniMap', () => {
       scale: expect.any(Number),
       applied: expect.any(Boolean),
       transition: expect.any(Boolean),
-      relative: expect.any(Boolean)
+      relative: expect.any(Boolean),
     });
   });
 
@@ -155,7 +155,7 @@ describe('MiniMap', () => {
       nodeActive: expect.any(Object),
       nodeSelected: expect.any(Object),
       nodes: expect.any(Array),
-      textLabels: expect.any(Boolean)
+      textLabels: expect.any(Boolean),
     };
     expect(mapStateToProps(mockState.animals)).toEqual(expectedResult);
   });
@@ -167,7 +167,7 @@ describe('MiniMap', () => {
     mapDispatchToProps(dispatch).onUpdateChartZoom(zoom);
     expect(dispatch.mock.calls[0][0]).toEqual({
       type: 'UPDATE_ZOOM',
-      zoom
+      zoom,
     });
   });
 });

--- a/src/components/node-list/index.js
+++ b/src/components/node-list/index.js
@@ -11,11 +11,11 @@ import { getGroupedNodes, getNodeSelected } from '../../selectors/nodes';
 import {
   loadNodeData,
   toggleNodeHovered,
-  toggleNodesDisabled
+  toggleNodesDisabled,
 } from '../../actions/nodes';
 import './styles/node-list.css';
 
-const isTagType = type => type === 'tag';
+const isTagType = (type) => type === 'tag';
 
 /**
  * Provides data from the store to populate a NodeList component.
@@ -40,7 +40,7 @@ const NodeListProvider = ({
   onToggleNodeActive,
   onToggleTagActive,
   onToggleTagFilter,
-  onToggleTypeDisabled
+  onToggleTypeDisabled,
 }) => {
   const [searchValue, updateSearchValue] = useState('');
   const items = getFilteredItems({
@@ -48,11 +48,11 @@ const NodeListProvider = ({
     tags,
     tagsEnabled,
     nodeSelected,
-    searchValue
+    searchValue,
   });
   const groups = getGroups({ types, items });
 
-  const onItemClick = item => {
+  const onItemClick = (item) => {
     if (isTagType(item.type)) {
       onTagItemChange(item, item.checked);
     } else {
@@ -76,7 +76,7 @@ const NodeListProvider = ({
     }
   };
 
-  const onItemMouseEnter = item => {
+  const onItemMouseEnter = (item) => {
     if (isTagType(item.type)) {
       onToggleTagActive(item.id, true);
     } else if (item.visible) {
@@ -84,7 +84,7 @@ const NodeListProvider = ({
     }
   };
 
-  const onItemMouseLeave = item => {
+  const onItemMouseLeave = (item) => {
     if (isTagType(item.type)) {
       onToggleTagActive(item.id, false);
     } else if (item.visible) {
@@ -96,9 +96,12 @@ const NodeListProvider = ({
     if (isTagType(type)) {
       // Filter all tags if at least one tag item set, otherwise enable all tags
       const tagItems = items[type] || [];
-      const someTagSet = tagItems.some(tagItem => !tagItem.unset);
+      const someTagSet = tagItems.some((tagItem) => !tagItem.unset);
       const allTagsValue = someTagSet ? undefined : true;
-      onToggleTagFilter(tagItems.map(tag => tag.id), allTagsValue);
+      onToggleTagFilter(
+        tagItems.map((tag) => tag.id),
+        allTagsValue
+      );
     } else {
       onToggleTypeDisabled(type, checked);
     }
@@ -107,12 +110,15 @@ const NodeListProvider = ({
   const onTagItemChange = (tagItem, wasChecked) => {
     const tagItems = items[tagItem.type] || [];
     const oneTagChecked =
-      tagItems.filter(tagItem => tagItem.checked).length === 1;
+      tagItems.filter((tagItem) => tagItem.checked).length === 1;
     const shouldResetTags = wasChecked && oneTagChecked;
 
     if (shouldResetTags) {
       // Unset all tags
-      onToggleTagFilter(tags.map(tag => tag.id), undefined);
+      onToggleTagFilter(
+        tags.map((tag) => tag.id),
+        undefined
+      );
     } else {
       // Toggle the tag
       onToggleTagFilter([tagItem.id], !wasChecked);
@@ -124,9 +130,9 @@ const NodeListProvider = ({
   };
 
   // Deselect node on Escape key
-  const handleKeyDown = event => {
+  const handleKeyDown = (event) => {
     utils.handleKeyEvent(event.keyCode, {
-      escape: () => onToggleNodeSelected(null)
+      escape: () => onToggleNodeSelected(null),
     });
   };
   useEffect(() => {
@@ -151,16 +157,16 @@ const NodeListProvider = ({
   );
 };
 
-export const mapStateToProps = state => ({
+export const mapStateToProps = (state) => ({
   tags: getTagData(state),
   tagsEnabled: state.tag.enabled,
   nodes: getGroupedNodes(state),
   nodeSelected: getNodeSelected(state),
   sections: getSections(state),
-  types: getNodeTypes(state)
+  types: getNodeTypes(state),
 });
 
-export const mapDispatchToProps = dispatch => ({
+export const mapDispatchToProps = (dispatch) => ({
   onToggleTagActive: (tagIDs, active) => {
     dispatch(toggleTagActive(tagIDs, active));
   },
@@ -170,18 +176,15 @@ export const mapDispatchToProps = dispatch => ({
   onToggleTypeDisabled: (typeID, disabled) => {
     dispatch(toggleTypeDisabled(typeID, disabled));
   },
-  onToggleNodeSelected: nodeID => {
+  onToggleNodeSelected: (nodeID) => {
     dispatch(loadNodeData(nodeID));
   },
-  onToggleNodeActive: nodeID => {
+  onToggleNodeActive: (nodeID) => {
     dispatch(toggleNodeHovered(nodeID));
   },
   onToggleNodesDisabled: (nodeIDs, disabled) => {
     dispatch(toggleNodesDisabled(nodeIDs, disabled));
-  }
+  },
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(NodeListProvider);
+export default connect(mapStateToProps, mapDispatchToProps)(NodeListProvider);

--- a/src/components/node-list/node-list-group.js
+++ b/src/components/node-list/node-list-group.js
@@ -21,7 +21,7 @@ export const NodeListGroup = ({
   onItemClick,
   onItemChange,
   onItemMouseEnter,
-  onItemMouseLeave
+  onItemMouseLeave,
 }) => (
   <li
     className={classnames(
@@ -29,7 +29,7 @@ export const NodeListGroup = ({
       `pipeline-nodelist__group--type-${id}`,
       `pipeline-nodelist__group--kind-${kind}`,
       {
-        'pipeline-nodelist__group--all-unset': allUnset
+        'pipeline-nodelist__group--all-unset': allUnset,
       }
     )}>
     <h3 className="pipeline-nodelist__heading">
@@ -43,14 +43,14 @@ export const NodeListGroup = ({
         checked={checked}
         visibleIcon={visibleIcon}
         invisibleIcon={invisibleIcon}
-        onChange={e => {
+        onChange={(e) => {
           onToggleChecked(id, !e.target.checked);
         }}>
         <button
           aria-label={`${collapsed ? 'Show' : 'Hide'} ${name.toLowerCase()}`}
           onClick={() => onToggleCollapsed(id)}
           className={classnames('pipeline-type-group-toggle', {
-            'pipeline-type-group-toggle--alt': collapsed
+            'pipeline-type-group-toggle--alt': collapsed,
           })}
         />
       </NodeListRow>

--- a/src/components/node-list/node-list-groups.js
+++ b/src/components/node-list/node-list-groups.js
@@ -13,24 +13,24 @@ const NodeListGroups = ({
   onItemClick,
   onItemMouseEnter,
   onItemMouseLeave,
-  onItemChange
+  onItemChange,
 }) => {
   const [collapsed, setCollapsed] = useState(storedState.groupsCollapsed || {});
 
   // Collapse/expand node group
-  const onToggleGroupCollapsed = typeID => {
+  const onToggleGroupCollapsed = (typeID) => {
     const groupsCollapsed = Object.assign({}, collapsed, {
-      [typeID]: !collapsed[typeID]
+      [typeID]: !collapsed[typeID],
     });
     setCollapsed(groupsCollapsed);
     saveState({ groupsCollapsed });
   };
 
-  return sections.map(section => (
+  return sections.map((section) => (
     <nav className="pipeline-nodelist-section kedro" key={section.name}>
       <h2 className="pipeline-nodelist-section__title">{section.name}</h2>
       <ul className="pipeline-nodelist__list">
-        {section.types.map(typeId => {
+        {section.types.map((typeId) => {
           const group = groups[typeId];
           return (
             <NodeListGroup

--- a/src/components/node-list/node-list-items.js
+++ b/src/components/node-list/node-list-items.js
@@ -13,8 +13,8 @@ const { escapeRegExp, getHighlightedText } = utils;
  * @param {object} nodes Grouped nodes
  * @return {array} List of node IDs
  */
-export const getNodeIDs = nodes => {
-  const getNodeIDs = type => nodes[type].map(node => node.id);
+export const getNodeIDs = (nodes) => {
+  const getNodeIDs = (type) => nodes[type].map((node) => node.id);
   const concatNodeIDs = (nodeIDs, type) => nodeIDs.concat(getNodeIDs(type));
 
   return Object.keys(nodes).reduce(concatNodeIDs, []);
@@ -27,13 +27,13 @@ export const getNodeIDs = nodes => {
  * @return {object} The grouped nodes with highlightedLabel fields added
  */
 export const highlightMatch = (nodes, searchValue) => {
-  const addHighlightedLabel = node => ({
+  const addHighlightedLabel = (node) => ({
     highlightedLabel: getHighlightedText(node.name, searchValue),
-    ...node
+    ...node,
   });
   const addLabelsToNodes = (newNodes, type) => ({
     ...newNodes,
-    [type]: nodes[type].map(addHighlightedLabel)
+    [type]: nodes[type].map(addHighlightedLabel),
   });
 
   return Object.keys(nodes).reduce(addLabelsToNodes, {});
@@ -59,11 +59,11 @@ export const nodeMatchesSearch = (node, searchValue) => {
  * @return {object} Grouped nodes
  */
 export const filterNodes = (nodes, searchValue) => {
-  const filterNodesByType = type =>
-    nodes[type].filter(node => nodeMatchesSearch(node, searchValue));
+  const filterNodesByType = (type) =>
+    nodes[type].filter((node) => nodeMatchesSearch(node, searchValue));
   const filterNodeLists = (newNodes, type) => ({
     ...newNodes,
-    [type]: filterNodesByType(type)
+    [type]: filterNodesByType(type),
   });
 
   return Object.keys(nodes).reduce(filterNodeLists, {});
@@ -76,13 +76,13 @@ export const filterNodes = (nodes, searchValue) => {
  * @return {object} Grouped nodes, and node IDs
  */
 export const getFilteredNodes = createSelector(
-  [state => state.nodes, state => state.searchValue],
+  [(state) => state.nodes, (state) => state.searchValue],
   (nodes, searchValue) => {
     const filteredNodes = filterNodes(nodes, searchValue);
 
     return {
       filteredNodes: highlightMatch(filteredNodes, searchValue),
-      nodeIDs: getNodeIDs(filteredNodes)
+      nodeIDs: getNodeIDs(filteredNodes),
     };
   }
 );
@@ -94,7 +94,7 @@ export const getFilteredNodes = createSelector(
  * @return {object} Grouped tags
  */
 export const getFilteredTags = createSelector(
-  [state => state.tags, state => state.searchValue],
+  [(state) => state.tags, (state) => state.searchValue],
   (tags, searchValue) =>
     highlightMatch(filterNodes({ tag: tags }, searchValue), searchValue)
 );
@@ -106,9 +106,9 @@ export const getFilteredTags = createSelector(
  * @return {array} Node list items
  */
 export const getFilteredTagItems = createSelector(
-  [getFilteredTags, state => state.tagsEnabled],
+  [getFilteredTags, (state) => state.tagsEnabled],
   (filteredTags, tagsEnabled) => ({
-    tag: filteredTags.tag.map(tag => ({
+    tag: filteredTags.tag.map((tag) => ({
       ...tag,
       type: 'tag',
       visibleIcon: IndicatorIcon,
@@ -119,8 +119,8 @@ export const getFilteredTagItems = createSelector(
       visible: true,
       disabled: false,
       unset: typeof tagsEnabled[tag.id] === 'undefined',
-      checked: tagsEnabled[tag.id] === true
-    }))
+      checked: tagsEnabled[tag.id] === true,
+    })),
   })
 );
 
@@ -145,13 +145,13 @@ const compareEnabledThenAlpha = (itemA, itemB) => {
  * @return {number} Comparison result
  */
 export const getFilteredNodeItems = createSelector(
-  [getFilteredNodes, state => state.nodeSelected],
+  [getFilteredNodes, (state) => state.nodeSelected],
   ({ filteredNodes }, nodeSelected) => {
     const result = {};
 
     for (const type of Object.keys(filteredNodes)) {
       result[type] = filteredNodes[type]
-        .map(node => {
+        .map((node) => {
           const checked = !node.disabled_node;
           const disabled = node.disabled_tag || node.disabled_type;
           return {
@@ -164,7 +164,7 @@ export const getFilteredNodeItems = createSelector(
             visible: !disabled && checked,
             unset: false,
             checked,
-            disabled
+            disabled,
           };
         })
         .sort(compareEnabledThenAlpha);
@@ -179,9 +179,9 @@ export const getFilteredNodeItems = createSelector(
  * @return {array} List of sections
  */
 export const getSections = createSelector(() =>
-  Object.keys(sidebar).map(name => ({
+  Object.keys(sidebar).map((name) => ({
     name,
-    types: Object.values(sidebar[name])
+    types: Object.values(sidebar[name]),
   }))
 );
 
@@ -198,8 +198,8 @@ export const createGroup = (itemType, itemsOfType = []) => {
     type: itemType,
     id: itemType.id,
     count: itemsOfType.length,
-    allUnset: itemsOfType.every(item => item.unset),
-    allChecked: itemsOfType.every(item => item.checked)
+    allUnset: itemsOfType.every((item) => item.unset),
+    allChecked: itemsOfType.every((item) => item.checked),
   };
 
   if (itemType.id === 'tag') {
@@ -208,7 +208,7 @@ export const createGroup = (itemType, itemsOfType = []) => {
       kind: 'filter',
       checked: !group.allUnset,
       visibleIcon: group.allChecked ? IndicatorIcon : IndicatorPartialIcon,
-      invisibleIcon: IndicatorOffIcon
+      invisibleIcon: IndicatorOffIcon,
     });
   } else {
     Object.assign(group, {
@@ -216,7 +216,7 @@ export const createGroup = (itemType, itemsOfType = []) => {
       kind: 'element',
       checked: !itemType.disabled,
       visibleIcon: VisibleIcon,
-      invisibleIcon: InvisibleIcon
+      invisibleIcon: InvisibleIcon,
     });
   }
   return group;
@@ -229,7 +229,7 @@ export const createGroup = (itemType, itemsOfType = []) => {
  * @return {array} List of groups
  */
 export const getGroups = createSelector(
-  [state => state.types, state => state.items],
+  [(state) => state.types, (state) => state.items],
   (nodeTypes, items) => {
     const groups = {};
     const itemTypes = [...nodeTypes, { id: 'tag' }];
@@ -251,7 +251,7 @@ export const getFilteredItems = createSelector(
   (filteredNodeItems, filteredTagItems) => {
     return {
       ...filteredTagItems,
-      ...filteredNodeItems
+      ...filteredNodeItems,
     };
   }
 );

--- a/src/components/node-list/node-list-items.test.js
+++ b/src/components/node-list/node-list-items.test.js
@@ -8,14 +8,14 @@ import {
   getFilteredTagItems,
   getSections,
   getGroups,
-  getFilteredItems
+  getFilteredItems,
 } from './node-list-items';
 import { mockState } from '../../utils/state.mock';
 import { getGroupedNodes } from '../../selectors/nodes';
 import { getNodeTypes } from '../../selectors/node-types';
 import { getTagData } from '../../selectors/tags';
 
-const ungroupNodes = groupedNodes =>
+const ungroupNodes = (groupedNodes) =>
   Object.keys(groupedNodes).reduce(
     (names, key) => names.concat(groupedNodes[key]),
     []
@@ -28,16 +28,16 @@ describe('node-list-selectors', () => {
     const { filteredNodes } = getFilteredNodes({ nodes, searchValue });
     const nodeList = ungroupNodes(filteredNodes);
 
-    test.each(nodeList.map(node => node.name))(
+    test.each(nodeList.map((node) => node.name))(
       `node name "%s" contains search term "${searchValue}"`,
-      name => {
+      (name) => {
         expect(name).toEqual(expect.stringMatching(searchValue));
       }
     );
 
-    test.each(nodeList.map(node => node.highlightedLabel))(
+    test.each(nodeList.map((node) => node.highlightedLabel))(
       `node label "%s" contains highlighted search term "<b>${searchValue}</b>"`,
-      name => {
+      (name) => {
         expect(name).toEqual(expect.stringMatching(`<b>${searchValue}</b>`));
       }
     );
@@ -53,16 +53,16 @@ describe('node-list-selectors', () => {
       expect(filteredTags).toHaveLength(2);
     });
 
-    test.each(filteredTags.map(tag => tag.name))(
+    test.each(filteredTags.map((tag) => tag.name))(
       `tag name "%s" contains search term "${searchValue}"`,
-      name => {
+      (name) => {
         expect(name).toEqual(expect.stringMatching(searchValue));
       }
     );
 
-    test.each(filteredTags.map(tag => tag.highlightedLabel))(
+    test.each(filteredTags.map((tag) => tag.highlightedLabel))(
       `tag label "%s" contains highlighted search term "<b>${searchValue}</b>"`,
-      name => {
+      (name) => {
         expect(name).toEqual(expect.stringMatching(`<b>${searchValue}</b>`));
       }
     );
@@ -74,7 +74,7 @@ describe('node-list-selectors', () => {
     const filteredTagItems = getFilteredTagItems({
       tags,
       searchValue,
-      tagsEnabled: {}
+      tagsEnabled: {},
     }).tag;
 
     const tagItems = expect.arrayContaining([
@@ -91,8 +91,8 @@ describe('node-list-selectors', () => {
         visible: expect.any(Boolean),
         disabled: expect.any(Boolean),
         unset: expect.any(Boolean),
-        checked: expect.any(Boolean)
-      })
+        checked: expect.any(Boolean),
+      }),
     ]);
 
     it('returns expected items matching the searchValue', () => {
@@ -110,7 +110,7 @@ describe('node-list-selectors', () => {
     });
 
     it('returns the filtered items that contains the search value', () => {
-      filteredTagItems.forEach(tagItem => {
+      filteredTagItems.forEach((tagItem) => {
         expect(tagItem.name).toContain(searchValue);
         expect(tagItem.id).toContain(searchValue);
       });
@@ -123,8 +123,8 @@ describe('node-list-selectors', () => {
     const section = expect.arrayContaining([
       expect.objectContaining({
         name: expect.any(String),
-        types: expect.any(Array)
-      })
+        types: expect.any(Array),
+      }),
     ]);
 
     it('returns sections of the correct format', () => {
@@ -140,7 +140,7 @@ describe('node-list-selectors', () => {
       tags: getTagData(mockState.animals),
       tagsEnabled: {},
       nodeSelected: {},
-      searchValue
+      searchValue,
     });
 
     const items = expect.arrayContaining([
@@ -155,8 +155,8 @@ describe('node-list-selectors', () => {
         visible: expect.any(Boolean),
         disabled: expect.any(Boolean),
         unset: expect.any(Boolean),
-        checked: expect.any(Boolean)
-      })
+        checked: expect.any(Boolean),
+      }),
     ]);
 
     it('filters expected number of items', () => {
@@ -172,7 +172,7 @@ describe('node-list-selectors', () => {
           task: items,
           data: items,
           parameters: items,
-          tag: items
+          tag: items,
         })
       );
     });
@@ -185,7 +185,7 @@ describe('node-list-selectors', () => {
       tags: getTagData(mockState.animals),
       tagsEnabled: {},
       nodeSelected: {},
-      searchValue: ''
+      searchValue: '',
     });
 
     const groups = getGroups({ types, items });
@@ -200,7 +200,7 @@ describe('node-list-selectors', () => {
       count: expect.any(Number),
       allUnset: expect.any(Boolean),
       allChecked: expect.any(Boolean),
-      checked: expect.any(Boolean)
+      checked: expect.any(Boolean),
     });
 
     it('returns groups for each type in the correct format', () => {
@@ -209,7 +209,7 @@ describe('node-list-selectors', () => {
           task: groupType,
           data: groupType,
           parameters: groupType,
-          tag: groupType
+          tag: groupType,
         })
       );
     });
@@ -218,13 +218,13 @@ describe('node-list-selectors', () => {
   describe('getNodeIDs', () => {
     const generateNodes = (type, count) =>
       Array.from(new Array(count)).map((d, i) => ({
-        id: type + i
+        id: type + i,
       }));
 
     const nodes = {
       data: generateNodes('data', 10),
       task: generateNodes('task', 10),
-      parameters: generateNodes('parameters', 10)
+      parameters: generateNodes('parameters', 10),
     };
 
     it('returns a list of node IDs', () => {
@@ -244,12 +244,12 @@ describe('node-list-selectors', () => {
     const nodeList = ungroupNodes(formattedNodes);
 
     describe(`nodes which match the search term "${searchValue}"`, () => {
-      const matchingNodeList = nodeList.filter(node =>
+      const matchingNodeList = nodeList.filter((node) =>
         node.name.includes(searchValue)
       );
-      test.each(matchingNodeList.map(node => node.highlightedLabel))(
+      test.each(matchingNodeList.map((node) => node.highlightedLabel))(
         `node label "%s" contains highlighted search term "<b>${searchValue}</b>"`,
-        label => {
+        (label) => {
           expect(label).toEqual(expect.stringMatching(`<b>${searchValue}</b>`));
         }
       );
@@ -257,11 +257,11 @@ describe('node-list-selectors', () => {
 
     describe(`nodes which do not match the search term "${searchValue}"`, () => {
       const notMatchingNodeList = nodeList.filter(
-        node => !node.name.includes(searchValue)
+        (node) => !node.name.includes(searchValue)
       );
-      test.each(notMatchingNodeList.map(node => node.highlightedLabel))(
+      test.each(notMatchingNodeList.map((node) => node.highlightedLabel))(
         `node label "%s" does not contain "<b>"`,
-        label => {
+        (label) => {
           expect(label).not.toEqual(expect.stringMatching(`<b>`));
         }
       );
@@ -297,23 +297,23 @@ describe('node-list-selectors', () => {
     const filteredNodes = filterNodes(nodes, searchValue);
     const nodeList = ungroupNodes(filteredNodes);
     const notMatchingNodeList = ungroupNodes(nodes).filter(
-      node => !node.name.includes(searchValue)
+      (node) => !node.name.includes(searchValue)
     );
 
     describe('nodes which match the search term', () => {
-      test.each(nodeList.map(node => node.name))(
+      test.each(nodeList.map((node) => node.name))(
         `node name "%s" should contain search term "${searchValue}"`,
-        name => {
+        (name) => {
           expect(name).toEqual(expect.stringMatching(searchValue));
         }
       );
     });
 
     describe('nodes which do not match the search term', () => {
-      test.each(notMatchingNodeList.map(node => node.id))(
+      test.each(notMatchingNodeList.map((node) => node.id))(
         `filtered node list should not contain a node with id "%s"`,
-        nodeID => {
-          expect(nodeList.map(node => node.id)).not.toContain(
+        (nodeID) => {
+          expect(nodeList.map((node) => node.id)).not.toContain(
             expect.stringMatching(searchValue)
           );
         }

--- a/src/components/node-list/node-list-row-list.js
+++ b/src/components/node-list/node-list-row-list.js
@@ -11,7 +11,7 @@ const NodeRowList = ({
   onItemClick,
   onItemChange,
   onItemMouseEnter,
-  onItemMouseLeave
+  onItemMouseLeave,
 }) => (
   <ul
     className={modifiers(
@@ -19,7 +19,7 @@ const NodeRowList = ({
       { closed: collapsed },
       'pipeline-nodelist__list pipeline-nodelist__list--nested'
     )}>
-    {items.map(item => (
+    {items.map((item) => (
       <NodeListRow
         container="li"
         key={item.id}
@@ -41,7 +41,7 @@ const NodeRowList = ({
         onClick={() => onItemClick(item)}
         onMouseEnter={() => onItemMouseEnter(item)}
         onMouseLeave={() => onItemMouseLeave(item)}
-        onChange={e => onItemChange(item, !e.target.checked)}
+        onChange={(e) => onItemChange(item, !e.target.checked)}
       />
     ))}
   </ul>
@@ -54,7 +54,7 @@ const NodeRowLazyList = ({
   onItemClick,
   onItemChange,
   onItemMouseEnter,
-  onItemMouseLeave
+  onItemMouseLeave,
 }) => (
   <LazyList
     height={(start, end) => (end - start) * nodeListRowHeight}
@@ -68,7 +68,7 @@ const NodeRowLazyList = ({
       lowerRef,
       listStyle,
       upperStyle,
-      lowerStyle
+      lowerStyle,
     }) => (
       <ul
         ref={listRef}
@@ -80,19 +80,19 @@ const NodeRowLazyList = ({
         )}>
         <li
           className={modifiers('pipeline-nodelist__placeholder-upper', {
-            fade: start !== end && start > 0
+            fade: start !== end && start > 0,
           })}
           ref={upperRef}
           style={upperStyle}
         />
         <li
           className={modifiers('pipeline-nodelist__placeholder-lower', {
-            fade: start !== end && end < total
+            fade: start !== end && end < total,
           })}
           ref={lowerRef}
           style={lowerStyle}
         />
-        {items.slice(start, end).map(item => (
+        {items.slice(start, end).map((item) => (
           <NodeListRow
             container="li"
             key={item.id}
@@ -114,7 +114,7 @@ const NodeRowLazyList = ({
             onClick={() => onItemClick(item)}
             onMouseEnter={() => onItemMouseEnter(item)}
             onMouseLeave={() => onItemMouseLeave(item)}
-            onChange={e => onItemChange(item, !e.target.checked)}
+            onChange={(e) => onItemChange(item, !e.target.checked)}
           />
         ))}
       </ul>
@@ -124,9 +124,9 @@ const NodeRowLazyList = ({
 
 export const mapStateToProps = (state, ownProps) => ({
   lazy: state.flags.lazy,
-  ...ownProps
+  ...ownProps,
 });
 
-export default connect(mapStateToProps)(props =>
+export default connect(mapStateToProps)((props) =>
   props.lazy ? <NodeRowLazyList {...props} /> : <NodeRowList {...props} />
 );

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -26,7 +26,7 @@ const shouldMemo = (prevProps, nextProps) =>
       'visible',
       'selected',
       'label',
-      'children'
+      'children',
     ],
     prevProps,
     nextProps
@@ -54,7 +54,7 @@ const NodeListRow = memo(
     selected,
     type,
     visibleIcon = VisibleIcon,
-    invisibleIcon = InvisibleIcon
+    invisibleIcon = InvisibleIcon,
   }) => {
     const VisibilityIcon = checked ? visibleIcon : invisibleIcon;
     const isButton = onClick && kind !== 'filter';
@@ -70,7 +70,7 @@ const NodeListRow = memo(
             'pipeline-nodelist__row--active': active,
             'pipeline-nodelist__row--selected': selected,
             'pipeline-nodelist__row--disabled': disabled,
-            'pipeline-nodelist__row--unchecked': !checked
+            'pipeline-nodelist__row--unchecked': !checked,
           }
         )}
         title={name}
@@ -93,7 +93,7 @@ const NodeListRow = memo(
                   'pipeline-nodelist__row__type-icon--disabled': disabled,
                   'pipeline-nodelist__row__type-icon--nested': !children,
                   'pipeline-nodelist__row__type-icon--active': active,
-                  'pipeline-nodelist__row__type-icon--selected': selected
+                  'pipeline-nodelist__row__type-icon--selected': selected,
                 }
               )}
               type={type}
@@ -105,7 +105,7 @@ const NodeListRow = memo(
               `pipeline-nodelist__row__label--kind-${kind}`,
               {
                 'pipeline-nodelist__row__label--faded': faded,
-                'pipeline-nodelist__row__label--disabled': disabled
+                'pipeline-nodelist__row__label--disabled': disabled,
               }
             )}
             dangerouslySetInnerHTML={{ __html: label }}
@@ -117,7 +117,7 @@ const NodeListRow = memo(
           className={classnames('pipeline-row__toggle', {
             'pipeline-row__toggle--disabled': disabled,
             'pipeline-row__toggle--selected': selected,
-            'pipeline-row__toggle--not-tag': type !== 'tag'
+            'pipeline-row__toggle--not-tag': type !== 'tag',
           })}>
           <input
             id={id}
@@ -140,7 +140,7 @@ const NodeListRow = memo(
                 'pipeline-row__toggle-icon--checked': checked,
                 'pipeline-row__toggle-icon--unchecked': !checked,
                 'pipeline-row__toggle-icon--unset': unset,
-                'pipeline-row__toggle-icon--all-unset': allUnset
+                'pipeline-row__toggle-icon--all-unset': allUnset,
               }
             )}
           />
@@ -156,7 +156,7 @@ export const mapStateToProps = (state, ownProps) => ({
   active:
     typeof ownProps.active !== 'undefined'
       ? ownProps.active
-      : getNodeActive(state)[ownProps.id] || false
+      : getNodeActive(state)[ownProps.id] || false,
 });
 
 export default connect(mapStateToProps)(NodeListRow);

--- a/src/components/node-list/node-list-row.test.js
+++ b/src/components/node-list/node-list-row.test.js
@@ -20,7 +20,7 @@ describe('NodeListRow', () => {
       onMouseEnter: jest.fn(),
       onMouseLeave: jest.fn(),
       onChange: jest.fn(),
-      type: node.type
+      type: node.type,
     };
     return { props };
   };
@@ -84,7 +84,7 @@ describe('NodeListRow', () => {
 
   it('maps state to props', () => {
     const expectedResult = expect.objectContaining({
-      active: expect.any(Boolean)
+      active: expect.any(Boolean),
     });
     expect(mapStateToProps(mockState.animals, {})).toEqual(expectedResult);
   });

--- a/src/components/node-list/node-list-search.js
+++ b/src/components/node-list/node-list-search.js
@@ -16,7 +16,7 @@ export const NodeListSearch = ({ onUpdateSearchValue, searchValue, theme }) => {
    * you hit the shortcut again you will receive the default browser behaviour
    * @param {object} event Keydown event
    */
-  const handleWindowKeyDown = event => {
+  const handleWindowKeyDown = (event) => {
     const isKeyF = event.key === 'f' || event.keyCode === 70;
     const isKeyCtrlOrCmd = event.ctrlKey || event.metaKey;
     if (isKeyF && isKeyCtrlOrCmd) {
@@ -42,7 +42,7 @@ export const NodeListSearch = ({ onUpdateSearchValue, searchValue, theme }) => {
    * Listen for keyboard events, and trigger relevant actions
    * @param {number} keyCode The key event keycode
    */
-  const handleKeyDown = event => {
+  const handleKeyDown = (event) => {
     const isKeyEscape = event.key === 'Escape' || event.keyCode === 27;
     if (isKeyEscape) {
       onUpdateSearchValue('');
@@ -65,8 +65,8 @@ export const NodeListSearch = ({ onUpdateSearchValue, searchValue, theme }) => {
   );
 };
 
-export const mapStateToProps = state => ({
-  theme: state.theme
+export const mapStateToProps = (state) => ({
+  theme: state.theme,
 });
 
 export default connect(mapStateToProps)(NodeListSearch);

--- a/src/components/node-list/node-list-search.test.js
+++ b/src/components/node-list/node-list-search.test.js
@@ -58,7 +58,7 @@ describe('NodeListSearch', () => {
 
   it('maps state to props', () => {
     const expectedResult = {
-      theme: expect.any(String)
+      theme: expect.any(String),
     };
     expect(mapStateToProps(mockState.animals)).toEqual(expectedResult);
   });

--- a/src/components/node-list/node-list.js
+++ b/src/components/node-list/node-list.js
@@ -20,11 +20,11 @@ const NodeList = ({
   onItemClick,
   onItemMouseEnter,
   onItemMouseLeave,
-  onItemChange
+  onItemChange,
 }) => (
   <div
     className={classnames('pipeline-nodelist', {
-      'pipeline-nodelist--fade': faded
+      'pipeline-nodelist--fade': faded,
     })}>
     <NodeListSearch
       onUpdateSearchValue={onUpdateSearchValue}

--- a/src/components/node-list/node-list.test.js
+++ b/src/components/node-list/node-list.test.js
@@ -25,12 +25,12 @@ describe('NodeList', () => {
       getNodeData(mockState.animals)[0].name,
       'a',
       'aaaaaaaaaaaaaaaaa',
-      ''
+      '',
     ];
 
     test.each(searches)(
       'filters the node list when entering the search text "%s"',
-      searchText => {
+      (searchText) => {
         const search = () => wrapper.find('.kui-input__field');
         search().simulate('change', { target: { value: searchText } });
         const nodeList = wrapper.find(
@@ -38,10 +38,10 @@ describe('NodeList', () => {
         );
         const nodes = getNodeData(mockState.animals);
         const tags = getTagData(mockState.animals);
-        const expectedResult = nodes.filter(node =>
+        const expectedResult = nodes.filter((node) =>
           node.name.includes(searchText)
         );
-        const expectedTagResult = tags.filter(tag =>
+        const expectedTagResult = tags.filter((tag) =>
           tag.name.includes(searchText)
         );
         expect(search().props().value).toBe(searchText);
@@ -67,10 +67,10 @@ describe('NodeList', () => {
       search().simulate('change', { target: { value: searchText } });
       // Check that search input value and node list have been updated
       expect(search().props().value).toBe(searchText);
-      const expectedResult = nodes.filter(node =>
+      const expectedResult = nodes.filter((node) =>
         node.name.includes(searchText)
       );
-      const expectedTagResult = tags.filter(tag =>
+      const expectedTagResult = tags.filter((tag) =>
         tag.name.includes(searchText)
       );
       expect(nodeList().length).toBe(
@@ -94,11 +94,12 @@ describe('NodeList', () => {
           '.pipeline-nodelist__group--kind-element .pipeline-nodelist__list--nested'
         )
         .find('.pipeline-nodelist__row');
-    const rowName = row =>
+    const rowName = (row) =>
       row.find('.pipeline-nodelist__row__text').prop('title');
-    const isRowEnabled = row => row.hasClass('pipeline-nodelist__row--visible');
-    const setShownRowsEnabled = enable =>
-      rows().forEach(row =>
+    const isRowEnabled = (row) =>
+      row.hasClass('pipeline-nodelist__row--visible');
+    const setShownRowsEnabled = (enable) =>
+      rows().forEach((row) =>
         row
           .find('.pipeline-nodelist__row__checkbox')
           .simulate('change', { target: { checked: enable } })
@@ -106,7 +107,9 @@ describe('NodeList', () => {
     // Get search text value and filtered nodes
     const nodes = getNodeData(mockState.animals);
     const searchText = nodes[0].name;
-    const expectedResult = nodes.filter(node => node.name.includes(searchText));
+    const expectedResult = nodes.filter((node) =>
+      node.name.includes(searchText)
+    );
 
     describe('toggle only visible rows when searching', () => {
       beforeAll(() => {
@@ -117,7 +120,7 @@ describe('NodeList', () => {
         // Disable the found rows
         setShownRowsEnabled(false);
         // All visible rows should now be disabled
-        expect(rows().everyWhere(row => !isRowEnabled(row))).toBe(true);
+        expect(rows().everyWhere((row) => !isRowEnabled(row))).toBe(true);
         // Clear the search form so that all rows are now visible
         search().simulate('change', { target: { value: '' } });
       });
@@ -127,32 +130,32 @@ describe('NodeList', () => {
       });
 
       test('Some rows should not be enabled', () => {
-        expect(rows().someWhere(row => !isRowEnabled(row))).toBe(true);
+        expect(rows().someWhere((row) => !isRowEnabled(row))).toBe(true);
       });
 
       test('Some rows should be enabled', () => {
-        expect(rows().someWhere(row => isRowEnabled(row))).toBe(true);
+        expect(rows().someWhere((row) => isRowEnabled(row))).toBe(true);
       });
 
       test('Previously-visible rows should now be not enabled', () => {
         expect(
           rows()
-            .filterWhere(row => !isRowEnabled(row))
-            .map(row => rowName(row))
+            .filterWhere((row) => !isRowEnabled(row))
+            .map((row) => rowName(row))
             .sort()
-        ).toEqual(expectedResult.map(node => node.name).sort());
+        ).toEqual(expectedResult.map((node) => node.name).sort());
       });
 
       test('Previously-hidden rows should still be enabled', () => {
         expect(
           rows()
-            .filterWhere(row => isRowEnabled(row))
-            .map(row => rowName(row))
+            .filterWhere((row) => isRowEnabled(row))
+            .map((row) => rowName(row))
             .sort()
         ).toEqual(
           nodes
-            .filter(node => !node.name.includes(searchText))
-            .map(node => node.name)
+            .filter((node) => !node.name.includes(searchText))
+            .map((node) => node.name)
             .sort()
         );
       });
@@ -161,10 +164,10 @@ describe('NodeList', () => {
         setShownRowsEnabled(true);
         expect(
           rows()
-            .filterWhere(row => isRowEnabled(row))
-            .map(row => rowName(row))
+            .filterWhere((row) => isRowEnabled(row))
+            .map((row) => rowName(row))
             .sort()
-        ).toEqual(nodes.map(node => node.name).sort());
+        ).toEqual(nodes.map((node) => node.name).sort());
       });
     });
 
@@ -181,30 +184,31 @@ describe('NodeList', () => {
       wrapper.find(`.pipeline-nodelist__row[title="${text}"]`);
 
     const changeRows = (wrapper, names, checked) =>
-      names.forEach(name =>
+      names.forEach((name) =>
         checkboxByName(wrapper, name).simulate('change', {
-          target: { checked }
+          target: { checked },
         })
       );
 
-    const elements = wrapper =>
+    const elements = (wrapper) =>
       wrapper
         .find(
           '.pipeline-nodelist__group--kind-element .pipeline-nodelist__list--nested'
         )
         .find('.pipeline-nodelist__row')
-        .map(row => [
+        .map((row) => [
           row.prop('title'),
-          !row.hasClass('pipeline-nodelist__row--disabled')
+          !row.hasClass('pipeline-nodelist__row--disabled'),
         ]);
 
-    const elementsEnabled = wrapper =>
+    const elementsEnabled = (wrapper) =>
       elements(wrapper).filter(([_, enabled]) => enabled);
 
-    const tagItem = wrapper =>
+    const tagItem = (wrapper) =>
       wrapper.find('.pipeline-nodelist__group--type-tag');
 
-    const partialIcon = wrapper => tagItem(wrapper).find(IndicatorPartialIcon);
+    const partialIcon = (wrapper) =>
+      tagItem(wrapper).find(IndicatorPartialIcon);
 
     it('selecting tags enables only elements with given tags', () => {
       const wrapper = setup.mount(<NodeList />);
@@ -217,7 +221,7 @@ describe('NodeList', () => {
         ['Horse', true],
         ['Sheep', true],
         ['Parameters', true],
-        ['Params:rabbit', true]
+        ['Params:rabbit', true],
       ]);
 
       changeRows(wrapper, ['Small', 'Large'], true);
@@ -234,7 +238,7 @@ describe('NodeList', () => {
         ['Sheep', true],
         ['Weasel', true],
         ['Parameters', true],
-        ['Params:rabbit', true]
+        ['Params:rabbit', true],
       ]);
     });
 
@@ -262,7 +266,7 @@ describe('NodeList', () => {
         ['Whale', false],
         // Parameters
         ['Parameters', false],
-        ['Params:rabbit', false]
+        ['Params:rabbit', false],
       ]);
     });
 
@@ -374,19 +378,19 @@ describe('NodeList', () => {
         disabled_type: expect.any(Boolean),
         id: expect.any(String),
         name: expect.any(String),
-        type: expect.any(String)
-      })
+        type: expect.any(String),
+      }),
     ]);
     const expectedResult = expect.objectContaining({
       tags: expect.any(Object),
       tagsEnabled: expect.any(Object),
       nodes: expect.objectContaining({
         data: nodeList,
-        task: nodeList
+        task: nodeList,
       }),
       nodeSelected: expect.any(Object),
       sections: expect.any(Array),
-      types: expect.any(Array)
+      types: expect.any(Array),
     });
     expect(mapStateToProps(mockState.animals)).toEqual(expectedResult);
   });

--- a/src/components/pipeline-list/index.js
+++ b/src/components/pipeline-list/index.js
@@ -18,7 +18,7 @@ export const PipelineList = ({
   onUpdateActivePipeline,
   pipeline,
   theme,
-  onToggleOpen
+  onToggleOpen,
 }) => {
   if (!pipeline.ids.length && !asyncDataSource) {
     return null;
@@ -33,11 +33,11 @@ export const PipelineList = ({
         width={null}
         onChanged={onUpdateActivePipeline}
         defaultText={pipeline.name[pipeline.active] || 'Default'}>
-        {pipeline.ids.map(id => (
+        {pipeline.ids.map((id) => (
           <MenuOption
             key={`pipeline-${id}`}
             className={classnames({
-              'pipeline-list__option--active': pipeline.active === id
+              'pipeline-list__option--active': pipeline.active === id,
             })}
             value={id}
             primaryText={pipeline.name[id]}
@@ -48,19 +48,16 @@ export const PipelineList = ({
   );
 };
 
-export const mapStateToProps = state => ({
+export const mapStateToProps = (state) => ({
   asyncDataSource: state.asyncDataSource,
   pipeline: state.pipeline,
-  theme: state.theme
+  theme: state.theme,
 });
 
-export const mapDispatchToProps = dispatch => ({
-  onUpdateActivePipeline: event => {
+export const mapDispatchToProps = (dispatch) => ({
+  onUpdateActivePipeline: (event) => {
     dispatch(loadPipelineData(event.value));
-  }
+  },
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(PipelineList);
+export default connect(mapStateToProps, mapDispatchToProps)(PipelineList);

--- a/src/components/pipeline-list/pipeline-list.test.js
+++ b/src/components/pipeline-list/pipeline-list.test.js
@@ -29,10 +29,7 @@ describe('PipelineList', () => {
     'should change the active pipeline to %s on clicking menu option %s',
     (id, i) => {
       const wrapper = setup.mount(<PipelineList onToggleOpen={jest.fn()} />);
-      wrapper
-        .find('MenuOption')
-        .at(i)
-        .simulate('click');
+      wrapper.find('MenuOption').at(i).simulate('click');
       expect(wrapper.find('PipelineList').props().pipeline.active).toBe(id);
     }
   );
@@ -52,7 +49,7 @@ describe('PipelineList', () => {
     const { active, ids } = wrapper.find('PipelineList').props().pipeline;
     const hasClass = wrapper
       .find('MenuOption')
-      .at(ids.findIndex(id => id !== active))
+      .at(ids.findIndex((id) => id !== active))
       .hasClass('pipeline-list__option--active');
     expect(hasClass).toBe(false);
   });
@@ -64,9 +61,9 @@ describe('PipelineList', () => {
         active: expect.any(String),
         main: expect.any(String),
         name: expect.any(Object),
-        ids: expect.any(Array)
+        ids: expect.any(Array),
       },
-      theme: mockState.animals.theme
+      theme: mockState.animals.theme,
     });
   });
 

--- a/src/components/primary-toolbar/index.js
+++ b/src/components/primary-toolbar/index.js
@@ -6,7 +6,7 @@ import {
   toggleLayers,
   toggleSidebar,
   toggleTextLabels,
-  toggleTheme
+  toggleTheme,
 } from '../../actions';
 import IconButton from '../icon-button';
 import MenuIcon from '../icons/menu';
@@ -34,7 +34,7 @@ export const PrimaryToolbar = ({
   textLabels,
   theme,
   visible,
-  visibleLayers
+  visibleLayers,
 }) => (
   <>
     <ul className="pipeline-primary-toolbar kedro">
@@ -44,7 +44,7 @@ export const PrimaryToolbar = ({
           'pipeline-menu-button',
           'pipeline-menu-button--menu',
           {
-            'pipeline-menu-button--inverse': !visible.sidebar
+            'pipeline-menu-button--inverse': !visible.sidebar,
           }
         )}
         onClick={() => onToggleSidebar(!visible.sidebar)}
@@ -89,33 +89,30 @@ export const PrimaryToolbar = ({
   </>
 );
 
-export const mapStateToProps = state => ({
+export const mapStateToProps = (state) => ({
   disableLayerBtn: !state.layer.ids.length,
   textLabels: state.textLabels,
   theme: state.theme,
   visible: state.visible,
-  visibleLayers: Boolean(getVisibleLayerIDs(state).length)
+  visibleLayers: Boolean(getVisibleLayerIDs(state).length),
 });
 
-export const mapDispatchToProps = dispatch => ({
-  onToggleExportModal: value => {
+export const mapDispatchToProps = (dispatch) => ({
+  onToggleExportModal: (value) => {
     dispatch(toggleExportModal(value));
   },
-  onToggleLayers: value => {
+  onToggleLayers: (value) => {
     dispatch(toggleLayers(Boolean(value)));
   },
-  onToggleSidebar: visible => {
+  onToggleSidebar: (visible) => {
     dispatch(toggleSidebar(visible));
   },
-  onToggleTextLabels: value => {
+  onToggleTextLabels: (value) => {
     dispatch(toggleTextLabels(Boolean(value)));
   },
-  onToggleTheme: value => {
+  onToggleTheme: (value) => {
     dispatch(toggleTheme(value));
-  }
+  },
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(PrimaryToolbar);
+export default connect(mapStateToProps, mapDispatchToProps)(PrimaryToolbar);

--- a/src/components/primary-toolbar/primary-toolbar.test.js
+++ b/src/components/primary-toolbar/primary-toolbar.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ConnectedPrimaryToolbar, {
   PrimaryToolbar,
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 } from './index';
 import { mockState, setup } from '../../utils/state.mock';
 
@@ -17,7 +17,7 @@ describe('PrimaryToolbar', () => {
       themeBtn: false,
       labelBtn: false,
       layerBtn: false,
-      exportBtn: false
+      exportBtn: false,
     };
     const wrapper = setup.mount(<ConnectedPrimaryToolbar />, { visible });
     expect(wrapper.find('.pipeline-icon-toolbar__button').length).toBe(1);
@@ -25,7 +25,7 @@ describe('PrimaryToolbar', () => {
 
   it('hides one button when visible prop is false for one of them', () => {
     const visible = {
-      labelBtn: false
+      labelBtn: false,
     };
     const wrapper = setup.mount(<ConnectedPrimaryToolbar />, { visible });
     expect(wrapper.find('.pipeline-icon-toolbar__button').length).toBe(4);
@@ -36,7 +36,7 @@ describe('PrimaryToolbar', () => {
     ['.pipeline-menu-button--theme', 'onToggleTheme'],
     ['.pipeline-menu-button--labels', 'onToggleTextLabels'],
     ['.pipeline-menu-button--export', 'onToggleExportModal'],
-    ['.pipeline-menu-button--layers', 'onToggleLayers']
+    ['.pipeline-menu-button--layers', 'onToggleLayers'],
   ];
 
   test.each(functionCalls)(
@@ -47,14 +47,11 @@ describe('PrimaryToolbar', () => {
         textLabels: mockState.animals.textLabels,
         theme: mockState.animals.theme,
         visible: mockState.animals.visible,
-        [callback]: mockFn
+        [callback]: mockFn,
       };
       const wrapper = setup.mount(<PrimaryToolbar {...props} />);
       expect(mockFn.mock.calls.length).toBe(0);
-      wrapper
-        .find(selector)
-        .find('button')
-        .simulate('click');
+      wrapper.find(selector).find('button').simulate('click');
       expect(mockFn.mock.calls.length).toBe(1);
     }
   );
@@ -70,9 +67,9 @@ describe('PrimaryToolbar', () => {
         labelBtn: expect.any(Boolean),
         layerBtn: expect.any(Boolean),
         themeBtn: expect.any(Boolean),
-        sidebar: expect.any(Boolean)
+        sidebar: expect.any(Boolean),
       }),
-      visibleLayers: expect.any(Boolean)
+      visibleLayers: expect.any(Boolean),
     };
     expect(mapStateToProps(mockState.animals)).toEqual(expectedResult);
   });
@@ -83,7 +80,7 @@ describe('PrimaryToolbar', () => {
       mapDispatchToProps(dispatch).onToggleExportModal(true);
       expect(dispatch.mock.calls[0][0]).toEqual({
         visible: true,
-        type: 'TOGGLE_EXPORT_MODAL'
+        type: 'TOGGLE_EXPORT_MODAL',
       });
     });
 
@@ -92,7 +89,7 @@ describe('PrimaryToolbar', () => {
       mapDispatchToProps(dispatch).onToggleLayers(true);
       expect(dispatch.mock.calls[0][0]).toEqual({
         visible: true,
-        type: 'TOGGLE_LAYERS'
+        type: 'TOGGLE_LAYERS',
       });
     });
 
@@ -101,7 +98,7 @@ describe('PrimaryToolbar', () => {
       mapDispatchToProps(dispatch).onToggleSidebar(true);
       expect(dispatch.mock.calls[0][0]).toEqual({
         visible: true,
-        type: 'TOGGLE_SIDEBAR'
+        type: 'TOGGLE_SIDEBAR',
       });
     });
 
@@ -110,7 +107,7 @@ describe('PrimaryToolbar', () => {
       mapDispatchToProps(dispatch).onToggleTextLabels(true);
       expect(dispatch.mock.calls[0][0]).toEqual({
         textLabels: true,
-        type: 'TOGGLE_TEXT_LABELS'
+        type: 'TOGGLE_TEXT_LABELS',
       });
     });
 
@@ -119,7 +116,7 @@ describe('PrimaryToolbar', () => {
       mapDispatchToProps(dispatch).onToggleTheme('light');
       expect(dispatch.mock.calls[0][0]).toEqual({
         theme: 'light',
-        type: 'TOGGLE_THEME'
+        type: 'TOGGLE_THEME',
       });
     });
   });

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -19,7 +19,7 @@ export const Sidebar = ({ visible }) => {
     <>
       <div
         className={classnames('pipeline-sidebar', {
-          'pipeline-sidebar--visible': visible
+          'pipeline-sidebar--visible': visible,
         })}>
         <div className="pipeline-ui">
           <PipelineList onToggleOpen={togglePipeline} />
@@ -35,8 +35,8 @@ export const Sidebar = ({ visible }) => {
   );
 };
 
-const mapStateToProps = state => ({
-  visible: state.visible.sidebar
+const mapStateToProps = (state) => ({
+  visible: state.visible.sidebar,
 });
 
 export default connect(mapStateToProps)(Sidebar);

--- a/src/components/sidebar/sidebar.test.js
+++ b/src/components/sidebar/sidebar.test.js
@@ -6,7 +6,7 @@ const mockProps = {
   flags: { pipelines: true },
   theme: mockState.animals.theme,
   onToggle: () => {},
-  visible: true
+  visible: true,
 };
 
 describe('Sidebar', () => {
@@ -23,7 +23,7 @@ describe('Sidebar', () => {
 
   it('hides when clicking the hide menu button', () => {
     const wrapper = setup.mount(<MountSidebar />, {
-      visible: { sidebar: true }
+      visible: { sidebar: true },
     });
     wrapper.find('button[aria-label="Hide menu"]').simulate('click');
     const sidebar = wrapper.find('.pipeline-sidebar');
@@ -32,7 +32,7 @@ describe('Sidebar', () => {
 
   it('shows when clicking the show menu button', () => {
     const wrapper = setup.mount(<MountSidebar />, {
-      visible: { sidebar: false }
+      visible: { sidebar: false },
     });
     wrapper.find('button[aria-label="Show menu"]').simulate('click');
     const sidebar = wrapper.find('.pipeline-sidebar');

--- a/src/components/tooltip/index.js
+++ b/src/components/tooltip/index.js
@@ -9,7 +9,7 @@ const zeroWidthSpace = String.fromCharCode(0x200b);
  * @param {string} text Any text with special characters
  * @return {string} text
  */
-export const insertZeroWidthSpace = text =>
+export const insertZeroWidthSpace = (text) =>
   text.replace(/([^\w\s]|[_])/g, `${zeroWidthSpace}$1${zeroWidthSpace}`);
 
 /**
@@ -33,7 +33,7 @@ const Tooltip = ({ chartSize, targetRect, visible, text }) => {
       className={classnames('pipeline-tooltip', {
         'pipeline-tooltip--visible': visible,
         'pipeline-tooltip--right': isRight,
-        'pipeline-tooltip--top': isTop
+        'pipeline-tooltip--top': isTop,
       })}
       style={{ transform: `translate(${x}px, ${y}px)` }}>
       <div className="pipeline-tooltip__text">{insertZeroWidthSpace(text)}</div>
@@ -45,7 +45,7 @@ Tooltip.defaultProps = {
   chartSize: {},
   targetRect: {},
   visible: false,
-  text: ''
+  text: '',
 };
 
 export default Tooltip;

--- a/src/components/tooltip/tooltip.test.js
+++ b/src/components/tooltip/tooltip.test.js
@@ -10,7 +10,7 @@ const mockProps = {
     outerWidth: 1198,
     sidebarWidth: sidebarWidth.open,
     top: 0,
-    width: 898
+    width: 898,
   },
   targetRect: {
     bottom: 341.05895,
@@ -20,10 +20,10 @@ const mockProps = {
     top: 338.95785,
     width: 9.83453,
     x: 856.19622,
-    y: 338.95785
+    y: 338.95785,
   },
   text: 'lorem_ipsum-dolor: sit [amet]',
-  visible: true
+  visible: true,
 };
 
 describe('Tooltip', () => {
@@ -36,7 +36,7 @@ describe('Tooltip', () => {
   it('should not add the top class when the tooltip is towards the bottom', () => {
     const targetRect = {
       ...mockProps.targetRect,
-      top: mockProps.chartSize.height - 10
+      top: mockProps.chartSize.height - 10,
     };
     const wrapper = setup.shallow(Tooltip, { ...mockProps, targetRect });
     const container = wrapper.find('.pipeline-tooltip--top');
@@ -46,7 +46,7 @@ describe('Tooltip', () => {
   it('should not add the right class when the tooltip is towards the left', () => {
     const targetRect = {
       ...mockProps.targetRect,
-      left: 10
+      left: 10,
     };
     const wrapper = setup.shallow(Tooltip, { ...mockProps, targetRect });
     const container = wrapper.find('.pipeline-tooltip--right');
@@ -56,7 +56,7 @@ describe('Tooltip', () => {
   it("should add the 'top' class when the tooltip is towards the top", () => {
     const targetRect = {
       ...mockProps.targetRect,
-      top: 10
+      top: 10,
     };
     const wrapper = setup.shallow(Tooltip, { ...mockProps, targetRect });
     const container = wrapper.find('.pipeline-tooltip--top');
@@ -66,7 +66,7 @@ describe('Tooltip', () => {
   it("should add the 'right' class when the tooltip is towards the right", () => {
     const targetRect = {
       ...mockProps.targetRect,
-      left: mockProps.chartSize.width - 10
+      left: mockProps.chartSize.width - 10,
     };
     const wrapper = setup.shallow(Tooltip, { ...mockProps, targetRect });
     const container = wrapper.find('.pipeline-tooltip--right');
@@ -77,9 +77,9 @@ describe('Tooltip', () => {
 describe('insertZeroWidthSpace', () => {
   describe('special characters', () => {
     const z = String.fromCharCode(0x200b);
-    const wrap = text => z + text + z;
+    const wrap = (text) => z + text + z;
     const characters = '-_[]/:\\!@£$%^&*()'.split('');
-    test.each(characters)('wraps %s with a zero-width space', d => {
+    test.each(characters)('wraps %s with a zero-width space', (d) => {
       expect(insertZeroWidthSpace(d)).toBe(wrap(d));
       expect(insertZeroWidthSpace(d).length).toBe(3);
     });
@@ -87,7 +87,7 @@ describe('insertZeroWidthSpace', () => {
 
   describe('alphanumeric characters', () => {
     const characters = ['a', 'B', '123', 'aBc123', '0', ''];
-    test.each(characters)('does not wrap %s with a zero-width space', d => {
+    test.each(characters)('does not wrap %s with a zero-width space', (d) => {
       expect(insertZeroWidthSpace(d)).toBe(d);
       expect(insertZeroWidthSpace(d).length).toBe(d.length);
     });
@@ -95,7 +95,7 @@ describe('insertZeroWidthSpace', () => {
 
   describe('spaces', () => {
     const characters = [' ', '\t', '\n', 'a b', ' a '];
-    test.each(characters)('does not wrap %s with a zero-width space', d => {
+    test.each(characters)('does not wrap %s with a zero-width space', (d) => {
       expect(insertZeroWidthSpace(d)).toBe(d);
       expect(insertZeroWidthSpace(d).length).toBe(d.length);
     });

--- a/src/components/wrapper/index.js
+++ b/src/components/wrapper/index.js
@@ -16,7 +16,7 @@ export const Wrapper = ({ loading, theme }) => (
   <div
     className={classnames('kedro-pipeline', {
       'kui-theme--dark': theme === 'dark',
-      'kui-theme--light': theme === 'light'
+      'kui-theme--light': theme === 'light',
     })}>
     <h1 className="pipeline-title">Kedro-Viz</h1>
     <Sidebar />
@@ -29,9 +29,9 @@ export const Wrapper = ({ loading, theme }) => (
   </div>
 );
 
-export const mapStateToProps = state => ({
+export const mapStateToProps = (state) => ({
   loading: isLoading(state),
-  theme: state.theme
+  theme: state.theme,
 });
 
 export default connect(mapStateToProps)(Wrapper);

--- a/src/components/wrapper/wrapper.test.js
+++ b/src/components/wrapper/wrapper.test.js
@@ -3,7 +3,7 @@ import { mockState, setup } from '../../utils/state.mock';
 
 const { theme } = mockState.animals;
 const mockProps = {
-  theme
+  theme,
 };
 
 describe('Wrapper', () => {
@@ -23,7 +23,7 @@ describe('Wrapper', () => {
   it('maps state to props', () => {
     expect(mapStateToProps(mockState.animals)).toEqual({
       loading: false,
-      theme
+      theme,
     });
   });
 });

--- a/src/config.js
+++ b/src/config.js
@@ -7,11 +7,11 @@ export const localStorageName = 'KedroViz';
 // value here, please also update their corresponding value in src/styles/_variables.scss
 export const metaSidebarWidth = {
   open: 400,
-  closed: 0
+  closed: 0,
 };
 export const sidebarWidth = {
   open: 400,
-  closed: 56
+  closed: 56,
 };
 
 export const chartMinWidthScale = 0.25;
@@ -22,22 +22,22 @@ export const flags = {
     description: 'Use older Dagre graphing algorithm',
     default: false,
     private: false,
-    icon: '📈'
+    icon: '📈',
   },
   lazy: {
     description: 'Improved sidebar performance',
     default: false,
-    icon: '😴'
-  }
+    icon: '😴',
+  },
 };
 
 export const sidebar = {
   Categories: {
-    Tags: 'tag'
+    Tags: 'tag',
   },
   Elements: {
     Nodes: 'task',
     Datasets: 'data',
-    Parameters: 'parameters'
-  }
+    Parameters: 'parameters',
+  },
 };

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -10,12 +10,12 @@ describe('config', () => {
   describe('flags', () => {
     test.each(Object.keys(flags))(
       'flags.%s should be an object with description, default and icon keys',
-      key => {
+      (key) => {
         expect(flags[key]).toEqual(
           expect.objectContaining({
             description: expect.any(String),
             default: expect.any(Boolean),
-            icon: expect.any(String)
+            icon: expect.any(String),
           })
         );
       }

--- a/src/reducers/flags.js
+++ b/src/reducers/flags.js
@@ -4,7 +4,7 @@ function flagsReducer(flagsState = {}, action) {
   switch (action.type) {
     case CHANGE_FLAG: {
       return Object.assign({}, flagsState, {
-        [action.name]: action.value
+        [action.name]: action.value,
       });
     }
 

--- a/src/reducers/graph.js
+++ b/src/reducers/graph.js
@@ -1,7 +1,7 @@
 import { UPDATE_GRAPH_LAYOUT } from '../actions/graph';
 
 function nodeReducer(graphState = {}, action) {
-  const updateState = newState => Object.assign({}, graphState, newState);
+  const updateState = (newState) => Object.assign({}, graphState, newState);
 
   switch (action.type) {
     case UPDATE_GRAPH_LAYOUT: {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -14,7 +14,7 @@ import {
   TOGGLE_THEME,
   UPDATE_CHART_SIZE,
   UPDATE_ZOOM,
-  UPDATE_FONT_LOADED
+  UPDATE_FONT_LOADED,
 } from '../actions';
 
 /**
@@ -67,7 +67,7 @@ const combinedReducer = combineReducers({
   zoom: createReducer({}, UPDATE_ZOOM, 'zoom'),
   fontLoaded: createReducer(false, UPDATE_FONT_LOADED, 'fontLoaded'),
   textLabels: createReducer(true, TOGGLE_TEXT_LABELS, 'textLabels'),
-  theme: createReducer('dark', TOGGLE_THEME, 'theme')
+  theme: createReducer('dark', TOGGLE_THEME, 'theme'),
 });
 
 const rootReducer = (state, action) =>

--- a/src/reducers/layers.js
+++ b/src/reducers/layers.js
@@ -4,7 +4,7 @@ function layerReducer(layerState = {}, action) {
   switch (action.type) {
     case TOGGLE_LAYERS: {
       return Object.assign({}, layerState, {
-        visible: action.visible
+        visible: action.visible,
       });
     }
 

--- a/src/reducers/loading.js
+++ b/src/reducers/loading.js
@@ -6,19 +6,19 @@ function loadingReducer(loadingState = {}, action) {
   switch (action.type) {
     case TOGGLE_PIPELINE_LOADING: {
       return Object.assign({}, loadingState, {
-        pipeline: action.loading
+        pipeline: action.loading,
       });
     }
 
     case TOGGLE_GRAPH_LOADING: {
       return Object.assign({}, loadingState, {
-        graph: action.loading
+        graph: action.loading,
       });
     }
 
     case TOGGLE_NODE_DATA_LOADING: {
       return Object.assign({}, loadingState, {
-        node: action.loading
+        node: action.loading,
       });
     }
 

--- a/src/reducers/node-type.js
+++ b/src/reducers/node-type.js
@@ -5,8 +5,8 @@ function nodeTypeReducer(nodeTypeState = {}, action) {
     case TOGGLE_TYPE_DISABLED: {
       return Object.assign({}, nodeTypeState, {
         disabled: Object.assign({}, nodeTypeState.disabled, {
-          [action.typeID]: action.disabled
-        })
+          [action.typeID]: action.disabled,
+        }),
       });
     }
     default:

--- a/src/reducers/nodes.js
+++ b/src/reducers/nodes.js
@@ -2,17 +2,17 @@ import {
   TOGGLE_NODE_CLICKED,
   TOGGLE_NODES_DISABLED,
   TOGGLE_NODE_HOVERED,
-  ADD_NODE_METADATA
+  ADD_NODE_METADATA,
 } from '../actions/nodes';
 import { UPDATE_ACTIVE_PIPELINE } from '../actions/pipelines';
 
 function nodeReducer(nodeState = {}, action) {
-  const updateState = newState => Object.assign({}, nodeState, newState);
+  const updateState = (newState) => Object.assign({}, nodeState, newState);
 
   switch (action.type) {
     case TOGGLE_NODE_CLICKED: {
       return updateState({
-        clicked: action.nodeClicked
+        clicked: action.nodeClicked,
       });
     }
 
@@ -24,23 +24,23 @@ function nodeReducer(nodeState = {}, action) {
         disabled: action.nodeIDs.reduce(
           (disabled, id) =>
             Object.assign({}, disabled, {
-              [id]: action.isDisabled
+              [id]: action.isDisabled,
             }),
           nodeState.disabled
-        )
+        ),
       });
     }
 
     case TOGGLE_NODE_HOVERED: {
       return updateState({
-        hovered: action.nodeHovered
+        hovered: action.nodeHovered,
       });
     }
 
     case UPDATE_ACTIVE_PIPELINE: {
       return updateState({
         clicked: null,
-        hovered: null
+        hovered: null,
       });
     }
 
@@ -48,24 +48,24 @@ function nodeReducer(nodeState = {}, action) {
       const { id, data } = action.data;
       return updateState({
         fetched: Object.assign({}, nodeState.fetched, {
-          [id]: true
+          [id]: true,
         }),
         code: Object.assign({}, nodeState.code, {
-          [id]: data.code
+          [id]: data.code,
         }),
         filepath: Object.assign({}, nodeState.filepath, {
-          [id]: data.filepath
+          [id]: data.filepath,
         }),
         docstring: Object.assign({}, nodeState.docstring, {
-          [id]: data.docstring
+          [id]: data.docstring,
         }),
         parameters: Object.assign({}, nodeState.parameters, {
-          [id]: data.parameters
+          [id]: data.parameters,
         }),
         // the data returned from the API under the field name 'type' for dataset type nodes
         datasetType: Object.assign({}, nodeState.datasetType, {
-          [id]: data.type
-        })
+          [id]: data.type,
+        }),
       });
     }
 

--- a/src/reducers/pipeline.js
+++ b/src/reducers/pipeline.js
@@ -4,7 +4,7 @@ function pipelineReducer(pipelineState = {}, action) {
   switch (action.type) {
     case UPDATE_ACTIVE_PIPELINE: {
       return Object.assign({}, pipelineState, {
-        active: action.pipeline
+        active: action.pipeline,
       });
     }
 

--- a/src/reducers/reducers.test.js
+++ b/src/reducers/reducers.test.js
@@ -13,13 +13,13 @@ import {
   TOGGLE_TEXT_LABELS,
   TOGGLE_THEME,
   UPDATE_CHART_SIZE,
-  UPDATE_FONT_LOADED
+  UPDATE_FONT_LOADED,
 } from '../actions';
 import {
   TOGGLE_NODE_CLICKED,
   TOGGLE_NODES_DISABLED,
   TOGGLE_NODE_HOVERED,
-  ADD_NODE_METADATA
+  ADD_NODE_METADATA,
 } from '../actions/nodes';
 import { TOGGLE_TAG_ACTIVE, TOGGLE_TAG_FILTER } from '../actions/tags';
 import { TOGGLE_TYPE_DISABLED } from '../actions/node-type';
@@ -35,21 +35,21 @@ describe('Reducer', () => {
       expect(
         reducer(mockState.animals, {
           type: RESET_DATA,
-          data: normalizeData(animals)
+          data: normalizeData(animals),
         })
       ).toEqual(mockState.animals);
     });
 
     it('should reset the state with new data', () => {
       // Exclude graph prop
-      const removeGraph = state => {
+      const removeGraph = (state) => {
         const stateCopy = Object.assign({}, state);
         delete stateCopy.graph;
         return stateCopy;
       };
       const newState = reducer(mockState.demo, {
         type: RESET_DATA,
-        data: normalizeData(animals)
+        data: normalizeData(animals),
       });
       expect(removeGraph(newState)).toEqual(removeGraph(mockState.animals));
     });
@@ -60,7 +60,7 @@ describe('Reducer', () => {
       const nodeClicked = 'abc123';
       const newState = reducer(mockState.animals, {
         type: TOGGLE_NODE_CLICKED,
-        nodeClicked
+        nodeClicked,
       });
       expect(newState.node.clicked).toEqual(nodeClicked);
     });
@@ -71,7 +71,7 @@ describe('Reducer', () => {
       const nodeHovered = 'abc123';
       const newState = reducer(mockState.animals, {
         type: TOGGLE_NODE_HOVERED,
-        nodeHovered
+        nodeHovered,
       });
       expect(newState.node.hovered).toEqual(nodeHovered);
     });
@@ -82,23 +82,23 @@ describe('Reducer', () => {
       const newState = reducer(mockState.animals, {
         type: TOGGLE_NODES_DISABLED,
         nodeIDs: ['123', 'abc'],
-        isDisabled: true
+        isDisabled: true,
       });
-      expect(newState.node.disabled).toEqual({ '123': true, abc: true });
+      expect(newState.node.disabled).toEqual({ 123: true, abc: true });
     });
 
     it('should set nodeClicked to null if the selected node is being disabled', () => {
       const nodeID = 'abc123';
       const clickNodeAction = {
         type: TOGGLE_NODE_CLICKED,
-        nodeClicked: nodeID
+        nodeClicked: nodeID,
       };
       const clickedState = reducer(mockState.animals, clickNodeAction);
       expect(clickedState.node.clicked).toEqual(nodeID);
       const disableNodeAction = {
         type: TOGGLE_NODES_DISABLED,
         nodeIDs: [nodeID],
-        isDisabled: true
+        isDisabled: true,
       };
       const disabledState = reducer(clickedState, disableNodeAction);
       expect(disabledState.node.clicked).toEqual(null);
@@ -109,7 +109,7 @@ describe('Reducer', () => {
     it('should toggle the value of textLabels', () => {
       const newState = reducer(mockState.animals, {
         type: TOGGLE_TEXT_LABELS,
-        textLabels: true
+        textLabels: true,
       });
       expect(mockState.animals.textLabels).toBe(true);
       expect(newState.textLabels).toBe(true);
@@ -121,7 +121,7 @@ describe('Reducer', () => {
       const newState = reducer(mockState.animals, {
         type: TOGGLE_TAG_ACTIVE,
         tagIDs: ['huge'],
-        active: true
+        active: true,
       });
       expect(newState.tag.active).toEqual({ huge: true });
     });
@@ -132,7 +132,7 @@ describe('Reducer', () => {
       const newState = reducer(mockState.animals, {
         type: TOGGLE_TAG_FILTER,
         tagIDs: ['small'],
-        enabled: true
+        enabled: true,
       });
       expect(newState.tag.enabled).toEqual({ small: true });
     });
@@ -142,7 +142,7 @@ describe('Reducer', () => {
     it('should toggle the theme to light', () => {
       const newState = reducer(mockState.animals, {
         type: TOGGLE_THEME,
-        theme: 'light'
+        theme: 'light',
       });
       expect(newState.theme).toBe('light');
     });
@@ -153,7 +153,7 @@ describe('Reducer', () => {
       const newState = reducer(mockState.animals, {
         type: TOGGLE_TYPE_DISABLED,
         typeID: '123',
-        disabled: true
+        disabled: true,
       });
       expect(newState.nodeType.disabled).toEqual({ 123: true });
     });
@@ -163,7 +163,7 @@ describe('Reducer', () => {
     it('should toggle whether layers are shown', () => {
       const newState = reducer(mockState.animals, {
         type: TOGGLE_LAYERS,
-        visible: false
+        visible: false,
       });
       expect(newState.layer.visible).toEqual(false);
     });
@@ -173,7 +173,7 @@ describe('Reducer', () => {
     it('should toggle whether the sidebar is open', () => {
       const newState = reducer(mockState.animals, {
         type: TOGGLE_SIDEBAR,
-        visible: false
+        visible: false,
       });
       expect(newState.visible.sidebar).toEqual(false);
     });
@@ -241,7 +241,7 @@ describe('Reducer', () => {
     it("should update the chart's dimensions", () => {
       const newState = reducer(mockState.animals, {
         type: UPDATE_CHART_SIZE,
-        chartSize: document.body.getBoundingClientRect()
+        chartSize: document.body.getBoundingClientRect(),
       });
       expect(newState.chartSize).toEqual({
         bottom: expect.any(Number),
@@ -249,7 +249,7 @@ describe('Reducer', () => {
         left: expect.any(Number),
         right: expect.any(Number),
         top: expect.any(Number),
-        width: expect.any(Number)
+        width: expect.any(Number),
       });
     });
   });
@@ -258,7 +258,7 @@ describe('Reducer', () => {
     it('should update the state when the webfont is loaded', () => {
       const newState = reducer(mockState.animals, {
         type: UPDATE_FONT_LOADED,
-        fontLoaded: true
+        fontLoaded: true,
       });
       expect(newState.fontLoaded).toBe(true);
     });
@@ -269,7 +269,7 @@ describe('Reducer', () => {
       const newState = reducer(mockState.animals, {
         type: CHANGE_FLAG,
         name: 'testFlag',
-        value: true
+        value: true,
       });
       expect(newState.flags.testFlag).toBe(true);
     });

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -1,13 +1,13 @@
 import { TOGGLE_TAG_ACTIVE, TOGGLE_TAG_FILTER } from '../actions/tags';
 
 function tagReducer(tagState = {}, action) {
-  const updateState = newState => Object.assign({}, tagState, newState);
+  const updateState = (newState) => Object.assign({}, tagState, newState);
 
   /**
    * Batch update tags from an array of tag IDs
    * @param {string} key Tag action value prop
    */
-  const batchChanges = key =>
+  const batchChanges = (key) =>
     action.tagIDs.reduce((result, tagID) => {
       result[tagID] = action[key];
       return result;
@@ -16,13 +16,13 @@ function tagReducer(tagState = {}, action) {
   switch (action.type) {
     case TOGGLE_TAG_ACTIVE: {
       return updateState({
-        active: Object.assign({}, tagState.active, batchChanges('active'))
+        active: Object.assign({}, tagState.active, batchChanges('active')),
       });
     }
 
     case TOGGLE_TAG_FILTER: {
       return updateState({
-        enabled: Object.assign({}, tagState.enabled, batchChanges('enabled'))
+        enabled: Object.assign({}, tagState.enabled, batchChanges('enabled')),
       });
     }
 

--- a/src/reducers/visible.js
+++ b/src/reducers/visible.js
@@ -3,38 +3,38 @@ import {
   TOGGLE_EXPORT_MODAL,
   TOGGLE_LAYERS,
   TOGGLE_SIDEBAR,
-  TOGGLE_MINIMAP
+  TOGGLE_MINIMAP,
 } from '../actions';
 
 function visibleReducer(visibleState = {}, action) {
   switch (action.type) {
     case TOGGLE_GRAPH: {
       return Object.assign({}, visibleState, {
-        graph: action.visible
+        graph: action.visible,
       });
     }
 
     case TOGGLE_EXPORT_MODAL: {
       return Object.assign({}, visibleState, {
-        exportModal: action.visible
+        exportModal: action.visible,
       });
     }
 
     case TOGGLE_LAYERS: {
       return Object.assign({}, visibleState, {
-        layers: action.visible
+        layers: action.visible,
       });
     }
 
     case TOGGLE_SIDEBAR: {
       return Object.assign({}, visibleState, {
-        sidebar: action.visible
+        sidebar: action.visible,
       });
     }
 
     case TOGGLE_MINIMAP: {
       return Object.assign({}, visibleState, {
-        miniMap: action.visible
+        miniMap: action.visible,
       });
     }
 

--- a/src/selectors/disabled.js
+++ b/src/selectors/disabled.js
@@ -3,18 +3,18 @@ import { arrayToObject } from '../utils';
 import { getNodeDisabledPipeline, getPipelineNodeIDs } from './pipeline';
 import { getTagCount } from './tags';
 
-const getNodeIDs = state => state.node.ids;
-const getNodeDisabledNode = state => state.node.disabled;
-const getNodeTags = state => state.node.tags;
-const getNodeType = state => state.node.type;
-const getTagEnabled = state => state.tag.enabled;
-const getNodeTypeDisabled = state => state.nodeType.disabled;
-const getEdgeIDs = state => state.edge.ids;
-const getEdgeSources = state => state.edge.sources;
-const getEdgeTargets = state => state.edge.targets;
-const getLayerIDs = state => state.layer.ids;
-const getLayersVisible = state => state.layer.visible;
-const getNodeLayer = state => state.node.layer;
+const getNodeIDs = (state) => state.node.ids;
+const getNodeDisabledNode = (state) => state.node.disabled;
+const getNodeTags = (state) => state.node.tags;
+const getNodeType = (state) => state.node.type;
+const getTagEnabled = (state) => state.tag.enabled;
+const getNodeTypeDisabled = (state) => state.nodeType.disabled;
+const getEdgeIDs = (state) => state.edge.ids;
+const getEdgeSources = (state) => state.edge.sources;
+const getEdgeTargets = (state) => state.edge.targets;
+const getLayerIDs = (state) => state.layer.ids;
+const getLayersVisible = (state) => state.layer.visible;
+const getNodeLayer = (state) => state.node.layer;
 
 /**
  * Calculate whether nodes should be disabled based on their tags
@@ -22,13 +22,13 @@ const getNodeLayer = state => state.node.layer;
 export const getNodeDisabledTag = createSelector(
   [getNodeIDs, getTagEnabled, getTagCount, getNodeTags],
   (nodeIDs, tagEnabled, tagCount, nodeTags) =>
-    arrayToObject(nodeIDs, nodeID => {
+    arrayToObject(nodeIDs, (nodeID) => {
       if (tagCount.enabled === 0) {
         return false;
       }
       if (nodeTags[nodeID].length) {
         // Hide task nodes that don't have at least one tag filter enabled
-        return !nodeTags[nodeID].some(tag => tagEnabled[tag]);
+        return !nodeTags[nodeID].some((tag) => tagEnabled[tag]);
       }
       return true;
     })
@@ -44,7 +44,7 @@ export const getNodeDisabled = createSelector(
     getNodeDisabledTag,
     getNodeDisabledPipeline,
     getNodeType,
-    getNodeTypeDisabled
+    getNodeTypeDisabled,
   ],
   (
     nodeIDs,
@@ -54,12 +54,12 @@ export const getNodeDisabled = createSelector(
     nodeType,
     typeDisabled
   ) =>
-    arrayToObject(nodeIDs, id =>
+    arrayToObject(nodeIDs, (id) =>
       [
         nodeDisabledNode[id],
         nodeDisabledTag[id],
         nodeDisabledPipeline[id],
-        typeDisabled[nodeType[id]]
+        typeDisabled[nodeType[id]],
       ].some(Boolean)
     )
 );
@@ -69,7 +69,7 @@ export const getNodeDisabled = createSelector(
  */
 export const getVisibleNodeIDs = createSelector(
   [getPipelineNodeIDs, getNodeDisabled],
-  (nodeIDs, nodeDisabled) => nodeIDs.filter(id => !nodeDisabled[id])
+  (nodeIDs, nodeDisabled) => nodeIDs.filter((id) => !nodeDisabled[id])
 );
 
 /**
@@ -85,7 +85,7 @@ export const getVisibleLayerIDs = createSelector(
     for (const nodeID of nodeIDs) {
       visibleLayerIDs[nodeLayer[nodeID]] = true;
     }
-    return layerIDs.filter(layerID => visibleLayerIDs[layerID]);
+    return layerIDs.filter((layerID) => visibleLayerIDs[layerID]);
   }
 );
 
@@ -95,7 +95,7 @@ export const getVisibleLayerIDs = createSelector(
 export const getEdgeDisabled = createSelector(
   [getEdgeIDs, getNodeDisabled, getEdgeSources, getEdgeTargets],
   (edgeIDs, nodeDisabled, edgeSources, edgeTargets) =>
-    arrayToObject(edgeIDs, edgeID => {
+    arrayToObject(edgeIDs, (edgeID) => {
       const source = edgeSources[edgeID];
       const target = edgeTargets[edgeID];
       return Boolean(nodeDisabled[source] || nodeDisabled[target]);

--- a/src/selectors/disabled.test.js
+++ b/src/selectors/disabled.test.js
@@ -4,18 +4,18 @@ import {
   getNodeDisabled,
   getEdgeDisabled,
   getVisibleNodeIDs,
-  getVisibleLayerIDs
+  getVisibleLayerIDs,
 } from './disabled';
 import { toggleNodesDisabled } from '../actions/nodes';
 import { toggleLayers } from '../actions';
 import { toggleTagFilter } from '../actions/tags';
 import reducer from '../reducers';
 
-const getNodeIDs = state => state.node.ids;
-const getEdgeIDs = state => state.edge.ids;
-const getEdgeSources = state => state.edge.sources;
-const getEdgeTargets = state => state.edge.targets;
-const getNodeTags = state => state.node.tags;
+const getNodeIDs = (state) => state.node.ids;
+const getEdgeIDs = (state) => state.edge.ids;
+const getEdgeSources = (state) => state.edge.sources;
+const getEdgeTargets = (state) => state.edge.targets;
+const getNodeTags = (state) => state.node.tags;
 
 describe('Selectors', () => {
   describe('getNodeDisabledTag', () => {
@@ -28,7 +28,7 @@ describe('Selectors', () => {
     it('returns an object whose values are all Booleans', () => {
       expect(
         Object.values(getNodeDisabledTag(mockState.animals)).every(
-          value => typeof value === 'boolean'
+          (value) => typeof value === 'boolean'
         )
       ).toBe(true);
     });
@@ -44,7 +44,7 @@ describe('Selectors', () => {
       const tag = mockState.animals.tag.ids[0];
       const nodeTags = getNodeTags(mockState.animals);
       // Choose a node that has no tags (and which should be disabled)
-      const hasNoTags = id => !Boolean(nodeTags[id].length);
+      const hasNoTags = (id) => !Boolean(nodeTags[id].length);
       const disabledNodeID = getNodeIDs(mockState.animals).find(hasNoTags);
       // Update the state to enable one of the tags for that node
       const newMockState = reducer(
@@ -58,7 +58,7 @@ describe('Selectors', () => {
       const nodeTags = getNodeTags(mockState.animals);
       // Choose a node that has > 1 tag
       const enabledNodeID = getNodeIDs(mockState.animals).find(
-        id => nodeTags[id].length > 1
+        (id) => nodeTags[id].length > 1
       );
       // Update the state to enable one of the tags for that node
       const enabledNodeTags = nodeTags[enabledNodeID];
@@ -73,7 +73,7 @@ describe('Selectors', () => {
       const nodeTags = getNodeTags(mockState.animals);
       // Choose a node that has > 1 tag
       const enabledNodeID = getNodeIDs(mockState.animals).find(
-        id => nodeTags[id].length > 1
+        (id) => nodeTags[id].length > 1
       );
       // Update the state to activate all of the tag filters for that node
       const enabledNodeTags = nodeTags[enabledNodeID];
@@ -99,7 +99,7 @@ describe('Selectors', () => {
     it('returns an object whose values are all Booleans', () => {
       expect(
         Object.values(getNodeDisabled(mockState.animals)).every(
-          value => typeof value === 'boolean'
+          (value) => typeof value === 'boolean'
         )
       ).toBe(true);
     });
@@ -127,7 +127,7 @@ describe('Selectors', () => {
     it('returns an object whose values are all Booleans', () => {
       expect(
         Object.values(getEdgeDisabled(mockState.animals)).every(
-          value => typeof value === 'boolean'
+          (value) => typeof value === 'boolean'
         )
       ).toBe(true);
     });
@@ -141,10 +141,10 @@ describe('Selectors', () => {
 
     it('disables an edge if one of its nodes is disabled', () => {
       const disabledEdges = Object.keys(edgeDisabled).filter(
-        id => edgeDisabled[id]
+        (id) => edgeDisabled[id]
       );
       const disabledEdgesMock = edges.filter(
-        id =>
+        (id) =>
           getEdgeSources(newMockState)[id] === nodeID ||
           getEdgeTargets(newMockState)[id] === nodeID
       );
@@ -153,10 +153,10 @@ describe('Selectors', () => {
 
     it('does not disable an edge if none of its nodes are disabled', () => {
       const enabledEdges = Object.keys(edgeDisabled).filter(
-        id => !edgeDisabled[id]
+        (id) => !edgeDisabled[id]
       );
       const enabledEdgesMock = edges.filter(
-        id =>
+        (id) =>
           getEdgeSources(newMockState)[id] !== nodeID &&
           getEdgeTargets(newMockState)[id] !== nodeID
       );
@@ -176,7 +176,7 @@ describe('Selectors', () => {
     it('returns an object whose values are all Booleans', () => {
       expect(
         Object.values(getEdgeDisabled(mockState.animals)).every(
-          value => typeof value === 'boolean'
+          (value) => typeof value === 'boolean'
         )
       ).toBe(true);
     });
@@ -207,8 +207,8 @@ describe('Selectors', () => {
         ...mockState.animals,
         layer: {
           ids: [],
-          visible: true
-        }
+          visible: true,
+        },
       };
       expect(getVisibleLayerIDs(newMockState)).toEqual([]);
     });

--- a/src/selectors/edges.js
+++ b/src/selectors/edges.js
@@ -1,10 +1,10 @@
 import { createSelector } from 'reselect';
 import { getNodeDisabled, getEdgeDisabled } from './disabled';
 
-const getNodeIDs = state => state.node.ids;
-const getEdgeIDs = state => state.edge.ids;
-const getEdgeSources = state => state.edge.sources;
-const getEdgeTargets = state => state.edge.targets;
+const getNodeIDs = (state) => state.node.ids;
+const getEdgeIDs = (state) => state.edge.ids;
+const getEdgeSources = (state) => state.edge.sources;
+const getEdgeTargets = (state) => state.edge.targets;
 
 /**
  * Create a new transitive edge from the first and last edge in the path
@@ -31,7 +31,7 @@ export const getTransitiveEdges = createSelector(
     const transitiveEdges = {
       edgeIDs: [],
       sources: {},
-      targets: {}
+      targets: {},
     };
 
     /**
@@ -40,8 +40,8 @@ export const getTransitiveEdges = createSelector(
      * for each path that visits disabled nodes between enabled nodes.
      * @param {Array} path The route that has been explored so far
      */
-    const walkGraphEdges = path => {
-      edgeIDs.forEach(edgeID => {
+    const walkGraphEdges = (path) => {
+      edgeIDs.forEach((edgeID) => {
         const source = path[path.length - 1];
         // Filter to only edges where the source node is the previous target
         if (edgeSources[edgeID] !== source) {
@@ -59,11 +59,11 @@ export const getTransitiveEdges = createSelector(
     };
 
     // Only run walk if some nodes are disabled
-    if (nodeIDs.some(nodeID => nodeDisabled[nodeID])) {
+    if (nodeIDs.some((nodeID) => nodeDisabled[nodeID])) {
       // Examine the children of every enabled node. The walk only needs
       // to be run in a single direction (i.e. top down), because links
       // that end in a terminus can never be transitive.
-      nodeIDs.forEach(nodeID => {
+      nodeIDs.forEach((nodeID) => {
         if (!nodeDisabled[nodeID]) {
           walkGraphEdges([nodeID]);
         }
@@ -84,15 +84,15 @@ export const getVisibleEdges = createSelector(
     getEdgeDisabled,
     getEdgeSources,
     getEdgeTargets,
-    getTransitiveEdges
+    getTransitiveEdges,
   ],
   (edgeIDs, edgeDisabled, edgeSources, edgeTargets, transitiveEdges) =>
     edgeIDs
-      .filter(id => !edgeDisabled[id])
+      .filter((id) => !edgeDisabled[id])
       .concat(transitiveEdges.edgeIDs)
-      .map(id => ({
+      .map((id) => ({
         id,
         source: edgeSources[id] || transitiveEdges.sources[id],
-        target: edgeTargets[id] || transitiveEdges.targets[id]
+        target: edgeTargets[id] || transitiveEdges.targets[id],
       }))
 );

--- a/src/selectors/edges.test.js
+++ b/src/selectors/edges.test.js
@@ -4,10 +4,10 @@ import { addNewEdge, getTransitiveEdges, getVisibleEdges } from './edges';
 import { toggleNodesDisabled } from '../actions/nodes';
 import reducer from '../reducers';
 
-const getNodeIDs = state => state.node.ids;
-const getEdgeIDs = state => state.edge.ids;
-const getEdgeSources = state => state.edge.sources;
-const getEdgeTargets = state => state.edge.targets;
+const getNodeIDs = (state) => state.node.ids;
+const getEdgeIDs = (state) => state.edge.ids;
+const getEdgeSources = (state) => state.edge.sources;
+const getEdgeTargets = (state) => state.edge.targets;
 
 describe('Selectors', () => {
   describe('addNewEdge', () => {
@@ -26,14 +26,14 @@ describe('Selectors', () => {
     it('adds a new source to the sources dictionary', () => {
       addNewEdge('source_name', 'target', transitiveEdges);
       expect(transitiveEdges.sources).toEqual({
-        'source_name|target': 'source_name'
+        'source_name|target': 'source_name',
       });
     });
 
     it('adds a new target to the targets dictionary', () => {
       addNewEdge('source', 'target name', transitiveEdges);
       expect(transitiveEdges.targets).toEqual({
-        'source|target name': 'target name'
+        'source|target name': 'target name',
       });
     });
 
@@ -48,16 +48,16 @@ describe('Selectors', () => {
     const edgeSources = getEdgeSources(mockState.animals);
     const edgeTargets = getEdgeTargets(mockState.animals);
     // Find a node which has multiple inputs and outputs, which we can disable
-    const disabledNode = getNodeIDs(mockState.animals).find(node => {
-      const hasMultipleConnections = edgeNodes =>
-        Object.values(edgeNodes).filter(edge => edge === node).length > 1;
+    const disabledNode = getNodeIDs(mockState.animals).find((node) => {
+      const hasMultipleConnections = (edgeNodes) =>
+        Object.values(edgeNodes).filter((edge) => edge === node).length > 1;
       return (
         hasMultipleConnections(edgeSources) &&
         hasMultipleConnections(edgeTargets)
       );
     });
     const sourceEdge = getEdgeIDs(mockState.animals).find(
-      edge => edgeTargets[edge] === disabledNode
+      (edge) => edgeTargets[edge] === disabledNode
     );
     const source = edgeSources[sourceEdge];
 
@@ -66,7 +66,7 @@ describe('Selectors', () => {
         expect(getTransitiveEdges(mockState.animals)).toEqual({
           edgeIDs: [],
           sources: {},
-          targets: {}
+          targets: {},
         });
       });
     });
@@ -105,7 +105,7 @@ describe('Selectors', () => {
     it('gets only the visible edges', () => {
       const edgeDisabled = getEdgeDisabled(mockState.animals);
       expect(
-        getVisibleEdges(mockState.animals).map(d => edgeDisabled[d.id])
+        getVisibleEdges(mockState.animals).map((d) => edgeDisabled[d.id])
       ).toEqual(expect.arrayContaining([false]));
     });
 
@@ -115,17 +115,17 @@ describe('Selectors', () => {
           expect.objectContaining({
             id: expect.any(String),
             source: expect.any(String),
-            target: expect.any(String)
-          })
+            target: expect.any(String),
+          }),
         ])
       );
     });
 
     it('includes transitive edges when necessary', () => {
       // Find a node which has multiple inputs and outputs, which we can disable
-      const disabledNodeID = getNodeIDs(mockState.animals).find(node => {
-        const hasMultipleConnections = edgeNodes =>
-          Object.values(edgeNodes).filter(edge => edge === node).length > 1;
+      const disabledNodeID = getNodeIDs(mockState.animals).find((node) => {
+        const hasMultipleConnections = (edgeNodes) =>
+          Object.values(edgeNodes).filter((edge) => edge === node).length > 1;
         return (
           hasMultipleConnections(getEdgeSources(mockState.animals)) &&
           hasMultipleConnections(getEdgeTargets(mockState.animals))

--- a/src/selectors/layers.js
+++ b/src/selectors/layers.js
@@ -1,8 +1,8 @@
 import { createSelector } from 'reselect';
 import { getVisibleLayerIDs } from './disabled';
 
-const getGraph = state => state.graph;
-const getLayerName = state => state.layer.name;
+const getGraph = (state) => state.graph;
+const getLayerName = (state) => state.layer.name;
 
 /**
  * Get layer positions
@@ -37,11 +37,11 @@ export const getLayers = createSelector(
       const currentBound = bounds[id] || [0, 0];
       const prevBound = bounds[layerIDs[i - 1]] || [
         currentBound[0],
-        currentBound[0]
+        currentBound[0],
       ];
       const nextBound = bounds[layerIDs[i + 1]] || [
         currentBound[1],
-        currentBound[1]
+        currentBound[1],
       ];
       const start = (prevBound[1] + currentBound[0]) / 2;
       const end = (currentBound[1] + nextBound[0]) / 2;
@@ -53,7 +53,7 @@ export const getLayers = createSelector(
         x: (rectWidth - width) / -2,
         y: start,
         width: rectWidth,
-        height: Math.max(end - start, 0)
+        height: Math.max(end - start, 0),
       };
     });
   }

--- a/src/selectors/layers.test.js
+++ b/src/selectors/layers.test.js
@@ -8,7 +8,7 @@ describe('Selectors', () => {
     });
 
     it("returns an array whose IDs match the current pipeline's layer IDs, in the same order", () => {
-      expect(getLayers(mockState.animals).map(d => d.id)).toEqual(
+      expect(getLayers(mockState.animals).map((d) => d.id)).toEqual(
         mockState.animals.layer.ids
       );
     });
@@ -18,8 +18,8 @@ describe('Selectors', () => {
         expect.arrayContaining([
           expect.objectContaining({
             y: expect.any(Number),
-            height: expect.any(Number)
-          })
+            height: expect.any(Number),
+          }),
         ])
       );
     });
@@ -27,13 +27,13 @@ describe('Selectors', () => {
     it("calculates appropriate y/height positions for each layer corresponding to each layer's nodes", () => {
       const { nodes } = mockState.animals.graph;
       const layers = getLayers(mockState.animals);
-      const layerIDs = layers.map(layer => layer.id);
+      const layerIDs = layers.map((layer) => layer.id);
       const layersObj = layers.reduce((layers, layer) => {
         layers[layer.id] = layer;
         return layers;
       }, {});
 
-      nodes.forEach(node => {
+      nodes.forEach((node) => {
         // We don't need to check y/height positions if the layer field isn't there( this is the case for 'task' type nodes ).
         if (node.layer === null || typeof node.layer === 'undefined') {
           return;

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -5,9 +5,9 @@ import { getVisibleLayerIDs } from './disabled';
 import { getVisibleMetaSidebar } from '../selectors/metadata';
 import { sidebarWidth, metaSidebarWidth, chartMinWidthScale } from '../config';
 
-const getOldgraphFlag = state => state.flags.oldgraph;
-const getVisibleSidebar = state => state.visible.sidebar;
-const getFontLoaded = state => state.fontLoaded;
+const getOldgraphFlag = (state) => state.flags.oldgraph;
+const getVisibleSidebar = (state) => state.visible.sidebar;
+const getFontLoaded = (state) => state.fontLoaded;
 
 /**
  * Select a subset of state that is watched by graph layout calculators
@@ -19,7 +19,7 @@ export const getGraphInput = createSelector(
     getVisibleEdges,
     getVisibleLayerIDs,
     getOldgraphFlag,
-    getFontLoaded
+    getFontLoaded,
   ],
   (nodes, edges, layers, oldgraph, fontLoaded) => {
     if (!fontLoaded) {
@@ -40,7 +40,7 @@ export const getSidebarWidth = (visible, { open, closed }) =>
  * and add some useful new ones
  */
 export const getChartSize = createSelector(
-  [getVisibleSidebar, getVisibleMetaSidebar, state => state.chartSize],
+  [getVisibleSidebar, getVisibleMetaSidebar, (state) => state.chartSize],
   (visibleSidebar, visibleMetaSidebar, chartSize) => {
     const { left, top, width, height } = chartSize;
     if (!width || !height) {
@@ -66,7 +66,7 @@ export const getChartSize = createSelector(
       width: chartWidth,
       minWidthScale: chartMinWidthScale,
       sidebarWidth: sidebarWidthActual,
-      metaSidebarWidth: metaSidebarWidthActual
+      metaSidebarWidth: metaSidebarWidthActual,
     };
   }
 );
@@ -74,9 +74,6 @@ export const getChartSize = createSelector(
 /**
  * Gets the current chart zoom
  */
-export const getChartZoom = createSelector(
-  [state => state.zoom],
-  zoom => ({
-    ...zoom
-  })
-);
+export const getChartZoom = createSelector([(state) => state.zoom], (zoom) => ({
+  ...zoom,
+}));

--- a/src/selectors/layout.test.js
+++ b/src/selectors/layout.test.js
@@ -13,7 +13,7 @@ describe('Selectors', () => {
           edges: expect.any(Array),
           layers: expect.any(Array),
           oldgraph: expect.any(Boolean),
-          fontLoaded: expect.any(Boolean)
+          fontLoaded: expect.any(Boolean),
         })
       );
     });
@@ -43,14 +43,14 @@ describe('Selectors', () => {
         outerWidth: undefined,
         sidebarWidth: undefined,
         top: undefined,
-        width: undefined
+        width: undefined,
       });
     });
 
     it('returns a DOMRect converted into an Object, with some extra properties', () => {
       const newMockState = {
         ...mockState.animals,
-        chartSize: { left: 100, top: 100, width: 1000, height: 1000 }
+        chartSize: { left: 100, top: 100, width: 1000, height: 1000 },
       };
       expect(getChartSize(newMockState)).toEqual({
         height: expect.any(Number),
@@ -61,7 +61,7 @@ describe('Selectors', () => {
         metaSidebarWidth: expect.any(Number),
         minWidthScale: expect.any(Number),
         top: expect.any(Number),
-        width: expect.any(Number)
+        width: expect.any(Number),
       });
     });
   });

--- a/src/selectors/linked-nodes.js
+++ b/src/selectors/linked-nodes.js
@@ -1,9 +1,9 @@
 import { createSelector } from 'reselect';
 import { getVisibleEdges } from './edges';
 
-const getClickedNode = state => state.node.clicked;
-const getHoveredNode = state => state.node.hovered;
-const getLazyFlag = state => state.flags.lazy;
+const getClickedNode = (state) => state.node.clicked;
+const getHoveredNode = (state) => state.node.hovered;
+const getLazyFlag = (state) => state.flags.lazy;
 
 /**
  * Get the node that should be used as the center of the set of linked nodes
@@ -22,7 +22,7 @@ export const getCentralNode = createSelector(
  */
 export const getVisibleEdgesByNode = createSelector(
   [getVisibleEdges],
-  edges => {
+  (edges) => {
     const sourceEdges = {};
     const targetEdges = {};
 
@@ -56,7 +56,7 @@ const findLinkedNodes = (nodeID, edgesByNode, visited) => {
     visited[nodeID] = true;
 
     if (edgesByNode[nodeID]) {
-      edgesByNode[nodeID].forEach(nodeID =>
+      edgesByNode[nodeID].forEach((nodeID) =>
         findLinkedNodes(nodeID, edgesByNode, visited)
       );
     }

--- a/src/selectors/linked-nodes.test.js
+++ b/src/selectors/linked-nodes.test.js
@@ -5,7 +5,7 @@ import reducer from '../reducers';
 
 describe('getLinkedNodes function', () => {
   const { nodes } = mockState.animals.graph;
-  const nodeID = nodes.find(d => d.name.includes('salmon')).id;
+  const nodeID = nodes.find((d) => d.name.includes('salmon')).id;
   const newMockState = reducer(mockState.animals, toggleNodeClicked(nodeID));
   const linkedNodes = getLinkedNodes(newMockState);
 
@@ -20,7 +20,7 @@ describe('getLinkedNodes function', () => {
       ['sheep', '6525f2e6'],
       ['cat', '9d989e8d'],
       ['dog', 'e4951252'],
-      ['parameters', 'f1f1425b']
+      ['parameters', 'f1f1425b'],
     ])('node %s should be true', (name, id) => {
       expect(linkedNodes[id]).toBe(true);
     });
@@ -30,7 +30,7 @@ describe('getLinkedNodes function', () => {
     test.each([
       ['bear', '09f5edeb'],
       ['shark', '4f90af66'],
-      ['weasel', '85c4cf64']
+      ['weasel', '85c4cf64'],
     ])('node %s should be false', (name, id) => {
       expect(linkedNodes[id]).toBe(undefined);
     });

--- a/src/selectors/loading.js
+++ b/src/selectors/loading.js
@@ -1,9 +1,9 @@
 import { createSelector } from 'reselect';
 
-const getGraphLoading = state => state.loading.graph;
-const getPipelineLoading = state => state.loading.pipeline;
-const getFontLoading = state => !state.fontLoaded;
-const getNodeLoading = state => state.loading.node;
+const getGraphLoading = (state) => state.loading.graph;
+const getPipelineLoading = (state) => state.loading.pipeline;
+const getFontLoading = (state) => !state.fontLoaded;
+const getNodeLoading = (state) => state.loading.node;
 
 /**
  * Determine whether to show the loading spinner

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import { getGraphNodes } from './nodes';
 
-const getClickedNode = state => state.node.clicked;
+const getClickedNode = (state) => state.node.clicked;
 
 /**
  * Comparison for sorting alphabetically by name, otherwise by value
@@ -13,15 +13,15 @@ const sortAlpha = (a, b) => (a.name || a).localeCompare(b.name || b);
  */
 export const getVisibleMetaSidebar = createSelector(
   [getClickedNode],
-  nodeClicked => Boolean(nodeClicked)
+  (nodeClicked) => Boolean(nodeClicked)
 );
 
 /**
  * Templates for run commands
  */
 const runCommandTemplates = {
-  data: name => `kedro run --to-inputs ${name}`,
-  task: name => `kedro run --to-nodes ${name}`
+  data: (name) => `kedro run --to-inputs ${name}`,
+  task: (name) => `kedro run --to-nodes ${name}`,
 };
 
 /**
@@ -29,7 +29,7 @@ const runCommandTemplates = {
  * @param {object} node The node
  * @returns {?string} The run command for the node, if applicable
  */
-const getRunCommand = node => {
+const getRunCommand = (node) => {
   const template = runCommandTemplates[node.type];
   return template ? template(node.fullName) : null;
 };
@@ -41,14 +41,14 @@ export const getClickedNodeMetaData = createSelector(
   [
     getClickedNode,
     getGraphNodes,
-    state => state.node.tags,
-    state => state.tag.name,
-    state => state.pipeline,
-    state => state.node.filepath,
-    state => state.node.code,
-    state => state.node.docstring,
-    state => state.node.parameters,
-    state => state.node.datasetType
+    (state) => state.node.tags,
+    (state) => state.tag.name,
+    (state) => state.pipeline,
+    (state) => state.node.filepath,
+    (state) => state.node.code,
+    (state) => state.node.docstring,
+    (state) => state.node.parameters,
+    (state) => state.node.datasetType,
   ],
   (
     nodeId,
@@ -77,7 +77,7 @@ export const getClickedNodeMetaData = createSelector(
     const metadata = {
       node,
       tags: [...nodeTags[node.id]]
-        .map(tagId => tagNames[tagId])
+        .map((tagId) => tagNames[tagId])
         .sort(sortAlpha),
       pipeline: pipeline.name[pipeline.active],
       parameters,
@@ -85,16 +85,16 @@ export const getClickedNodeMetaData = createSelector(
       docstring: nodeDocstrings[node.id],
       code: nodeCodes[node.id],
       filepath: nodeFilepaths[node.id],
-      datasetType: nodeDatasetTypes[node.id]
+      datasetType: nodeDatasetTypes[node.id],
     };
 
     // Note: node.sources node.targets require oldgraph enabled
     if (node.sources && node.targets) {
       metadata.inputs = node.sources
-        .map(edge => nodes[edge.source])
+        .map((edge) => nodes[edge.source])
         .sort(sortAlpha);
       metadata.outputs = node.targets
-        .map(edge => nodes[edge.target])
+        .map((edge) => nodes[edge.target])
         .sort(sortAlpha);
     }
 

--- a/src/selectors/node-types.js
+++ b/src/selectors/node-types.js
@@ -2,11 +2,11 @@ import { createSelector } from 'reselect';
 import { getNodeDisabled } from './disabled';
 import { arrayToObject } from '../utils';
 
-const getNodeIDs = state => state.node.ids;
-const getNodeType = state => state.node.type;
-const getNodeTypeIDs = state => state.nodeType.ids;
-const getNodeTypeName = state => state.nodeType.name;
-const getNodeTypeDisabled = state => state.nodeType.disabled;
+const getNodeIDs = (state) => state.node.ids;
+const getNodeType = (state) => state.node.type;
+const getNodeTypeIDs = (state) => state.nodeType.ids;
+const getNodeTypeName = (state) => state.nodeType.name;
+const getNodeTypeDisabled = (state) => state.nodeType.disabled;
 
 /**
  * Calculate the total number of nodes (and the number of visible nodes)
@@ -15,14 +15,14 @@ const getNodeTypeDisabled = state => state.nodeType.disabled;
 export const getTypeNodeCount = createSelector(
   [getNodeTypeIDs, getNodeIDs, getNodeType, getNodeDisabled],
   (types, nodeIDs, nodeType, nodeDisabled) =>
-    arrayToObject(types, type => {
-      const typeNodeIDs = nodeIDs.filter(nodeID => nodeType[nodeID] === type);
+    arrayToObject(types, (type) => {
+      const typeNodeIDs = nodeIDs.filter((nodeID) => nodeType[nodeID] === type);
       const visibleTypeNodeIDs = typeNodeIDs.filter(
-        nodeID => !nodeDisabled[nodeID]
+        (nodeID) => !nodeDisabled[nodeID]
       );
       return {
         total: typeNodeIDs.length,
-        visible: visibleTypeNodeIDs.length
+        visible: visibleTypeNodeIDs.length,
       };
     })
 );
@@ -33,10 +33,10 @@ export const getTypeNodeCount = createSelector(
 export const getNodeTypes = createSelector(
   [getNodeTypeIDs, getNodeTypeName, getNodeTypeDisabled, getTypeNodeCount],
   (types, typeName, typeDisabled, typeNodeCount) =>
-    types.map(id => ({
+    types.map((id) => ({
       id,
       name: typeName[id],
       disabled: Boolean(typeDisabled[id]),
-      nodeCount: typeNodeCount[id]
+      nodeCount: typeNodeCount[id],
     }))
 );

--- a/src/selectors/nodes.js
+++ b/src/selectors/nodes.js
@@ -5,28 +5,28 @@ import { getPipelineNodeIDs } from './pipeline';
 import {
   getNodeDisabled,
   getNodeDisabledTag,
-  getVisibleNodeIDs
+  getVisibleNodeIDs,
 } from './disabled';
 import { getNodeRank } from './ranks';
 
-const getNodeName = state => state.node.name;
-const getNodeFullName = state => state.node.fullName;
-const getNodeDisabledNode = state => state.node.disabled;
-const getNodeTags = state => state.node.tags;
-const getNodeType = state => state.node.type;
-const getNodeLayer = state => state.node.layer;
-const getHoveredNode = state => state.node.hovered;
-const getTagActive = state => state.tag.active;
-const getTextLabels = state => state.textLabels;
-const getFontLoaded = state => state.fontLoaded;
-const getNodeTypeDisabled = state => state.nodeType.disabled;
-const getClickedNode = state => state.node.clicked;
+const getNodeName = (state) => state.node.name;
+const getNodeFullName = (state) => state.node.fullName;
+const getNodeDisabledNode = (state) => state.node.disabled;
+const getNodeTags = (state) => state.node.tags;
+const getNodeType = (state) => state.node.type;
+const getNodeLayer = (state) => state.node.layer;
+const getHoveredNode = (state) => state.node.hovered;
+const getTagActive = (state) => state.tag.active;
+const getTextLabels = (state) => state.textLabels;
+const getFontLoaded = (state) => state.fontLoaded;
+const getNodeTypeDisabled = (state) => state.nodeType.disabled;
+const getClickedNode = (state) => state.node.clicked;
 
 /**
  * Gets a map of nodeIds to graph nodes
  */
 export const getGraphNodes = createSelector(
-  [state => state.graph.nodes],
+  [(state) => state.graph.nodes],
   (nodes = []) =>
     nodes.reduce((result, node) => {
       result[node.id] = node;
@@ -40,11 +40,11 @@ export const getGraphNodes = createSelector(
 export const getNodeActive = createSelector(
   [getPipelineNodeIDs, getHoveredNode, getNodeTags, getTagActive],
   (nodeIDs, hoveredNode, nodeTags, tagActive) =>
-    arrayToObject(nodeIDs, nodeID => {
+    arrayToObject(nodeIDs, (nodeID) => {
       if (nodeID === hoveredNode) {
         return true;
       }
-      const activeViaTag = nodeTags[nodeID].some(tag => tagActive[tag]);
+      const activeViaTag = nodeTags[nodeID].some((tag) => tagActive[tag]);
       return Boolean(activeViaTag);
     })
 );
@@ -57,7 +57,7 @@ export const getNodeSelected = createSelector(
   (nodeIDs, clickedNode, nodeDisabled) =>
     arrayToObject(
       nodeIDs,
-      nodeID => nodeID === clickedNode && !nodeDisabled[nodeID]
+      (nodeID) => nodeID === clickedNode && !nodeDisabled[nodeID]
     )
 );
 
@@ -72,7 +72,7 @@ export const getNodeData = createSelector(
     getNodeDisabled,
     getNodeDisabledNode,
     getNodeDisabledTag,
-    getNodeTypeDisabled
+    getNodeTypeDisabled,
   ],
   (
     nodeIDs,
@@ -89,31 +89,29 @@ export const getNodeData = createSelector(
         if (nodeName[a] > nodeName[b]) return 1;
         return 0;
       })
-      .map(id => ({
+      .map((id) => ({
         id,
         name: nodeName[id],
         type: nodeType[id],
         disabled: nodeDisabled[id],
         disabled_node: Boolean(nodeDisabledNode[id]),
         disabled_tag: nodeDisabledTag[id],
-        disabled_type: Boolean(typeDisabled[nodeType[id]])
+        disabled_type: Boolean(typeDisabled[nodeType[id]]),
       }))
 );
 
 /**
  * Returns formatted nodes grouped by type
  */
-export const getGroupedNodes = createSelector(
-  [getNodeData],
-  nodes =>
-    nodes.reduce(function(obj, item) {
-      const key = item.type;
-      if (!obj.hasOwnProperty(key)) {
-        obj[key] = [];
-      }
-      obj[key].push(item);
-      return obj;
-    }, {})
+export const getGroupedNodes = createSelector([getNodeData], (nodes) =>
+  nodes.reduce(function (obj, item) {
+    const key = item.type;
+    if (!obj.hasOwnProperty(key)) {
+      obj[key] = [];
+    }
+    obj[key].push(item);
+    return obj;
+  }, {})
 );
 
 /**
@@ -135,8 +133,8 @@ export const getNodeTextWidth = createSelector(
       .data(nodeIDs)
       .enter()
       .append('text')
-      .text(nodeID => nodeName[nodeID])
-      .each(function(nodeID) {
+      .text((nodeID) => nodeName[nodeID])
+      .each(function (nodeID) {
         const width = this.getBBox ? this.getBBox().width : 0;
         nodeTextWidth[nodeID] = width;
       });
@@ -172,13 +170,13 @@ export const getNodeSize = createSelector(
     getNodeTextWidth,
     getTextLabels,
     getNodeType,
-    getFontLoaded
+    getFontLoaded,
   ],
   (nodeIDs, nodeTextWidth, textLabels, nodeType, fontLoaded) => {
     if (!fontLoaded) {
       return {};
     }
-    return arrayToObject(nodeIDs, nodeID => {
+    return arrayToObject(nodeIDs, (nodeID) => {
       const iconSize = textLabels ? 24 : 28;
       const padding = getPadding(textLabels, nodeType[nodeID] === 'task');
       const textWidth = textLabels ? nodeTextWidth[nodeID] : 0;
@@ -190,7 +188,7 @@ export const getNodeSize = createSelector(
         height: iconSize + padding.y * 2,
         textOffset: (innerWidth - textWidth) / 2 - 1,
         iconOffset: -innerWidth / 2,
-        iconSize
+        iconSize,
       };
     });
   }
@@ -209,7 +207,7 @@ export const getVisibleNodes = createSelector(
     getNodeSize,
     getNodeLayer,
     getNodeRank,
-    getFontLoaded
+    getFontLoaded,
   ],
   (
     nodeIDs,
@@ -222,7 +220,7 @@ export const getVisibleNodes = createSelector(
     fontLoaded
   ) =>
     fontLoaded
-      ? nodeIDs.map(id => ({
+      ? nodeIDs.map((id) => ({
           id,
           name: nodeName[id],
           label: nodeName[id],
@@ -230,7 +228,7 @@ export const getVisibleNodes = createSelector(
           type: nodeType[id],
           layer: nodeLayer[id],
           rank: nodeRank[id],
-          ...nodeSize[id]
+          ...nodeSize[id],
         }))
       : []
 );

--- a/src/selectors/nodes.test.js
+++ b/src/selectors/nodes.test.js
@@ -8,21 +8,21 @@ import {
   getNodeTextWidth,
   getPadding,
   getNodeSize,
-  getVisibleNodes
+  getVisibleNodes,
 } from './nodes';
 import { toggleTextLabels, updateFontLoaded } from '../actions';
 import { updateActivePipeline } from '../actions/pipelines';
 import {
   toggleNodeClicked,
   toggleNodeHovered,
-  toggleNodesDisabled
+  toggleNodesDisabled,
 } from '../actions/nodes';
 import reducer from '../reducers';
 
-const getNodeIDs = state => state.node.ids;
-const getNodeName = state => state.node.name;
-const getNodeType = state => state.node.type;
-const getNodePipelines = state => state.node.pipelines;
+const getNodeIDs = (state) => state.node.ids;
+const getNodeName = (state) => state.node.name;
+const getNodeType = (state) => state.node.type;
+const getNodePipelines = (state) => state.node.pipelines;
 
 const noFontState = reducer(mockState.animals, updateFontLoaded(false));
 
@@ -47,14 +47,16 @@ describe('Selectors', () => {
     it('returns true when a given node is hovered', () => {
       const nodes = getNodeIDs(mockState.animals);
       const nodeID = nodes[0];
-      const inactiveNodes = nodes.filter(id => id !== nodeID);
+      const inactiveNodes = nodes.filter((id) => id !== nodeID);
       const newMockState = reducer(
         mockState.animals,
         toggleNodeHovered(nodeID)
       );
       const nodeActive = getNodeActive(newMockState);
       expect(nodeActive[nodeID]).toEqual(true);
-      expect(inactiveNodes.every(id => nodeActive[id] === false)).toEqual(true);
+      expect(inactiveNodes.every((id) => nodeActive[id] === false)).toEqual(
+        true
+      );
     });
   });
 
@@ -78,14 +80,16 @@ describe('Selectors', () => {
     it('returns true when a given node is clicked', () => {
       const nodes = getNodeIDs(mockState.animals);
       const nodeID = nodes[0];
-      const inactiveNodes = nodes.filter(id => id !== nodeID);
+      const inactiveNodes = nodes.filter((id) => id !== nodeID);
       const newMockState = reducer(
         mockState.animals,
         toggleNodeClicked(nodeID)
       );
       const nodeActive = getNodeSelected(newMockState);
       expect(nodeActive[nodeID]).toEqual(true);
-      expect(inactiveNodes.every(id => nodeActive[id] === false)).toEqual(true);
+      expect(inactiveNodes.every((id) => nodeActive[id] === false)).toEqual(
+        true
+      );
     });
   });
 
@@ -99,15 +103,15 @@ describe('Selectors', () => {
             type: expect.stringMatching(/data|task/),
             disabled: expect.any(Boolean),
             disabled_node: expect.any(Boolean),
-            disabled_tag: expect.any(Boolean)
-          })
+            disabled_tag: expect.any(Boolean),
+          }),
         ])
       );
     });
 
     it('returns nodes sorted by name', () => {
       const nodeName = getNodeName(mockState.animals);
-      const nodeIDs = getNodeData(mockState.animals).map(d => d.id);
+      const nodeIDs = getNodeData(mockState.animals).map((d) => d.id);
       const visibleNodeIDs = getNodeIDs(mockState.animals).sort((a, b) => {
         if (nodeName[a] < nodeName[b]) return -1;
         if (nodeName[a] > nodeName[b]) return 1;
@@ -122,14 +126,14 @@ describe('Selectors', () => {
         mockState.animals,
         updateActivePipeline(activePipeline)
       );
-      const nodeDataIDs = getNodeData(state).map(d => d.id);
+      const nodeDataIDs = getNodeData(state).map((d) => d.id);
       const nodePipelines = getNodePipelines(state);
       const activePipelineNodeIDs = getNodeIDs(state).filter(
-        nodeID => nodePipelines[nodeID][activePipeline]
+        (nodeID) => nodePipelines[nodeID][activePipeline]
       );
       test.each(activePipelineNodeIDs)(
         `node %s is included in nodeData`,
-        nodeID => {
+        (nodeID) => {
           expect(nodeDataIDs).toContain(nodeID);
         }
       );
@@ -141,11 +145,11 @@ describe('Selectors', () => {
         mockState.animals,
         updateActivePipeline(activePipeline)
       );
-      const nodeIDs = getNodeData(state).map(d => d.id);
+      const nodeIDs = getNodeData(state).map((d) => d.id);
       const nodePipelines = getNodePipelines(state);
       test.each(nodeIDs)(
         `node %s is in active pipeline ${activePipeline}`,
-        nodeID => {
+        (nodeID) => {
           const nodeIsInActivePipeline = nodePipelines[nodeID][activePipeline];
           expect(nodeIsInActivePipeline).toBe(true);
         }
@@ -165,10 +169,12 @@ describe('Selectors', () => {
 
     test.each(types)(
       'returns all nodes in the active pipeline for "%s" type',
-      type => {
+      (type) => {
         const typeNodes = Object.values(groupedNodes[type]);
-        const typeNodeIDs = nodeIDs.filter(nodeID => nodeType[nodeID] === type);
-        expect(typeNodes.map(d => d.id)).toEqual(typeNodeIDs);
+        const typeNodeIDs = nodeIDs.filter(
+          (nodeID) => nodeType[nodeID] === type
+        );
+        expect(typeNodes.map((d) => d.id)).toEqual(typeNodeIDs);
       }
     );
   });
@@ -195,11 +201,11 @@ describe('Selectors', () => {
 
       it('returns an object whose values are all numbers', () => {
         expect(values.length).toEqual(getNodeIDs(mockState.animals).length);
-        expect(values.every(value => typeof value === 'number')).toBe(true);
+        expect(values.every((value) => typeof value === 'number')).toBe(true);
       });
 
       it('returns width=0 if svg getBBox is not supported', () => {
-        expect(values.every(value => value === 0)).toBe(true);
+        expect(values.every((value) => value === 0)).toBe(true);
       });
     });
   });
@@ -209,7 +215,7 @@ describe('Selectors', () => {
       expect(getPadding()).toEqual(
         expect.objectContaining({
           x: expect.any(Number),
-          y: expect.any(Number)
+          y: expect.any(Number),
         })
       );
     });
@@ -253,8 +259,8 @@ describe('Selectors', () => {
               height: expect.any(Number),
               textOffset: expect.any(Number),
               iconOffset: expect.any(Number),
-              iconSize: expect.any(Number)
-            })
+              iconSize: expect.any(Number),
+            }),
           ])
         );
       });
@@ -321,8 +327,8 @@ describe('Selectors', () => {
               height: expect.any(Number),
               textOffset: expect.any(Number),
               iconOffset: expect.any(Number),
-              iconSize: expect.any(Number)
-            })
+              iconSize: expect.any(Number),
+            }),
           ])
         );
       });
@@ -334,9 +340,9 @@ describe('Selectors', () => {
           mockState.animals,
           toggleNodesDisabled([nodeID], true)
         );
-        const visibleNodeIDs = getVisibleNodes(newMockState).map(d => d.id);
+        const visibleNodeIDs = getVisibleNodes(newMockState).map((d) => d.id);
         expect(visibleNodeIDs.sort()).toEqual(
-          nodes.filter(id => id !== nodeID).sort()
+          nodes.filter((id) => id !== nodeID).sort()
         );
         expect(visibleNodeIDs.includes(nodeID)).toEqual(false);
       });

--- a/src/selectors/pipeline.js
+++ b/src/selectors/pipeline.js
@@ -1,11 +1,11 @@
 import { createSelector } from 'reselect';
 import { arrayToObject } from '../utils';
 
-const getNodeIDs = state => state.node.ids;
-const getNodePipelines = state => state.node.pipelines;
-const getActivePipeline = state => state.pipeline.active;
-const getNodeTags = state => state.node.tags;
-const getAsyncDataSource = state => state.asyncDataSource;
+const getNodeIDs = (state) => state.node.ids;
+const getNodePipelines = (state) => state.node.pipelines;
+const getActivePipeline = (state) => state.pipeline.active;
+const getNodeTags = (state) => state.node.tags;
+const getAsyncDataSource = (state) => state.asyncDataSource;
 
 /**
  * Calculate whether nodes should be disabled based on their tags
@@ -18,7 +18,7 @@ export const getNodeDisabledPipeline = createSelector(
     }
     return arrayToObject(
       nodeIDs,
-      nodeID => !nodePipelines[nodeID][activePipeline]
+      (nodeID) => !nodePipelines[nodeID][activePipeline]
     );
   }
 );
@@ -29,7 +29,7 @@ export const getNodeDisabledPipeline = createSelector(
 export const getPipelineNodeIDs = createSelector(
   [getNodeIDs, getNodeDisabledPipeline],
   (nodeIDs, nodeDisabledPipeline) =>
-    nodeIDs.filter(nodeID => !nodeDisabledPipeline[nodeID])
+    nodeIDs.filter((nodeID) => !nodeDisabledPipeline[nodeID])
 );
 
 /**
@@ -39,8 +39,8 @@ export const getPipelineTagIDs = createSelector(
   [getPipelineNodeIDs, getNodeTags],
   (nodeIDs, nodeTags) => {
     const visibleTags = {};
-    nodeIDs.forEach(nodeID => {
-      nodeTags[nodeID].forEach(tagID => {
+    nodeIDs.forEach((nodeID) => {
+      nodeTags[nodeID].forEach((tagID) => {
         if (!visibleTags[tagID]) {
           visibleTags[tagID] = true;
         }

--- a/src/selectors/pipeline.test.js
+++ b/src/selectors/pipeline.test.js
@@ -3,15 +3,15 @@ import animals from '../utils/data/animals.mock.json';
 import {
   getNodeDisabledPipeline,
   getPipelineNodeIDs,
-  getPipelineTagIDs
+  getPipelineTagIDs,
 } from './pipeline';
 import reducer from '../reducers';
 import { updateActivePipeline } from '../actions/pipelines';
 
-const getNodeIDs = state => state.node.ids;
-const getNodePipelines = state => state.node.pipelines;
-const getActivePipeline = state => state.pipeline.active;
-const getTagIDs = state => state.tag.ids;
+const getNodeIDs = (state) => state.node.ids;
+const getNodePipelines = (state) => state.node.pipelines;
+const getActivePipeline = (state) => state.pipeline.active;
+const getTagIDs = (state) => state.tag.ids;
 
 describe('Selectors', () => {
   describe('getNodeDisabledPipeline', () => {
@@ -24,7 +24,7 @@ describe('Selectors', () => {
     it('returns an object whose values are all Booleans', () => {
       expect(
         Object.values(getNodeDisabledPipeline(mockState.animals)).every(
-          value => typeof value === 'boolean'
+          (value) => typeof value === 'boolean'
         )
       ).toBe(true);
     });
@@ -38,7 +38,7 @@ describe('Selectors', () => {
       const nodeDisabledPipeline = getNodeDisabledPipeline(newMockState);
       expect(
         mockState.animals.node.ids.every(
-          nodeID => !nodeDisabledPipeline[nodeID]
+          (nodeID) => !nodeDisabledPipeline[nodeID]
         )
       ).toBe(true);
     });
@@ -46,7 +46,7 @@ describe('Selectors', () => {
     it('does not disable any nodes that are in the active pipeline', () => {
       const activePipeline = 'ds';
       const activePipelineNodeIDs = mockState.animals.node.ids.filter(
-        nodeID => mockState.animals.node.pipelines[nodeID][activePipeline]
+        (nodeID) => mockState.animals.node.pipelines[nodeID][activePipeline]
       );
       const newMockState = reducer(
         mockState.animals,
@@ -54,14 +54,14 @@ describe('Selectors', () => {
       );
       const nodeDisabledPipeline = getNodeDisabledPipeline(newMockState);
       expect(
-        activePipelineNodeIDs.every(nodeID => !nodeDisabledPipeline[nodeID])
+        activePipelineNodeIDs.every((nodeID) => !nodeDisabledPipeline[nodeID])
       ).toBe(true);
     });
 
     it('disables every node that is not in the active pipeline', () => {
       const activePipeline = 'de';
       const inactivePipelineNodeIDs = mockState.animals.node.ids.filter(
-        nodeID => !mockState.animals.node.pipelines[nodeID][activePipeline]
+        (nodeID) => !mockState.animals.node.pipelines[nodeID][activePipeline]
       );
       const newMockState = reducer(
         mockState.animals,
@@ -69,7 +69,7 @@ describe('Selectors', () => {
       );
       const nodeDisabledPipeline = getNodeDisabledPipeline(newMockState);
       expect(
-        inactivePipelineNodeIDs.every(nodeID => nodeDisabledPipeline[nodeID])
+        inactivePipelineNodeIDs.every((nodeID) => nodeDisabledPipeline[nodeID])
       ).toBe(true);
     });
 
@@ -98,15 +98,15 @@ describe('Selectors', () => {
 
     it('does not contain any nodes that are not in the current pipeline', () => {
       expect(
-        pipelineNodeIDs.every(nodeID => nodePipelines[nodeID][activePipeline])
+        pipelineNodeIDs.every((nodeID) => nodePipelines[nodeID][activePipeline])
       ).toBe(true);
     });
 
     it('contains all nodes in the current pipeline', () => {
       const inactivePipelineNodeIDs = pipelineNodeIDs.filter(
-        nodeID => nodePipelines[nodeID][activePipeline]
+        (nodeID) => nodePipelines[nodeID][activePipeline]
       );
-      inactivePipelineNodeIDs.forEach(nodeID => {
+      inactivePipelineNodeIDs.forEach((nodeID) => {
         expect(pipelineNodeIDs).toContain(nodeID);
       });
     });
@@ -132,7 +132,7 @@ describe('Selectors', () => {
       const node = {
         id: 'new',
         tags: [tag.id],
-        pipelines: ['unused_pipeline'] // not included in default pipeline
+        pipelines: ['unused_pipeline'], // not included in default pipeline
       };
       const data = { ...animals };
       data.tags = [...data.tags, tag];

--- a/src/selectors/ranks.js
+++ b/src/selectors/ranks.js
@@ -3,7 +3,7 @@ import batchingToposort from 'batching-toposort';
 import { getVisibleNodeIDs, getVisibleLayerIDs } from './disabled';
 import { getVisibleEdges } from './edges';
 
-const getNodeLayer = state => state.node.layer;
+const getNodeLayer = (state) => state.node.layer;
 
 /**
  * Get list of visible nodes for each visible layer
@@ -25,7 +25,7 @@ export const getLayerNodes = createSelector(
     }
 
     // Convert to a nested array of layers of nodes
-    return layerIDs.map(layerID => layerNodes[layerID]);
+    return layerIDs.map((layerID) => layerNodes[layerID]);
   }
 );
 

--- a/src/selectors/ranks.test.js
+++ b/src/selectors/ranks.test.js
@@ -5,7 +5,7 @@ import { getVisibleEdges } from './edges';
 import { toggleLayers } from '../actions';
 import reducer from '../reducers';
 
-const getNodeLayer = state => state.node.layer;
+const getNodeLayer = (state) => state.node.layer;
 
 describe('Selectors', () => {
   describe('getLayerNodes', () => {
@@ -20,7 +20,7 @@ describe('Selectors', () => {
       const nodeLayer = getNodeLayer(mockState.animals);
       expect(
         getLayerNodes(mockState.animals).every((layerNodeIDs, i) =>
-          layerNodeIDs.every(nodeID => nodeLayer[nodeID] === layerIDs[i])
+          layerNodeIDs.every((nodeID) => nodeLayer[nodeID] === layerIDs[i])
         )
       ).toBe(true);
     });
@@ -51,7 +51,7 @@ describe('Selectors', () => {
 
     test('for every edge, the source rank is less than the target rank', () => {
       expect(
-        edges.every(edge => nodeRank[edge.source] < nodeRank[edge.target])
+        edges.every((edge) => nodeRank[edge.source] < nodeRank[edge.target])
       ).toBe(true);
     });
 

--- a/src/selectors/tags.js
+++ b/src/selectors/tags.js
@@ -1,9 +1,9 @@
 import { createSelector } from 'reselect';
 import { getPipelineTagIDs } from './pipeline';
 
-const getTagName = state => state.tag.name;
-const getTagActive = state => state.tag.active;
-const getTagEnabled = state => state.tag.enabled;
+const getTagName = (state) => state.tag.name;
+const getTagActive = (state) => state.tag.active;
+const getTagEnabled = (state) => state.tag.enabled;
 
 /**
  * Retrieve the formatted list of tag filters
@@ -11,11 +11,11 @@ const getTagEnabled = state => state.tag.enabled;
 export const getTagData = createSelector(
   [getPipelineTagIDs, getTagName, getTagActive, getTagEnabled],
   (tagIDs, tagName, tagActive, tagEnabled) =>
-    tagIDs.sort().map(id => ({
+    tagIDs.sort().map((id) => ({
       id,
       name: tagName[id],
       active: Boolean(tagActive[id]),
-      enabled: Boolean(tagEnabled[id])
+      enabled: Boolean(tagEnabled[id]),
     }))
 );
 
@@ -26,6 +26,6 @@ export const getTagCount = createSelector(
   [getPipelineTagIDs, getTagEnabled],
   (tagIDs, tagEnabled) => ({
     total: tagIDs.length,
-    enabled: tagIDs.filter(id => tagEnabled[id]).length
+    enabled: tagIDs.filter((id) => tagEnabled[id]).length,
   })
 );

--- a/src/selectors/tags.test.js
+++ b/src/selectors/tags.test.js
@@ -3,7 +3,7 @@ import { getTagData, getTagCount } from './tags';
 import { toggleTagFilter } from '../actions/tags';
 import reducer from '../reducers';
 
-const getTagIDs = state => state.tag.ids;
+const getTagIDs = (state) => state.tag.ids;
 const tagIDs = getTagIDs(mockState.animals);
 const tagData = getTagData(mockState.animals);
 
@@ -16,14 +16,14 @@ describe('Selectors', () => {
             id: expect.any(String),
             name: expect.any(String),
             active: false,
-            enabled: false
-          })
+            enabled: false,
+          }),
         ])
       );
     });
 
     it('retrieves a list of tags sorted by ID name', () => {
-      expect(tagData.map(d => d.id)).toEqual(tagIDs.sort());
+      expect(tagData.map((d) => d.id)).toEqual(tagIDs.sort());
     });
   });
 
@@ -37,7 +37,7 @@ describe('Selectors', () => {
       expect(getTagCount(mockState.animals)).toEqual(
         expect.objectContaining({
           enabled: 0,
-          total: tagIDs.length
+          total: tagIDs.length,
         })
       );
     });
@@ -46,7 +46,7 @@ describe('Selectors', () => {
       expect(getTagCount(newMockState)).toEqual(
         expect.objectContaining({
           enabled: 1,
-          total: tagIDs.length
+          total: tagIDs.length,
         })
       );
     });

--- a/src/store/__mocks__/load-data.js
+++ b/src/store/__mocks__/load-data.js
@@ -9,7 +9,7 @@ import node_parameters from '../../utils/data/node_parameters.mock.json';
  * such as pipelines, layers, tags, etc
  * @param {object} data A dataset file
  */
-export const mockAPIFeatureSupport = data => {
+export const mockAPIFeatureSupport = (data) => {
   let dataCopy = Object.assign({}, data);
   if (window.deletePipelines) {
     delete dataCopy.selected_pipeline;
@@ -22,7 +22,7 @@ export const mockAPIFeatureSupport = data => {
  * Create a promise that resolves after a timeout
  * @param {number} ms Timeout in milliseconds
  */
-const timeout = ms => new Promise(resolve => setTimeout(resolve, ms));
+const timeout = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Mock asynchronously loading/parsing data

--- a/src/store/helpers.js
+++ b/src/store/helpers.js
@@ -26,7 +26,7 @@ export const loadState = () => {
  * Save updated state to localStorage
  * @param {Object} state New state object
  */
-export const saveState = state => {
+export const saveState = (state) => {
   if (noWindow) {
     return;
   }
@@ -49,7 +49,7 @@ export const saveState = state => {
  * @param {object} obj An object containing keys and booleans
  * @return {object} A new clone object but with the falsey keys removed
  */
-export const pruneFalseyKeys = obj => {
+export const pruneFalseyKeys = (obj) => {
   const newObj = {};
   for (let key in obj) {
     if (obj.hasOwnProperty(key) && obj[key]) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -11,10 +11,10 @@ import { saveState, pruneFalseyKeys } from './helpers';
  * update state.graph via a web worker when it changes.
  * @param {object} store Redux store
  */
-const updateGraphOnChange = store => {
+const updateGraphOnChange = (store) => {
   const watchGraph = watch(() => getGraphInput(store.getState()));
   store.subscribe(
-    watchGraph(graphInput => {
+    watchGraph((graphInput) => {
       store.dispatch(calculateGraph(graphInput));
     })
   );
@@ -24,27 +24,27 @@ const updateGraphOnChange = store => {
  * Save selected state properties to window.localStorage
  * @param {object} state Redux state snapshot
  */
-const saveStateToLocalStorage = state => {
+const saveStateToLocalStorage = (state) => {
   saveState({
     node: {
-      disabled: pruneFalseyKeys(state.node.disabled)
+      disabled: pruneFalseyKeys(state.node.disabled),
     },
     nodeType: {
-      disabled: state.nodeType.disabled
+      disabled: state.nodeType.disabled,
     },
     pipeline: {
-      active: state.pipeline.active
+      active: state.pipeline.active,
     },
     layer: {
-      visible: state.layer.visible
+      visible: state.layer.visible,
     },
     tag: {
-      enabled: state.tag.enabled
+      enabled: state.tag.enabled,
     },
     textLabels: state.textLabels,
     theme: state.theme,
     visible: state.visible,
-    flags: state.flags
+    flags: state.flags,
   });
 };
 

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -16,7 +16,7 @@ export const createInitialState = () => ({
   loading: {
     graph: false,
     pipeline: false,
-    node: false
+    node: false,
   },
   visible: {
     graph: true,
@@ -27,9 +27,9 @@ export const createInitialState = () => ({
     sidebar: true,
     themeBtn: true,
     miniMapBtn: true,
-    miniMap: true
+    miniMap: true,
   },
-  zoom: {}
+  zoom: {},
 });
 
 /**
@@ -38,9 +38,9 @@ export const createInitialState = () => ({
  * @param {object} state Initial/extant state
  * @return {object} Combined state from localStorage
  */
-export const mergeLocalStorage = state => {
+export const mergeLocalStorage = (state) => {
   const localStorageState = loadState();
-  Object.keys(localStorageState).forEach(key => {
+  Object.keys(localStorageState).forEach((key) => {
     if (!state[key]) {
       delete localStorageState[key];
     }
@@ -76,14 +76,14 @@ export const preparePipelineState = (data, applyFixes) => {
  * @param {object} props Props passed to App component
  * @return {object} Updated initial state
  */
-export const prepareNonPipelineState = props => {
+export const prepareNonPipelineState = (props) => {
   const state = mergeLocalStorage(createInitialState());
 
   return {
     ...state,
     flags: { ...state.flags, ...getFlagsFromUrl() },
     theme: props.theme || state.theme,
-    visible: { ...state.visible, ...props.visible }
+    visible: { ...state.visible, ...props.visible },
   };
 };
 
@@ -95,7 +95,7 @@ export const prepareNonPipelineState = props => {
  */
 const getInitialState = (props = {}) => ({
   ...prepareNonPipelineState(props),
-  ...preparePipelineState(props.data, props.data !== 'json')
+  ...preparePipelineState(props.data, props.data !== 'json'),
 });
 
 export default getInitialState;

--- a/src/store/initial-state.test.js
+++ b/src/store/initial-state.test.js
@@ -2,7 +2,7 @@ import getInitialState, {
   createInitialState,
   mergeLocalStorage,
   preparePipelineState,
-  prepareNonPipelineState
+  prepareNonPipelineState,
 } from './initial-state';
 import { saveState } from './helpers';
 import animals from '../utils/data/animals.mock.json';
@@ -18,14 +18,14 @@ describe('mergeLocalStorage', () => {
     const localStorageValues = {
       textLabels: false,
       theme: 'light',
-      tag: { enabled: 'medium' }
+      tag: { enabled: 'medium' },
     };
     saveState(localStorageValues);
     expect(
       mergeLocalStorage({
         textLabels: true,
         theme: 'dark',
-        tag: { enabled: 'large' }
+        tag: { enabled: 'large' },
       })
     ).toMatchObject(localStorageValues);
     window.localStorage.clear();
@@ -34,7 +34,7 @@ describe('mergeLocalStorage', () => {
   it('does not add values if localStorage keys do not match state values', () => {
     const extraValues = {
       additional: 1,
-      props: '2'
+      props: '2',
     };
     expect(mergeLocalStorage(extraValues)).toMatchObject(extraValues);
   });
@@ -50,7 +50,7 @@ describe('mergeLocalStorage', () => {
 describe('preparePipelineState', () => {
   const localStorageState = {
     node: { disabled: { abc123: true } },
-    pipeline: { active: 'unknown pipeline id' }
+    pipeline: { active: 'unknown pipeline id' },
   };
 
   it('applies localStorage values on top of normalised pipeline data', () => {
@@ -80,8 +80,8 @@ describe('prepareNonPipelineState', () => {
     // In this case, location.href is not provided
     expect(prepareNonPipelineState({ data: animals })).toMatchObject({
       flags: {
-        oldgraph: expect.any(Boolean)
-      }
+        oldgraph: expect.any(Boolean),
+      },
     });
   });
 
@@ -94,7 +94,7 @@ describe('prepareNonPipelineState', () => {
 
   it('overrides visible with values from prop', () => {
     const props = {
-      visible: { miniMap: true, sidebar: false, themeBtn: false }
+      visible: { miniMap: true, sidebar: false, themeBtn: false },
     };
     expect(prepareNonPipelineState({ data: animals, ...props })).toMatchObject(
       props
@@ -122,8 +122,8 @@ describe('getInitialState', () => {
         exportBtn: true,
         labelBtn: true,
         layerBtn: true,
-        themeBtn: true
-      }
+        themeBtn: true,
+      },
     });
   });
 
@@ -132,18 +132,18 @@ describe('getInitialState', () => {
       getInitialState({
         ...props,
         theme: 'light',
-        visible: { themeBtn: false }
+        visible: { themeBtn: false },
       })
     ).toMatchObject({
       theme: 'light',
-      visible: { labelBtn: true, themeBtn: false }
+      visible: { labelBtn: true, themeBtn: false },
     });
   });
 
   it('uses localstorage values instead of defaults if provided', () => {
     const storeValues = {
       textLabels: false,
-      theme: 'light'
+      theme: 'light',
     };
     saveState(storeValues);
     expect(getInitialState(props)).toMatchObject(storeValues);
@@ -153,7 +153,7 @@ describe('getInitialState', () => {
   it('uses prop values instead of localstorage if provided', () => {
     saveState({ theme: 'light' });
     expect(getInitialState({ ...props, theme: 'dark' })).toMatchObject({
-      theme: 'dark'
+      theme: 'dark',
     });
     window.localStorage.clear();
   });

--- a/src/store/load-data.js
+++ b/src/store/load-data.js
@@ -20,7 +20,7 @@ const loadJsonData = (path = getUrl('main'), fallback = {}) =>
       );
     }
 
-    return new Promise(resolve => resolve(fallback));
+    return new Promise((resolve) => resolve(fallback));
   });
 
 export default loadJsonData;

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -7,7 +7,7 @@ import { arrayToObject } from '../utils';
 export const createInitialPipelineState = () => ({
   pipeline: {
     ids: [],
-    name: {}
+    name: {},
   },
   node: {
     ids: [],
@@ -25,33 +25,33 @@ export const createInitialPipelineState = () => ({
     docstring: {},
     parameters: {},
     filepath: {},
-    datasetType: {}
+    datasetType: {},
   },
   nodeType: {
     ids: ['task', 'data', 'parameters'],
     name: {
       data: 'Datasets',
       task: 'Nodes',
-      parameters: 'Parameters'
+      parameters: 'Parameters',
     },
-    disabled: {}
+    disabled: {},
   },
   edge: {
     ids: [],
     sources: {},
-    targets: {}
+    targets: {},
   },
   layer: {
     ids: [],
     name: {},
-    visible: true
+    visible: true,
   },
   tag: {
     ids: [],
     name: {},
     active: {},
-    enabled: {}
-  }
+    enabled: {},
+  },
 });
 
 /**
@@ -59,7 +59,7 @@ export const createInitialPipelineState = () => ({
  * @param {Object} data - The parsed data input
  * @return {Boolean} True if valid for formatting
  */
-const validateInput = data => {
+const validateInput = (data) => {
   if (!data) {
     throw new Error('No data provided to Kedro-Viz');
   }
@@ -90,7 +90,7 @@ const createEdgeID = (source, target) => [source, target].join('|');
  * @param {string} pipeline.id - Unique ID
  * @param {string} pipeline.name - Pipeline name
  */
-const addPipeline = state => pipeline => {
+const addPipeline = (state) => (pipeline) => {
   const { id } = pipeline;
   if (state.pipeline.name[id]) {
     return;
@@ -105,7 +105,7 @@ const addPipeline = state => pipeline => {
  * @param {string} type - 'data' or 'task'
  * @param {Array} tags - List of associated tags
  */
-const addNode = state => node => {
+const addNode = (state) => (node) => {
   const { id } = node;
   if (state.node.name[id]) {
     return;
@@ -132,7 +132,7 @@ const addNode = state => node => {
  * @param {Object} source - Parent node
  * @param {Object} target - Child node
  */
-const addEdge = state => ({ source, target }) => {
+const addEdge = (state) => ({ source, target }) => {
   const id = createEdgeID(source, target);
   if (state.edge.ids.includes(id)) {
     return;
@@ -146,7 +146,7 @@ const addEdge = state => ({ source, target }) => {
  * Add a new Tag if it doesn't already exist
  * @param {Object} tag - Tag object
  */
-const addTag = state => tag => {
+const addTag = (state) => (tag) => {
   const { id } = tag;
   state.tag.ids.push(id);
   state.tag.name[id] = tag.name;
@@ -156,7 +156,7 @@ const addTag = state => tag => {
  * Add a new Layer if it doesn't already exist
  * @param {Object} layer - Layer object
  */
-const addLayer = state => layer => {
+const addLayer = (state) => (layer) => {
   // using layer name as both layerId and name.
   // It futureproofs it if we need a separate layer ID in the future.
   state.layer.ids.push(layer);
@@ -168,7 +168,7 @@ const addLayer = state => layer => {
  * @param {Object} data Raw unformatted data input
  * @return {Object} Formatted, normalized state
  */
-const normalizeData = data => {
+const normalizeData = (data) => {
   const state = createInitialPipelineState();
 
   if (data === 'json') {

--- a/src/store/normalize-data.test.js
+++ b/src/store/normalize-data.test.js
@@ -19,13 +19,13 @@ describe('normalizeData', () => {
   it('should return initialState if input is "json"', () => {
     expect(normalizeData('json')).toEqual({
       ...initialState,
-      asyncDataSource: true
+      asyncDataSource: true,
     });
   });
 
   it('should not add tags if tags are not supplied', () => {
     const data = Object.assign({}, animals, { tags: undefined });
-    data.nodes.forEach(node => {
+    data.nodes.forEach((node) => {
       delete node.tags;
     });
     expect(normalizeData(data).tag.ids).toHaveLength(0);
@@ -33,7 +33,7 @@ describe('normalizeData', () => {
 
   it('should not add pipelines if pipelines are not supplied', () => {
     const data = Object.assign({}, animals, { pipelines: undefined });
-    data.nodes.forEach(node => {
+    data.nodes.forEach((node) => {
       delete node.pipelines;
     });
     expect(normalizeData(data).pipeline.ids).toHaveLength(0);
@@ -41,7 +41,7 @@ describe('normalizeData', () => {
 
   it('should not add an active pipeline if pipelines.length is 0', () => {
     const data = Object.assign({}, animals, { pipelines: [] });
-    data.nodes.forEach(node => {
+    data.nodes.forEach((node) => {
       node.pipelines = [];
     });
     expect(normalizeData(data).pipeline.active).toBe(undefined);
@@ -49,7 +49,7 @@ describe('normalizeData', () => {
 
   it('should not add layers if layers are not supplied', () => {
     const data = Object.assign({}, animals, { layers: undefined });
-    data.nodes.forEach(node => {
+    data.nodes.forEach((node) => {
       delete node.layer;
     });
     expect(normalizeData(data).layer.ids).toHaveLength(0);
@@ -67,14 +67,14 @@ describe('normalizeData', () => {
 
   it('should fall back to node.name if node.full_name is not supplied', () => {
     const data = Object.assign({}, animals);
-    data.nodes.forEach(node => {
+    data.nodes.forEach((node) => {
       node.name = node.name + '-name';
       delete node.full_name;
     });
     const state = normalizeData(data);
     expect(
       state.node.ids.every(
-        nodeID => state.node.fullName[nodeID] === state.node.name[nodeID]
+        (nodeID) => state.node.fullName[nodeID] === state.node.name[nodeID]
       )
     ).toBe(true);
   });

--- a/src/utils/data-source.js
+++ b/src/utils/data-source.js
@@ -35,7 +35,7 @@ export const getSourceID = () => {
  * @param {string} source Data source identifier
  * @return {object|string} Either raw data itself, or 'json'
  */
-export const getDataValue = source => {
+export const getDataValue = (source) => {
   switch (source) {
     case 'animals':
       // Use data from the 'animals' test dataset

--- a/src/utils/data-source.test.js
+++ b/src/utils/data-source.test.js
@@ -43,7 +43,7 @@ describe('getDataValue', () => {
         edges: expect.any(Array),
         nodes: expect.any(Array),
         tags: expect.any(Array),
-        layers: expect.any(Array)
+        layers: expect.any(Array),
       })
     );
   });

--- a/src/utils/flags.js
+++ b/src/utils/flags.js
@@ -9,7 +9,7 @@ export const Flags = {
    * @param {string} name The flag name to test
    * @returns {boolean} The result
    */
-  isDefined: name => Flags.names().includes(name),
+  isDefined: (name) => Flags.names().includes(name),
 
   /**
    * Returns an array of defined flag names
@@ -26,7 +26,7 @@ export const Flags = {
       (result, flag) =>
         Object.assign(result, { [flag]: flagsConfig[flag].default }),
       {}
-    )
+    ),
 };
 
 /**
@@ -34,7 +34,7 @@ export const Flags = {
  * @param {string=} url The URL (optional, default current location)
  * @returns {object} An object with flags and their values
  */
-export const getFlagsFromUrl = url => {
+export const getFlagsFromUrl = (url) => {
   const flags = {};
 
   let urlParams;
@@ -59,13 +59,13 @@ export const getFlagsFromUrl = url => {
  * @param {object} flagsEnabled An object mapping of flag status
  * @returns {string} The info message
  */
-export const getFlagsMessage = flagsEnabled => {
+export const getFlagsMessage = (flagsEnabled) => {
   const allNames = Flags.names();
 
   if (allNames.length > 0) {
     let info = 'Experimental features 🏄‍♂️\n';
 
-    allNames.forEach(name => {
+    allNames.forEach((name) => {
       if (flagsConfig[name].private) {
         return;
       }

--- a/src/utils/flags.test.js
+++ b/src/utils/flags.test.js
@@ -6,7 +6,7 @@ const testFlagDescription = 'testflag description';
 const privateFlagDescription = 'private flag description';
 const flagsEnabled = {
   [testFlagName]: true,
-  [privateFlagName]: true
+  [privateFlagName]: true,
 };
 
 jest.mock('../config', () => ({
@@ -16,15 +16,15 @@ jest.mock('../config', () => ({
       description: 'testflag description',
       default: false,
       private: false,
-      icon: '🤖'
+      icon: '🤖',
     },
     privateflag: {
       description: 'private flag description',
       default: true,
       private: true,
-      icon: '🙊'
-    }
-  }
+      icon: '🙊',
+    },
+  },
 }));
 
 describe('flags', () => {
@@ -32,17 +32,17 @@ describe('flags', () => {
     expect(
       getFlagsFromUrl(`https://localhost:4141/?${testFlagName}=true`)
     ).toEqual({
-      [testFlagName]: true
+      [testFlagName]: true,
     });
 
     expect(
       getFlagsFromUrl(`https://localhost:4141/?${testFlagName}=1`)
     ).toEqual({
-      [testFlagName]: true
+      [testFlagName]: true,
     });
 
     expect(getFlagsFromUrl(`https://localhost:4141/?${testFlagName}`)).toEqual({
-      [testFlagName]: true
+      [testFlagName]: true,
     });
   });
 
@@ -50,13 +50,13 @@ describe('flags', () => {
     expect(
       getFlagsFromUrl(`https://localhost:4141/?${testFlagName}=false`)
     ).toEqual({
-      [testFlagName]: false
+      [testFlagName]: false,
     });
 
     expect(
       getFlagsFromUrl(`https://localhost:4141/?${testFlagName}=0`)
     ).toEqual({
-      [testFlagName]: false
+      [testFlagName]: false,
     });
   });
 
@@ -80,7 +80,7 @@ describe('flags', () => {
   it('Flags.defaults returns an object mapping flag defaults', () => {
     expect(Flags.defaults()).toEqual({
       [testFlagName]: false,
-      [privateFlagName]: true
+      [privateFlagName]: true,
     });
   });
 });

--- a/src/utils/graph/common.js
+++ b/src/utils/graph/common.js
@@ -66,28 +66,28 @@ export const angle = (a, b) => Math.atan2(a.y - b.y, a.x - b.x);
  * @param {object} node The node
  * @returns {number} The left edge position
  */
-export const nodeLeft = node => node.x - node.width * 0.5;
+export const nodeLeft = (node) => node.x - node.width * 0.5;
 
 /**
  * Returns the right edge x-position of the node
  * @param {object} node The node
  * @returns {number} The right edge position
  */
-export const nodeRight = node => node.x + node.width * 0.5;
+export const nodeRight = (node) => node.x + node.width * 0.5;
 
 /**
  * Returns the top edge y-position of the node
  * @param {object} node The node
  * @returns {number} The top edge position
  */
-export const nodeTop = node => node.y - node.height * 0.5;
+export const nodeTop = (node) => node.y - node.height * 0.5;
 
 /**
  * Returns the bottom edge y-position of the node
  * @param {object} node The node
  * @returns {number} The bottom edge position
  */
-export const nodeBottom = node => node.y + node.height * 0.5;
+export const nodeBottom = (node) => node.y + node.height * 0.5;
 
 /**
  * Finds the rows formed by nodes given the their positions in Y.
@@ -96,7 +96,7 @@ export const nodeBottom = node => node.y + node.height * 0.5;
  * @param {array} nodes The input nodes
  * @returns {array} The sorted rows of nodes
  */
-export const groupByRow = nodes => {
+export const groupByRow = (nodes) => {
   const rows = {};
 
   // Create rows using node Y values
@@ -106,11 +106,11 @@ export const groupByRow = nodes => {
   }
 
   // Sort the set of rows accounting for keys being strings
-  const rowNumbers = Object.keys(rows).map(row => parseFloat(row));
+  const rowNumbers = Object.keys(rows).map((row) => parseFloat(row));
   rowNumbers.sort((a, b) => a - b);
 
   // Sort rows in order of X position if set. Break ties with ids for stability
-  const sortedRows = rowNumbers.map(row => rows[row]);
+  const sortedRows = rowNumbers.map((row) => rows[row]);
   for (let i = 0; i < sortedRows.length; i += 1) {
     sortedRows[i].sort((a, b) => compare(a.x, b.x, a.id, b.id));
 
@@ -158,7 +158,7 @@ export const offsetNode = (node, offset) => {
  * @returns {object} The edge
  */
 export const offsetEdge = (edge, offset) => {
-  edge.points.forEach(point => {
+  edge.points.forEach((point) => {
     point.x = point.x - offset.x;
     point.y = point.y - offset.y;
   });
@@ -187,6 +187,6 @@ export const nearestOnLine = (x, y, ax, ay, bx, by) => {
     ax,
     ay,
     bx,
-    by
+    by,
   };
 };

--- a/src/utils/graph/constraints.js
+++ b/src/utils/graph/constraints.js
@@ -18,7 +18,7 @@ export const rowConstraint = {
   strength: () => 1,
   weightA: () => 0,
   weightB: () => 1,
-  required: true
+  required: true,
 };
 
 /**
@@ -33,7 +33,7 @@ export const layerConstraint = {
   strength: () => 1,
   weightA: () => 0,
   weightB: () => 1,
-  required: false
+  required: false,
 };
 
 /**
@@ -46,11 +46,11 @@ export const parallelConstraint = {
   operator: equalTo,
   target: () => 0,
   // Lower degree nodes can be moved more freely than higher
-  strength: co =>
+  strength: (co) =>
     1 / Math.max(1, 0.5 * (co.a.targets.length + co.b.sources.length)),
   weightA: () => 0.5,
   weightB: () => 0.5,
-  required: false
+  required: false,
 };
 
 /**
@@ -71,7 +71,7 @@ export const crossingConstraint = {
   strength: (co, constants) => 1 / constants.basisX,
   weightA: () => 0.5,
   weightB: () => 0.5,
-  required: false
+  required: false,
 };
 
 /**
@@ -87,7 +87,7 @@ export const separationConstraint = {
   strength: () => 1,
   weightA: () => 0.5,
   weightB: () => 0.5,
-  required: false
+  required: false,
 };
 
 /**
@@ -102,5 +102,5 @@ export const separationStrictConstraint = {
   strength: () => 1,
   weightA: () => 0,
   weightB: () => 1,
-  required: true
+  required: true,
 };

--- a/src/utils/graph/graph.js
+++ b/src/utils/graph/graph.js
@@ -9,7 +9,7 @@ const defaultOptions = {
     layerSpaceY: 55,
     basisX: 1500,
     padding: 100,
-    iterations: 20
+    iterations: 20,
   },
   routing: {
     spaceX: 26,
@@ -20,8 +20,8 @@ const defaultOptions = {
     stemMinTarget: 5,
     stemMax: 20,
     stemSpaceSource: 6,
-    stemSpaceTarget: 10
-  }
+    stemSpaceTarget: 10,
+  },
 };
 
 /**
@@ -43,14 +43,14 @@ export const graph = (nodes, edges, layers, options = defaultOptions) => {
   routing({ nodes, edges, layers, ...options.routing });
 
   const size = bounds(nodes, options.layout.padding);
-  nodes.forEach(node => offsetNode(node, size.min));
-  edges.forEach(edge => offsetEdge(edge, size.min));
+  nodes.forEach((node) => offsetNode(node, size.min));
+  edges.forEach((edge) => offsetEdge(edge, size.min));
 
   return {
     nodes,
     edges,
     layers,
-    size
+    size,
   };
 };
 
@@ -88,7 +88,7 @@ const addNearestLayers = (nodes, layers) => {
       (res, layer) => ({ ...res, [layer]: true }),
       {}
     );
-    const hasValidLayer = node => Boolean(layersMap[node.layer]);
+    const hasValidLayer = (node) => Boolean(layersMap[node.layer]);
 
     for (const node of nodes) {
       const layerNode = findNodeBy(
@@ -107,7 +107,7 @@ const addNearestLayers = (nodes, layers) => {
  * @param {object} node The input node
  * @returns {array} The connected nodes
  */
-const targetThenSourceNodes = node =>
+const targetThenSourceNodes = (node) =>
   targetNodes(node).concat(sourceNodes(node));
 
 /**
@@ -115,14 +115,14 @@ const targetThenSourceNodes = node =>
  * @param {object} node The input node
  * @returns {array} The target nodes
  */
-const targetNodes = node => node.targets.map(edge => edge.targetNode);
+const targetNodes = (node) => node.targets.map((edge) => edge.targetNode);
 
 /**
  * Returns the list of source nodes directly connected to the given node
  * @param {object} node The input node
  * @returns {array} The source nodes
  */
-const sourceNodes = node => node.sources.map(edge => edge.sourceNode);
+const sourceNodes = (node) => node.sources.map((edge) => edge.sourceNode);
 
 /**
  * Returns the distance between the two nodes using their assigned rank
@@ -147,7 +147,7 @@ const findNodeBy = (node, successors, metric, accept, visited) => {
   visited = visited || {};
   visited[node.id] = true;
 
-  const next = successors(node).filter(node => !visited[node.id]);
+  const next = successors(node).filter((node) => !visited[node.id]);
   const nearest = next.sort(
     (nodeA, nodeB) => metric(node, nodeA) - metric(node, nodeB)
   );
@@ -155,7 +155,7 @@ const findNodeBy = (node, successors, metric, accept, visited) => {
 
   return (
     accepted[0] ||
-    nearest.map(node =>
+    nearest.map((node) =>
       findNodeBy(node, successors, metric, accept, visited)
     )[0]
   );
@@ -170,7 +170,7 @@ const findNodeBy = (node, successors, metric, accept, visited) => {
 const bounds = (nodes, padding) => {
   const size = {
     min: { x: Infinity, y: Infinity },
-    max: { x: -Infinity, y: -Infinity }
+    max: { x: -Infinity, y: -Infinity },
   };
 
   for (const node of nodes) {

--- a/src/utils/graph/graph.test.js
+++ b/src/utils/graph/graph.test.js
@@ -19,7 +19,7 @@ import {
   compare,
   offsetEdge,
   offsetNode,
-  nearestOnLine
+  nearestOnLine,
 } from './common';
 
 describe('graph', () => {
@@ -35,7 +35,7 @@ describe('graph', () => {
         size: expect.any(Object),
         nodes: mockNodes,
         edges: mockEdges,
-        layers: mockLayers
+        layers: mockLayers,
       })
     );
   });
@@ -46,17 +46,17 @@ describe('graph', () => {
   });
 
   it('sets valid x and y properties on all input nodes', () => {
-    result.nodes.forEach(node => {
+    result.nodes.forEach((node) => {
       expect(node.x).toEqual(expect.any(Number));
       expect(node.y).toEqual(expect.any(Number));
     });
   });
 
   it('sets valid points property on all input edges', () => {
-    result.edges.forEach(edge => {
+    result.edges.forEach((edge) => {
       expect(edge.points.length).toBeGreaterThanOrEqual(2);
 
-      edge.points.forEach(point => {
+      edge.points.forEach((point) => {
         expect(point.x).toEqual(expect.any(Number));
         expect(point.y).toEqual(expect.any(Number));
       });
@@ -139,15 +139,22 @@ describe('commmon', () => {
       { x: 0, y: 3 },
       { x: 1, y: 2 },
       { x: 0, y: 4 },
-      { x: 3, y: 2 }
+      { x: 3, y: 2 },
     ];
 
     expect(groupByRow(nodes)).toEqual([
-      [{ x: 0, y: 0, row: 0 }, { x: 1, y: 0, row: 0 }],
+      [
+        { x: 0, y: 0, row: 0 },
+        { x: 1, y: 0, row: 0 },
+      ],
       [{ x: 0, y: 1, row: 1 }],
-      [{ x: 1, y: 2, row: 2 }, { x: 2, y: 2, row: 2 }, { x: 3, y: 2, row: 2 }],
+      [
+        { x: 1, y: 2, row: 2 },
+        { x: 2, y: 2, row: 2 },
+        { x: 3, y: 2, row: 2 },
+      ],
       [{ x: 0, y: 3, row: 3 }],
-      [{ x: 0, y: 4, row: 4 }]
+      [{ x: 0, y: 4, row: 4 }],
     ]);
   });
 
@@ -216,9 +223,19 @@ describe('commmon', () => {
   });
 
   it('offsetEdge returns the edge with each point translated in-place', () => {
-    const edge = { points: [{ x: 5, y: -10 }, { x: -8, y: 2 }] };
+    const edge = {
+      points: [
+        { x: 5, y: -10 },
+        { x: -8, y: 2 },
+      ],
+    };
     const result = offsetEdge(edge, { x: 1, y: 2 });
-    expect(result).toEqual({ points: [{ x: 4, y: -12 }, { x: -9, y: 0 }] });
+    expect(result).toEqual({
+      points: [
+        { x: 4, y: -12 },
+        { x: -9, y: 0 },
+      ],
+    });
     expect(result).toBe(edge);
   });
 
@@ -227,7 +244,7 @@ describe('commmon', () => {
     expect(nearestOnLine(0, 0, 0, 0, 0, 0)).toEqual(
       expect.objectContaining({
         x: 0,
-        y: 0
+        y: 0,
       })
     );
 
@@ -235,7 +252,7 @@ describe('commmon', () => {
     expect(nearestOnLine(-1, -1, 0, 0, 1, 1)).toEqual(
       expect.objectContaining({
         x: 0,
-        y: 0
+        y: 0,
       })
     );
 
@@ -243,7 +260,7 @@ describe('commmon', () => {
     expect(nearestOnLine(2, 2, 0, 0, 1, 1)).toEqual(
       expect.objectContaining({
         x: 1,
-        y: 1
+        y: 1,
       })
     );
 
@@ -251,7 +268,7 @@ describe('commmon', () => {
     expect(nearestOnLine(0.5, 0.5, 0, 0, 1, 1)).toEqual(
       expect.objectContaining({
         x: 0.5,
-        y: 0.5
+        y: 0.5,
       })
     );
 
@@ -259,7 +276,7 @@ describe('commmon', () => {
     expect(nearestOnLine(0.5, 0, 0, 0, 1, 1)).toEqual(
       expect.objectContaining({
         x: 0.25,
-        y: 0.25
+        y: 0.25,
       })
     );
 
@@ -267,7 +284,7 @@ describe('commmon', () => {
     expect(nearestOnLine(0.5, 1, 0, 0, 1, 1)).toEqual(
       expect.objectContaining({
         x: 0.75,
-        y: 0.75
+        y: 0.75,
       })
     );
   });
@@ -301,7 +318,7 @@ describe('solver', () => {
       strength: () => 1,
       weightA: () => 0.5,
       weightB: () => 0.5,
-      required: false
+      required: false,
     };
 
     const constraintXA = {
@@ -311,8 +328,8 @@ describe('solver', () => {
         ...constraintBase,
         property: 'x',
         operator: equalTo,
-        target: () => 5
-      }
+        target: () => 5,
+      },
     };
 
     const constraintXB = {
@@ -322,8 +339,8 @@ describe('solver', () => {
         ...constraintBase,
         property: 'x',
         operator: greaterOrEqual,
-        target: () => 8
-      }
+        target: () => 8,
+      },
     };
 
     const constraintXC = {
@@ -333,8 +350,8 @@ describe('solver', () => {
         ...constraintBase,
         property: 'x',
         operator: greaterOrEqual,
-        target: () => 20
-      }
+        target: () => 20,
+      },
     };
 
     const constraintYA = {
@@ -344,8 +361,8 @@ describe('solver', () => {
         ...constraintBase,
         property: 'y',
         operator: equalTo,
-        target: () => 5
-      }
+        target: () => 5,
+      },
     };
 
     const constraintYB = {
@@ -355,8 +372,8 @@ describe('solver', () => {
         ...constraintBase,
         property: 'y',
         operator: greaterOrEqual,
-        target: () => 1
-      }
+        target: () => 1,
+      },
     };
 
     const constraintYC = {
@@ -366,8 +383,8 @@ describe('solver', () => {
         ...constraintBase,
         property: 'y',
         operator: equalTo,
-        target: () => 100
-      }
+        target: () => 100,
+      },
     };
 
     solve(
@@ -377,7 +394,7 @@ describe('solver', () => {
         constraintXC,
         constraintYA,
         constraintYB,
-        constraintYC
+        constraintYC,
       ],
       null,
       8,
@@ -404,7 +421,7 @@ describe('solver', () => {
       strength: () => 1,
       weightA: () => 0.5,
       weightB: () => 0.5,
-      required: true
+      required: true,
     };
 
     const constraintXA = {
@@ -414,8 +431,8 @@ describe('solver', () => {
         ...constraintBase,
         property: 'x',
         operator: equalTo,
-        target: () => 5
-      }
+        target: () => 5,
+      },
     };
 
     const constraintXB = {
@@ -425,8 +442,8 @@ describe('solver', () => {
         ...constraintBase,
         property: 'x',
         operator: greaterOrEqual,
-        target: () => 8
-      }
+        target: () => 8,
+      },
     };
 
     const constraintXC = {
@@ -436,8 +453,8 @@ describe('solver', () => {
         ...constraintBase,
         property: 'x',
         operator: greaterOrEqual,
-        target: () => 20
-      }
+        target: () => 20,
+      },
     };
 
     const constraintYA = {
@@ -447,8 +464,8 @@ describe('solver', () => {
         ...constraintBase,
         property: 'y',
         operator: equalTo,
-        target: () => 5
-      }
+        target: () => 5,
+      },
     };
 
     const constraintYB = {
@@ -458,8 +475,8 @@ describe('solver', () => {
         ...constraintBase,
         property: 'y',
         operator: greaterOrEqual,
-        target: () => 1
-      }
+        target: () => 1,
+      },
     };
 
     const constraintYC = {
@@ -469,8 +486,8 @@ describe('solver', () => {
         ...constraintBase,
         property: 'y',
         operator: equalTo,
-        target: () => 100
-      }
+        target: () => 100,
+      },
     };
 
     solve(
@@ -480,7 +497,7 @@ describe('solver', () => {
         constraintXC,
         constraintYA,
         constraintYB,
-        constraintYC
+        constraintYC,
       ],
       null,
       1,

--- a/src/utils/graph/index.js
+++ b/src/utils/graph/index.js
@@ -12,7 +12,7 @@ export const graphNew = ({ nodes, edges, layers }) => {
   return {
     ...result,
     size: { ...result.size, marginx: 100, marginy: 100 },
-    oldgraph: false
+    oldgraph: false,
   };
 };
 
@@ -28,14 +28,14 @@ export const graphDagre = ({ nodes, edges, layers }) => {
     ranker: hasLayers ? 'none' : null,
     ranksep: hasLayers ? 200 : 70,
     marginx: 40,
-    marginy: 40
+    marginy: 40,
   });
 
-  nodes.forEach(node => {
+  nodes.forEach((node) => {
     graph.setNode(node.id, node);
   });
 
-  edges.forEach(edge => {
+  edges.forEach((edge) => {
     graph.setEdge(edge.source, edge.target, edge);
   });
 
@@ -43,15 +43,15 @@ export const graphDagre = ({ nodes, edges, layers }) => {
   dagre.layout(graph);
 
   return {
-    nodes: graph.nodes().map(id => {
+    nodes: graph.nodes().map((id) => {
       const node = graph.node(id);
       return {
         ...node,
-        order: node.x + node.y * 9999
+        order: node.x + node.y * 9999,
       };
     }),
-    edges: graph.edges().map(id => graph.edge(id)),
+    edges: graph.edges().map((id) => graph.edge(id)),
     size: graph.graph(),
-    oldgraph: true
+    oldgraph: true,
   };
 };

--- a/src/utils/graph/layout.js
+++ b/src/utils/graph/layout.js
@@ -6,7 +6,7 @@ import {
   parallelConstraint,
   crossingConstraint,
   separationConstraint,
-  separationStrictConstraint
+  separationStrictConstraint,
 } from './constraints';
 
 /**
@@ -32,7 +32,7 @@ export const layout = ({
   spaceX,
   spaceY,
   layerSpaceY,
-  iterations
+  iterations,
 }) => {
   const layerConstraints = [];
   const crossingConstraints = [];
@@ -52,27 +52,29 @@ export const layout = ({
     spaceX,
     spaceY,
     basisX,
-    layerSpace: (spaceY + layerSpaceY) * 0.5
+    layerSpace: (spaceY + layerSpaceY) * 0.5,
   };
 
   // Constraints in Y formed by the edges of the graph
-  const rowConstraints = edges.map(edge => ({
+  const rowConstraints = edges.map((edge) => ({
     base: rowConstraint,
     a: edge.targetNode,
-    b: edge.sourceNode
+    b: edge.sourceNode,
   }));
 
   // Constraints in Y separating nodes into layers if specified
   if (layers) {
     const layerNames = Object.values(layers);
-    let layerNodes = nodes.filter(node => node.nearestLayer === layerNames[0]);
+    let layerNodes = nodes.filter(
+      (node) => node.nearestLayer === layerNames[0]
+    );
 
     // For each defined layer
     for (let i = 0; i < layerNames.length - 1; i += 1) {
       const layer = layerNames[i];
       const nextLayer = layerNames[i + 1];
       const nextLayerNodes = nodes.filter(
-        node => node.nearestLayer === nextLayer
+        (node) => node.nearestLayer === nextLayer
       );
 
       // Create a temporary intermediary 'node'
@@ -83,7 +85,7 @@ export const layout = ({
         layerConstraints.push({
           base: layerConstraint,
           a: layerNode,
-          b: node
+          b: node,
         });
       }
 
@@ -92,7 +94,7 @@ export const layout = ({
         layerConstraints.push({
           base: layerConstraint,
           a: node,
-          b: layerNode
+          b: layerNode,
         });
       }
 
@@ -120,7 +122,7 @@ export const layout = ({
           a: edgeA.sourceNode,
           b: edgeB.sourceNode,
           edgeA: edgeA,
-          edgeB: edgeB
+          edgeB: edgeB,
         });
       }
 
@@ -131,7 +133,7 @@ export const layout = ({
           a: edgeA.targetNode,
           b: edgeB.targetNode,
           edgeA: edgeA,
-          edgeB: edgeB
+          edgeB: edgeB,
         });
       }
     }
@@ -142,7 +144,7 @@ export const layout = ({
     const constraint = {
       base: parallelConstraint,
       a: edge.sourceNode,
-      b: edge.targetNode
+      b: edge.targetNode,
     };
 
     parallelConstraints.push(constraint);
@@ -190,7 +192,7 @@ export const layout = ({
         separationConstraints.push({
           base: separationConstraint,
           a: rowNodes[j],
-          b: rowNodes[j + 1]
+          b: rowNodes[j + 1],
         });
       }
     }
@@ -223,7 +225,7 @@ export const layout = ({
         base: separationStrictConstraint,
         a: rowNodes[i + 1],
         b: rowNodes[i],
-        separation: targetSeparation
+        separation: targetSeparation,
       });
     }
   }
@@ -271,7 +273,7 @@ const expandDenseRows = (edges, rows, spaceY) => {
  * @param {array} edges The input edges
  * @returns {array} The density of each row
  */
-const rowDensity = edges => {
+const rowDensity = (edges) => {
   const rows = {};
 
   for (const edge of edges) {

--- a/src/utils/graph/routing.js
+++ b/src/utils/graph/routing.js
@@ -7,7 +7,7 @@ import {
   nodeLeft,
   nodeRight,
   nodeTop,
-  nodeBottom
+  nodeBottom,
 } from './common';
 
 /**
@@ -39,7 +39,7 @@ export const routing = ({
   stemMinTarget,
   stemMax,
   stemSpaceSource,
-  stemSpaceTarget
+  stemSpaceTarget,
 }) => {
   // Find the rows formed by nodes
   const rows = groupByRow(nodes);
@@ -90,7 +90,7 @@ export const routing = ({
       const rowExtended = [
         { ...firstNode, x: Number.MIN_SAFE_INTEGER },
         ...rows[l],
-        { ...firstNode, x: Number.MAX_SAFE_INTEGER }
+        { ...firstNode, x: Number.MAX_SAFE_INTEGER },
       ];
 
       // For each gap between each nodes on the row
@@ -132,16 +132,16 @@ export const routing = ({
       const offsetY = firstNode.height + spaceY;
       edge.points.push({
         x: nearestPoint.x + sourceOffsetX,
-        y: nearestPoint.y
+        y: nearestPoint.y,
       });
       edge.points.push({
         x: nearestPoint.x + sourceOffsetX,
-        y: nearestPoint.y + offsetY
+        y: nearestPoint.y + offsetY,
       });
 
       currentPoint = {
         x: nearestPoint.x,
-        y: nearestPoint.y + offsetY
+        y: nearestPoint.y + offsetY,
       };
     }
   }
@@ -203,32 +203,33 @@ export const routing = ({
     const sourceStem = [
       {
         x: source.x + sourceOffsetX,
-        y: nodeBottom(source)
+        y: nodeBottom(source),
       },
       {
         x: source.x + sourceOffsetX,
-        y: nodeBottom(source) + stemMinSource
+        y: nodeBottom(source) + stemMinSource,
       },
       {
         x: source.x + sourceOffsetX,
-        y: nodeBottom(source) + stemMinSource + Math.min(sourceOffsetY, stemMax)
-      }
+        y:
+          nodeBottom(source) + stemMinSource + Math.min(sourceOffsetY, stemMax),
+      },
     ];
 
     // Build the target stem for the edge
     const targetStem = [
       {
         x: target.x + targetOffsetX,
-        y: nodeTop(target) - stemMinTarget - Math.min(targetOffsetY, stemMax)
+        y: nodeTop(target) - stemMinTarget - Math.min(targetOffsetY, stemMax),
       },
       {
         x: target.x + targetOffsetX,
-        y: nodeTop(target) - stemMinTarget
+        y: nodeTop(target) - stemMinTarget,
       },
       {
         x: target.x + targetOffsetX,
-        y: nodeTop(target)
-      }
+        y: nodeTop(target),
+      },
     ];
 
     // Combine all points

--- a/src/utils/graph/solver.js
+++ b/src/utils/graph/solver.js
@@ -28,7 +28,7 @@ const key = (obj, key) => {
  * @param {function} operator The operator function
  * @returns {object|undefined} The kiwi.js operator
  */
-export const toStrictOperator = operator => {
+export const toStrictOperator = (operator) => {
   if (operator === equalTo) return kiwi.Operator.Eq;
   if (operator === greaterOrEqual) return kiwi.Operator.Ge;
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,7 +9,7 @@ import { pathRoot } from '../config';
  */
 export const arrayToObject = (array, callback) => {
   const newObject = {};
-  array.forEach(key => {
+  array.forEach((key) => {
     newObject[key] = callback(key);
   });
   return newObject;
@@ -53,6 +53,6 @@ export const unique = (d, i, arr) => arr.indexOf(d) === i;
  */
 export const changed = (props, objectA, objectB) => {
   return (
-    objectA && objectB && props.some(prop => objectA[prop] !== objectB[prop])
+    objectA && objectB && props.some((prop) => objectA[prop] !== objectB[prop])
   );
 };

--- a/src/utils/modifiers.test.js
+++ b/src/utils/modifiers.test.js
@@ -57,7 +57,7 @@ describe('modifiers classname utility', () => {
         type: 'mixed',
         big: true,
         small: false,
-        'very-big': true
+        'very-big': true,
       })
     ).toEqual(
       'test-name test-name--id-0 test-name--type-mixed test-name--big test-name--no-small test-name--very-big'

--- a/src/utils/random-data.js
+++ b/src/utils/random-data.js
@@ -23,7 +23,7 @@ const LAYERS = [
   'Primary',
   'Feature',
   'Model Input',
-  'Model Output'
+  'Model Output',
 ];
 
 /**
@@ -173,7 +173,7 @@ class Pipeline {
       pipelines: this.getNodePipelines(),
       tags: this.getRandomTags(),
       _sources: [],
-      _targets: []
+      _targets: [],
     };
     return node;
   }
@@ -241,11 +241,11 @@ class Pipeline {
 
     // Find the sorted list of node ranks
     const ranks = Object.keys(nodesByRank)
-      .map(rank => parseFloat(rank))
+      .map((rank) => parseFloat(rank))
       .sort((a, b) => a - b);
 
     // Gets a random node with the given rank index
-    const getRandomNodeAtRank = rankIndex => {
+    const getRandomNodeAtRank = (rankIndex) => {
       const rankValue = ranks[rankIndex];
       const rankNodes = nodesByRank[rankValue];
       const rankNodeIndex = this.utils.randomIndex(rankNodes.length);
@@ -270,7 +270,7 @@ class Pipeline {
         source: source.id,
         target: target.id,
         _sourceNode: source,
-        _targetNode: target
+        _targetNode: target,
       };
 
       edges.push(edge);
@@ -291,7 +291,7 @@ class Pipeline {
     const nodes = {};
 
     // Gets the total number of edges for the given node
-    const degree = node => node._sources.length + node._targets.length;
+    const degree = (node) => node._sources.length + node._targets.length;
 
     for (const edge of this.edges) {
       // Keep both nodes if they have enough combined connections
@@ -315,7 +315,7 @@ class Pipeline {
     return this.nodes
       .reduce((tags, node) => (node.tags ? tags.concat(node.tags) : tags), [])
       .filter(unique)
-      .map(tag => ({ name: tag, id: tag }));
+      .map((tag) => ({ name: tag, id: tag }));
   }
 
   /**
@@ -324,12 +324,12 @@ class Pipeline {
    */
   activeEdges() {
     const visibleNodes = arrayToObject(
-      this.nodes.map(node => node.id),
+      this.nodes.map((node) => node.id),
       () => true
     );
 
     return this.edges.filter(
-      edge => visibleNodes[edge.target] && visibleNodes[edge.source]
+      (edge) => visibleNodes[edge.target] && visibleNodes[edge.source]
     );
   }
 
@@ -352,13 +352,14 @@ class Pipeline {
 
     for (let rank = 0; rank < sortedNodes.length; rank++) {
       for (const id of sortedNodes[rank]) {
-        const node = this.nodes.find(node => node.id === id);
+        const node = this.nodes.find((node) => node.id === id);
         node.rank = rank;
         node.type = this.getType(node);
         node.name = this.getNodeName(node.type);
-        node.full_name = `${node.layer}_${node.type}_${node.rank}_${
-          node.name
-        }`.replace(/\s/g, '_');
+        node.full_name = `${node.layer}_${node.type}_${node.rank}_${node.name}`.replace(
+          /\s/g,
+          '_'
+        );
       }
     }
   }
@@ -391,8 +392,8 @@ class Pipeline {
       edges: this.edges,
       layers: LAYERS,
       nodes: this.nodes,
-      pipelines: this.pipelines.map(name => ({ id: name, name })),
-      tags: this.tags
+      pipelines: this.pipelines.map((name) => ({ id: name, name })),
+      tags: this.tags,
     };
   }
 }

--- a/src/utils/random-utils.js
+++ b/src/utils/random-utils.js
@@ -6,7 +6,7 @@ import seedrandom from 'seedrandom';
  * @param {number} length Hash/ID length
  * @return string
  */
-export const generateHash = length => {
+export const generateHash = (length) => {
   const result = [];
   const characters =
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
@@ -50,7 +50,7 @@ export const getSeedFromURL = () => {
  * Get an array of numbers
  * @param {number} n Length of the array
  */
-export const getNumberArray = n => Array.from(Array(n).keys());
+export const getNumberArray = (n) => Array.from(Array(n).keys());
 
 export const LOREM_IPSUM = 'lorem ipsum dolor sit amet consectetur adipiscing elit vestibulum id turpis nunc nulla vitae diam dignissim fermentum elit sit amet viverra libero quisque condimentum pellentesque convallis sed consequat neque ac rhoncus finibus'.split(
   ' '
@@ -68,13 +68,13 @@ const randomUtils = () => {
    * Get a random number between 0 to n-1, inclusive
    * @param {number} n Max number
    */
-  const randomIndex = n => Math.floor(random() * n);
+  const randomIndex = (n) => Math.floor(random() * n);
 
   /**
    * Get a random number between 1 to n, inclusive
    * @param {number} n Max number
    */
-  const randomNumber = n => Math.ceil(random() * n);
+  const randomNumber = (n) => Math.ceil(random() * n);
 
   /**
    * Get a random number between min and max, inclusive
@@ -87,7 +87,7 @@ const randomUtils = () => {
    * Get a random datum from an array
    * @param {Array} range The array to select a random item from
    */
-  const getRandom = range => range[randomIndex(range.length)];
+  const getRandom = (range) => range[randomIndex(range.length)];
 
   /**
    * Generate a random latin name
@@ -127,7 +127,7 @@ const randomUtils = () => {
     randomNumberBetween,
     getRandom,
     getRandomName,
-    getRandomSelection
+    getRandomSelection,
   };
 };
 

--- a/src/utils/random-utils.test.js
+++ b/src/utils/random-utils.test.js
@@ -6,7 +6,7 @@ const {
   randomNumberBetween,
   getRandom,
   getRandomName,
-  getRandomSelection
+  getRandomSelection,
 } = randomUtils();
 
 describe('utils', () => {
@@ -117,7 +117,9 @@ describe('utils', () => {
     });
 
     it('returns an array of items that were all contained in the original dataset', () => {
-      expect(getRandomSelection(arr, 4).every(d => arr.includes(d))).toBe(true);
+      expect(getRandomSelection(arr, 4).every((d) => arr.includes(d))).toBe(
+        true
+      );
     });
 
     it('does not return duplicates', () => {

--- a/src/utils/state.mock.js
+++ b/src/utils/state.mock.js
@@ -16,17 +16,17 @@ import { graphNew, graphDagre } from './graph';
  * by running the asynchronous actions synchronously
  * @param {Object} props
  */
-export const prepareState = props => {
+export const prepareState = (props) => {
   const initialState = getInitialState(props);
   const actions = [
     // Set fontLoaded = true:
     () => updateFontLoaded(true),
     // Precalculate graph layout:
-    state => {
+    (state) => {
       const layout = state.flags.oldgraph ? graphDagre : graphNew;
       const graph = layout(getGraphInput(state));
       return updateGraph(graph);
-    }
+    },
   ];
   return actions.reduce(
     (state, action) => reducer(state, action(state)),
@@ -40,7 +40,7 @@ export const prepareState = props => {
 export const mockState = {
   json: prepareState({ data: 'json' }),
   demo: prepareState({ data: demo }),
-  animals: prepareState({ data: animals })
+  animals: prepareState({ data: animals }),
 };
 
 /**
@@ -66,5 +66,5 @@ export const setup = {
    * @param {Object} Component A React component
    * @param {Object} props React component props
    */
-  shallow: (Component, props = {}) => shallow(<Component {...props} />)
+  shallow: (Component, props = {}) => shallow(<Component {...props} />),
 };

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -7,11 +7,7 @@ describe('utils', () => {
     });
 
     it('returns an object with properties', () => {
-      const callback = foo =>
-        foo
-          .split('')
-          .reverse()
-          .join('');
+      const callback = (foo) => foo.split('').reverse().join('');
       expect(arrayToObject(['foo'], callback)).toEqual({ foo: 'oof' });
     });
   });

--- a/src/utils/view.js
+++ b/src/utils/view.js
@@ -19,10 +19,10 @@ export const viewing = ({
   wrapper,
   onViewChanged,
   onViewEnd,
-  allowUserInput = true
+  allowUserInput = true,
 }) => {
   const zoom = d3Zoom()
-    .on('zoom', event => {
+    .on('zoom', (event) => {
       const transform = event.transform;
 
       // Ignore invalid transforms
@@ -50,7 +50,7 @@ export const viewing = ({
   return {
     zoom,
     container,
-    wrapper
+    wrapper,
   };
 };
 
@@ -83,7 +83,7 @@ export const isInvalidTransform = ({ x, y, k }) =>
  * @param {Object} view The view
  * @returns {Object} The view transform
  */
-export const getViewTransform = view => {
+export const getViewTransform = (view) => {
   const transform = zoomTransform(view.wrapper.current);
   return isInvalidTransform(transform) ? origin : negateTransform(transform);
 };
@@ -95,7 +95,7 @@ export const getViewTransform = view => {
  * @param {Object} transform The transform to negate
  * @returns {Object} The new transform
  */
-const negateTransform = transform =>
+const negateTransform = (transform) =>
   // This ensures +0 instead of -0
   origin.translate(-transform.x || 0, -transform.y || 0).scale(transform.k);
 
@@ -108,7 +108,10 @@ const negateTransform = transform =>
 export const setViewExtents = (view, { translate, scale }) => {
   if (translate) {
     const { minX, minY, maxX, maxY } = translate;
-    view.zoom.translateExtent([[minX, minY], [maxX, maxY]]);
+    view.zoom.translateExtent([
+      [minX, minY],
+      [maxX, maxY],
+    ]);
   }
 
   if (scale) {
@@ -122,7 +125,7 @@ export const setViewExtents = (view, { translate, scale }) => {
  * @param {Object} view The view
  * @returns {Object} The view extents
  */
-export const getViewExtents = view => {
+export const getViewExtents = (view) => {
   const scale = view.zoom.scaleExtent();
   const translate = view.zoom.translateExtent();
   return {
@@ -130,9 +133,9 @@ export const getViewExtents = view => {
       minX: translate[0][0],
       minY: translate[0][1],
       maxX: translate[1][0],
-      maxY: translate[1][1]
+      maxY: translate[1][1],
     },
-    scale: { minK: scale[0], maxK: scale[1] }
+    scale: { minK: scale[0], maxK: scale[1] },
   };
 };
 
@@ -142,13 +145,13 @@ export const getViewExtents = view => {
  * @param {Object} view The view
  * @returns {Object} The viewport extents
  */
-export const getViewport = view => {
+export const getViewport = (view) => {
   const viewport = view.zoom.extent()(select(view.container.current));
   return {
     top: viewport[0][1],
     left: viewport[0][0],
     bottom: viewport[1][1],
-    right: viewport[1][0]
+    right: viewport[1][0],
   };
 };
 
@@ -160,7 +163,7 @@ export const getViewport = view => {
 export const setViewport = (view, viewport) => {
   view.zoom.extent([
     [viewport.left, viewport.top],
-    [viewport.right, viewport.bottom]
+    [viewport.right, viewport.bottom],
   ]);
 };
 
@@ -278,7 +281,7 @@ export const viewTransformToFit = ({
   objectHeight,
   minScaleX = 0,
   minScaleFocus = 0,
-  focusOffset = 0.8
+  focusOffset = 0.8,
 }) => {
   let scale = origin.k;
   let x = origin.x;

--- a/src/utils/view.test.js
+++ b/src/utils/view.test.js
@@ -13,7 +13,7 @@ import {
   setViewExtents,
   getViewExtents,
   getViewport,
-  setViewport
+  setViewport,
 } from './view';
 
 describe('view', () => {
@@ -33,7 +33,7 @@ describe('view', () => {
       container,
       wrapper,
       onViewChanged: jest.fn(),
-      onViewEnd: jest.fn()
+      onViewEnd: jest.fn(),
     });
 
     // Elements have no dimensions in Jest so set viewport manually
@@ -41,7 +41,7 @@ describe('view', () => {
       top: 0,
       left: 0,
       bottom: height,
-      right: width
+      right: width,
     });
 
     return view;
@@ -55,7 +55,7 @@ describe('view', () => {
         container,
         wrapper,
         onViewChanged: jest.fn(),
-        onViewEnd: jest.fn()
+        onViewEnd: jest.fn(),
       });
       expect(view.zoom).toBeInstanceOf(Function);
       expect(view.container).toBe(container);
@@ -116,7 +116,7 @@ describe('view', () => {
         top: 0,
         left: 0,
         bottom: 100,
-        right: 100
+        right: 100,
       });
     });
 
@@ -126,7 +126,7 @@ describe('view', () => {
         top: 50,
         left: -50,
         bottom: 100,
-        right: 150
+        right: 150,
       };
 
       setViewport(view, viewport);
@@ -238,12 +238,12 @@ describe('view', () => {
           minX: -110,
           minY: -120,
           maxX: 120,
-          maxY: 130
+          maxY: 130,
         },
         scale: {
           minK: 1,
-          maxK: 1.5
-        }
+          maxK: 1.5,
+        },
       };
 
       setViewExtents(view, extents);
@@ -287,12 +287,12 @@ describe('view', () => {
           minX: -Infinity,
           maxX: Infinity,
           minY: -Infinity,
-          maxY: Infinity
+          maxY: Infinity,
         },
         scale: {
           minK: 0,
-          maxK: Infinity
-        }
+          maxK: Infinity,
+        },
       });
     });
 
@@ -304,12 +304,12 @@ describe('view', () => {
           minX: -1,
           maxX: 2,
           minY: -3,
-          maxY: 4
+          maxY: 4,
         },
         scale: {
           minK: 0.5,
-          maxK: 0.6
-        }
+          maxK: 0.6,
+        },
       };
 
       setViewExtents(view, extents);
@@ -330,14 +330,14 @@ describe('view', () => {
         objectHeight: 300,
         minScaleX: 0.4,
         minScaleFocus,
-        focusOffset: 0.8
+        focusOffset: 0.8,
       });
 
       // Resulting transform should clamp to minimum scale and center
       expect(transform).toEqual({
         k: minScaleFocus,
         x: -50,
-        y: 60
+        y: 60,
       });
     });
 
@@ -352,14 +352,14 @@ describe('view', () => {
         objectHeight: 50,
         minScaleX: 0.4,
         minScaleFocus: 0.8,
-        focusOffset: 0.8
+        focusOffset: 0.8,
       });
 
       // Resulting transform should scale up and center
       expect(transform).toEqual({
         k: 2,
         x: -60,
-        y: -10
+        y: -10,
       });
     });
 
@@ -376,14 +376,14 @@ describe('view', () => {
         objectHeight: 500,
         minScaleX: 0.4,
         minScaleFocus,
-        focusOffset: 0.8
+        focusOffset: 0.8,
       });
 
       // Resulting transform should clamp to minimum focus scale and center on focus point
       expect(transform).toEqual({
         k: minScaleFocus,
         x: 290,
-        y: -4
+        y: -4,
       });
     });
 
@@ -398,14 +398,14 @@ describe('view', () => {
         objectHeight: 50,
         minScaleX,
         minScaleFocus: 0.8,
-        focusOffset: 0.8
+        focusOffset: 0.8,
       });
 
       // Resulting transform should clamp to minimum X scale and center
       expect(transform).toEqual({
         k: minScaleX,
         x: 90,
-        y: -50
+        y: -50,
       });
     });
   });

--- a/src/utils/worker.js
+++ b/src/utils/worker.js
@@ -17,17 +17,17 @@ const graphWorker = isTest
 /**
  * Emulate a web worker for testing purposes
  */
-const createMockWorker = worker => {
+const createMockWorker = (worker) => {
   if (!isTest) {
     return worker;
   }
   return () => {
     const mockWorker = {
-      terminate: () => {}
+      terminate: () => {},
     };
-    Object.keys(worker).forEach(name => {
-      mockWorker[name] = payload =>
-        new Promise(resolve => resolve(worker[name](payload)));
+    Object.keys(worker).forEach((name) => {
+      mockWorker[name] = (payload) =>
+        new Promise((resolve) => resolve(worker[name](payload)));
     });
     return mockWorker;
   };
@@ -47,7 +47,7 @@ export function preventWorkerQueues(worker, getJob) {
   let instance = worker();
   let running = false;
 
-  return payload => {
+  return (payload) => {
     if (running) {
       // If worker is already processing a job, cancel it and restart
       instance.terminate();
@@ -55,7 +55,7 @@ export function preventWorkerQueues(worker, getJob) {
     }
     running = true;
 
-    return getJob(instance, payload).then(response => {
+    return getJob(instance, payload).then((response) => {
       running = false;
       return response;
     });


### PR DESCRIPTION
## Description

The recent Prettier update to >v2 introduced some new config options - these are the most relevant:

1. [Trailing commas](https://prettier.io/docs/en/options.html#trailing-commas)
2. [Arrow Function Parentheses](https://prettier.io/docs/en/options.html#arrow-function-parentheses)

## Development notes

I've run the formatter over our entire codebase again, with 
```cli
npx prettier --write "src/**/*.js"
```

## QA notes

n/a

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
