### PR TITLE
[KED-2437] Fix minimum zoom level

### DIFF
--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -75,41 +75,95 @@ describe('FlowChart', () => {
   });
 
   it('applies expected view extents when all sidebars closed', () => {
-    const wrapper = setup.mount(
-      <FlowChart
-        chartSize={mockChartSize({
-          sidebarWidth: 0,
-          metaSidebarWidth: 0,
-          codeSidebarWidth: 0,
-        })}
-      />
-    );
+    // Simulate closed sidebars
+    const chartSize = mockChartSize({
+      sidebarWidth: 0,
+      metaSidebarWidth: 0,
+      codeSidebarWidth: 0,
+    });
 
+    const wrapper = setup.mount(<FlowChart chartSize={chartSize} />);
     const instance = wrapper.find('FlowChart').instance();
     const viewExtents = getViewExtents(instance.view);
 
-    expect(viewExtents.translate).toEqual({ minX: -500, minY: -500, maxX: 1044, maxY: 1553 });
-    expect(viewExtents.scale.minK).toBeCloseTo(0.777);
-    expect(viewExtents.scale.maxK).toBe(2);    
+    const margin = instance.MARGIN;
+    const minScale = instance.MIN_SCALE;
+    const maxScale = instance.MAX_SCALE;
+
+    // Assert expected constants
+    expect(margin).toEqual(500);
+    expect(minScale).toEqual(0.8);
+    expect(maxScale).toEqual(2);
+
+    const { width: chartWidth, height: chartHeight } = chartSize;
+    const { width: graphWidth, height: graphHeight } = instance.props.graphSize;
+
+    // Translate extent should only include margin and graph size
+    expect(viewExtents.translate.minX).toEqual(-margin);
+    expect(viewExtents.translate.minY).toEqual(-margin);
+    expect(viewExtents.translate.maxX).toEqual(graphWidth + margin);
+    expect(viewExtents.translate.maxY).toEqual(graphHeight + margin);
+
+    // The scale at which the full graph in view
+    const fullScale = Math.min(
+      chartWidth / (graphWidth || 1),
+      chartHeight / (graphHeight || 1)
+    );
+
+    // Scale extent should allow full graph in view
+    expect(viewExtents.scale.minK).toBeLessThanOrEqual(fullScale);
+    expect(viewExtents.scale.maxK).toEqual(maxScale);
   });
 
   it('applies expected view extents when all sidebars open', () => {
-    const wrapper = setup.mount(
-      <FlowChart
-        chartSize={mockChartSize({
-          sidebarWidth: 150,
-          metaSidebarWidth: 180,
-          codeSidebarWidth: 255,
-        })}
-      />
-    );
+    // Simulate open sidebars
+    const chartSize = mockChartSize({
+      sidebarWidth: 150,
+      metaSidebarWidth: 180,
+      codeSidebarWidth: 255,
+    });
 
+    const wrapper = setup.mount(<FlowChart chartSize={chartSize} />);
     const instance = wrapper.find('FlowChart').instance();
     const viewExtents = getViewExtents(instance.view);
 
-    expect(viewExtents.translate).toEqual({ minX: -650, minY: -500, maxX: 1479, maxY: 1553 });
-    expect(viewExtents.scale.minK).toBeCloseTo(0.777);
-    expect(viewExtents.scale.maxK).toBe(2);
+    const margin = instance.MARGIN;
+    const minScale = instance.MIN_SCALE;
+    const maxScale = instance.MAX_SCALE;
+
+    // Assert expected constants
+    expect(margin).toEqual(500);
+    expect(minScale).toEqual(0.8);
+    expect(maxScale).toEqual(2);
+
+    const {
+      width: chartWidth,
+      height: chartHeight,
+      sidebarWidth,
+      metaSidebarWidth,
+      codeSidebarWidth,
+    } = chartSize;
+
+    const { width: graphWidth, height: graphHeight } = instance.props.graphSize;
+
+    const leftSidebarOffset = sidebarWidth;
+    const rightSidebarOffset = (metaSidebarWidth + codeSidebarWidth);
+
+    // Translate extent should include left and right sidebars, margin and graph size
+    expect(viewExtents.translate.minX).toEqual(-margin - leftSidebarOffset);
+    expect(viewExtents.translate.minY).toEqual(-margin);
+    expect(viewExtents.translate.maxX).toEqual(graphWidth + margin + rightSidebarOffset);
+    expect(viewExtents.translate.maxY).toEqual(graphHeight + margin);
+
+    // The scale at which the full graph in view
+    const fullScale = Math.min(
+      chartWidth / (graphWidth || 1),
+      chartHeight / (graphHeight || 1)
+    );
+
+    // Scale extent should allow full graph in view
+    expect(viewExtents.scale.minK).toBeLessThanOrEqual(fullScale);
+    expect(viewExtents.scale.maxK).toEqual(maxScale);
   });
 
   it('resizes the chart if the window resizes', () => {

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -88,10 +88,9 @@ describe('FlowChart', () => {
     const instance = wrapper.find('FlowChart').instance();
     const viewExtents = getViewExtents(instance.view);
 
-    expect(viewExtents).toEqual({
-      translate: { minX: -500, minY: -500, maxX: 1044, maxY: 1553 },
-      scale: { minK: 0.8, maxK: 2 },
-    });
+    expect(viewExtents.translate).toEqual({ minX: -500, minY: -500, maxX: 1044, maxY: 1553 });
+    expect(viewExtents.scale.minK).toBeCloseTo(0.777);
+    expect(viewExtents.scale.maxK).toBe(2);    
   });
 
   it('applies expected view extents when all sidebars open', () => {
@@ -108,10 +107,9 @@ describe('FlowChart', () => {
     const instance = wrapper.find('FlowChart').instance();
     const viewExtents = getViewExtents(instance.view);
 
-    expect(viewExtents).toEqual({
-      translate: { minX: -650, minY: -500, maxX: 1479, maxY: 1553 },
-      scale: { minK: 0.8, maxK: 2 },
-    });
+    expect(viewExtents.translate).toEqual({ minX: -650, minY: -500, maxX: 1479, maxY: 1553 });
+    expect(viewExtents.scale.minK).toBeCloseTo(0.777);
+    expect(viewExtents.scale.maxK).toBe(2);
   });
 
   it('resizes the chart if the window resizes', () => {

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -147,7 +147,7 @@ describe('FlowChart', () => {
     const { width: graphWidth, height: graphHeight } = instance.props.graphSize;
 
     const leftSidebarOffset = sidebarWidth;
-    const rightSidebarOffset = (metaSidebarWidth + codeSidebarWidth);
+    const rightSidebarOffset = metaSidebarWidth + codeSidebarWidth;
 
     // Translate extent should include left and right sidebars, margin and graph size
     expect(viewExtents.translate.minX).toEqual(-margin - leftSidebarOffset);

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -35,8 +35,6 @@ export class FlowChart extends Component {
       tooltip: { visible: false },
     };
 
-    this.defaultTransform = origin;
-
     this.onViewChange = this.onViewChange.bind(this);
     this.onViewChangeEnd = this.onViewChangeEnd.bind(this);
 
@@ -283,26 +281,39 @@ export class FlowChart extends Component {
    */
   updateViewExtents(transform) {
     const { k: scale } = transform || getViewTransform(this.view);
+
     const {
       sidebarWidth = 0,
       metaSidebarWidth = 0,
       codeSidebarWidth = 0,
+      width: chartWidth = 0,
+      height: chartHeight = 0,
     } = this.props.chartSize;
-    const { width = 0, height = 0 } = this.props.graphSize;
+
+    const {
+      width: graphWidth = 0,
+      height: graphHeight = 0,
+    } = this.props.graphSize;
 
     const leftSidebarOffset = sidebarWidth / scale;
     const rightSidebarOffset = (metaSidebarWidth + codeSidebarWidth) / scale;
     const margin = this.MARGIN;
 
+    // Find the relative minimum scale to fit whole graph
+    const minScale = Math.min(
+      chartWidth / (graphWidth || 1),
+      chartHeight / (graphHeight || 1)
+    );
+
     setViewExtents(this.view, {
       translate: {
         minX: -leftSidebarOffset - margin,
-        maxX: width + margin + rightSidebarOffset,
+        maxX: graphWidth + margin + rightSidebarOffset,
         minY: -margin,
-        maxY: height + margin,
+        maxY: graphHeight + margin,
       },
       scale: {
-        minK: this.MIN_SCALE * this.defaultTransform.k,
+        minK: this.MIN_SCALE * minScale,
         maxK: this.MAX_SCALE,
       },
     });
@@ -355,7 +366,7 @@ export class FlowChart extends Component {
       : null;
 
     // Find a transform that fits everything in view
-    this.defaultTransform = viewTransformToFit({
+    const transform = viewTransformToFit({
       offset,
       focus,
       viewWidth: chartWidth,
@@ -373,7 +384,7 @@ export class FlowChart extends Component {
     // Apply transform ignoring extents
     setViewTransformExact(
       this.view,
-      this.defaultTransform,
+      transform,
       isFirstTransform ? 0 : this.DURATION,
       false
     );

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -12,7 +12,6 @@ import { getVisibleMetaSidebar } from '../../selectors/metadata';
 import { drawNodes, drawEdges, drawLayers, drawLayerNames } from './draw';
 import {
   viewing,
-  origin,
   isOrigin,
   viewTransformToFit,
   setViewTransform,

--- a/src/components/minimap/index.js
+++ b/src/components/minimap/index.js
@@ -8,7 +8,6 @@ import { getChartSize, getChartZoom } from '../../selectors/layout';
 import { getCentralNode, getLinkedNodes } from '../../selectors/linked-nodes';
 import {
   viewing,
-  origin,
   isOrigin,
   viewTransformToFit,
   getViewTransform,

--- a/src/components/minimap/index.js
+++ b/src/components/minimap/index.js
@@ -31,7 +31,6 @@ export class MiniMap extends Component {
     this.isPointerDown = false;
     this.isPointerInside = false;
     this.lastTransitionTime = 0;
-    this.defaultTransform = origin;
 
     this.containerRef = React.createRef();
     this.svgRef = React.createRef();
@@ -269,7 +268,7 @@ export class MiniMap extends Component {
     const offset = { x: padding * 0.5, y: padding * 0.5 };
 
     // Find a transform that fits everything in view
-    this.defaultTransform = viewTransformToFit({
+    const transform = viewTransformToFit({
       offset,
       viewWidth: mapWidth - padding,
       viewHeight: mapHeight - padding,
@@ -283,7 +282,7 @@ export class MiniMap extends Component {
     // Apply transform ignoring extents
     setViewTransformExact(
       this.view,
-      this.defaultTransform,
+      transform,
       isFirstTransform ? 0 : this.DURATION,
       false
     );


### PR DESCRIPTION
## Description

Fixes minimum zoom level back to its original behaviour, such that the whole graph can be made visible.

## Development notes

Implemented the fix, some tidying and updated tests.

## QA notes

Zoom out and ensure graph fits fully in view.

Test using different size graphs of different aspect ratios.

Compare to previous release.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
