### PR TITLE
[KED-2448] Improve node selected view panning behaviour

### DIFF
--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -372,7 +372,7 @@ export class FlowChart extends Component {
       viewHeight: chartHeight,
       objectWidth: graphWidth,
       objectHeight: graphHeight,
-      minScaleX: 0.4,
+      minScaleX: 0.2,
       minScaleFocus: 0.3,
       focusOffset: 0.8,
     });

--- a/src/utils/view.js
+++ b/src/utils/view.js
@@ -311,16 +311,18 @@ export const viewTransformToFit = ({
   x += (viewWidth - objectWidth * scale) * 0.5;
   y += (viewHeight - objectHeight * scale) * 0.5;
 
-  const isCropped =
-    viewWidth < objectWidth * scale || viewHeight < objectHeight * scale;
+  // When there is a focus point set
+  if (focus) {
+    // Find which axes would become cropped
+    const isCroppedX = viewWidth < objectWidth * scale;
+    const isCroppedY = viewHeight < objectHeight * scale;
 
-  // When there is a focus point but object does not fit fully in view
-  if (focus && isCropped) {
     const objectCenterX = objectWidth * 0.5;
     const objectCenterY = objectHeight * 0.5;
 
-    const focusCenterOffsetX = objectCenterX - focus.x;
-    const focusCenterOffsetY = objectCenterY - focus.y;
+    // Offset on the cropped axes only
+    const focusCenterOffsetX = isCroppedX ? objectCenterX - focus.x : 0;
+    const focusCenterOffsetY = isCroppedY ? objectCenterY - focus.y : 0;
 
     const focusRelativeOffsetX = focusCenterOffsetX / objectWidth;
     const focusRelativeOffsetY = focusCenterOffsetY / objectHeight;

--- a/src/utils/view.js
+++ b/src/utils/view.js
@@ -311,7 +311,8 @@ export const viewTransformToFit = ({
   x += (viewWidth - objectWidth * scale) * 0.5;
   y += (viewHeight - objectHeight * scale) * 0.5;
 
-  const isCropped = scaleXClamp !== scaleX;
+  const isCropped =
+    viewWidth < objectWidth * scale || viewHeight < objectHeight * scale;
 
   // When there is a focus point but object does not fit fully in view
   if (focus && isCropped) {

--- a/src/utils/view.test.js
+++ b/src/utils/view.test.js
@@ -334,11 +334,11 @@ describe('view', () => {
       });
 
       // Resulting transform should clamp to minimum scale and center
-      expect(transform).toEqual({
-        k: minScaleFocus,
-        x: -50,
-        y: 60,
-      });
+      expect(transform.k).toEqual(minScaleFocus);
+
+      // In this example offset is fractional
+      expect(transform.x).toBeCloseTo(-43.333);
+      expect(transform.y).toBeCloseTo(6.666);
     });
 
     it('returns expected transform when example must be scaled up to fit', () => {

--- a/src/utils/view.test.js
+++ b/src/utils/view.test.js
@@ -336,8 +336,8 @@ describe('view', () => {
       // Resulting transform should clamp to minimum scale and center
       expect(transform.k).toEqual(minScaleFocus);
 
-      // In this example offset is fractional
-      expect(transform.x).toBeCloseTo(-43.333);
+      // In this example offset may be fractional
+      expect(transform.x).toEqual(-50);
       expect(transform.y).toBeCloseTo(6.666);
     });
 


### PR DESCRIPTION
## Description

Improve selected node view behaviour so panning only occurs when graph is cropped.

## Development notes

- Changes crop detection in view fit function to handle view width and height crops independently
- Allows a smaller zoom level on zoom reset / fit to reduce the need for above in practice

## QA notes

Test by selecting a node at various browser sizes, with various graph sizes, with various open panels.

Check that panning to selected node only occurs when the graph would be cropped by sidebars.
A slight zoom in may occur still when the scale does not meet a minimum.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
