### PR TITLE
[KED-2447] Fix node hover zoom bug

### DIFF
--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -290,7 +290,8 @@ describe('FlowChart', () => {
 
   it('maps state to props', () => {
     const expectedResult = {
-      centralNode: null,
+      clickedNode: expect.any(Object),
+      centralNode: expect.any(Object),
       chartSize: expect.any(Object),
       chartZoom: expect.any(Object),
       edges: expect.any(Array),

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -113,7 +113,7 @@ export class FlowChart extends Component {
       drawNodes.call(this, changed);
     }
 
-    if (changed('edges', 'nodes', 'layers', 'chartSize', 'centralNode')) {
+    if (changed('edges', 'nodes', 'layers', 'chartSize', 'clickedNode')) {
       this.resetView();
     } else {
       this.onChartZoomChanged(chartZoom);
@@ -347,7 +347,7 @@ export class FlowChart extends Component {
    * Zoom and scale to fit graph and any selected node in view
    */
   resetView() {
-    const { chartSize, graphSize, centralNode, nodes } = this.props;
+    const { chartSize, graphSize, clickedNode, nodes } = this.props;
     const { width: chartWidth, height: chartHeight } = chartSize;
     const { width: graphWidth, height: graphHeight } = graphSize;
 
@@ -360,8 +360,8 @@ export class FlowChart extends Component {
     const offset = { x: chartSize.sidebarWidth, y: 0 };
 
     // Use the selected node as focus point
-    const focus = centralNode
-      ? nodes.find((node) => node.id === centralNode)
+    const focus = clickedNode
+      ? nodes.find((node) => node.id === clickedNode)
       : null;
 
     // Find a transform that fits everything in view
@@ -548,6 +548,7 @@ const emptyNodes = [];
 const emptyGraphSize = {};
 
 export const mapStateToProps = (state, ownProps) => ({
+  clickedNode: state.node.clicked,
   centralNode: getCentralNode(state),
   chartSize: getChartSize(state),
   chartZoom: getChartZoom(state),


### PR DESCRIPTION
## Description

Fixes node hover zoom bug visible when 'lazy' feature flag is not enabled.

## Development notes

Changes flowchart to use specifically the  'clicked node' rather than 'central node' changes depending on context.

## QA notes

Test by hovering over a node when the  'lazy' feature flag is not enabled and also when it is enabled, ensuring that no zoom is triggered by hover in either case. Also check this on the `lib-test` build too.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
