### PR TITLE
[KED-2446] Add new 'sizewarning' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The following flags are available to toggle experimental features:
 - `code` - From release v3.9.0. Enable showing the code panel from a node's metadata panel. (default `false`)
 - `lazy` - From release v3.8.0. Improved sidebar performance. (default `false`)
 - `oldgraph` - From release v3.8.0. Display old version of graph (dagre algorithm) without improved graphing algorithm. (default `false`)
+- `sizewarning` - From release v3.9.1. Show a warning before rendering very large graphs. (default `true`)
 
 Note that newgraph has been removed from v3.8.0 onwards and is now the default functionality. Should there be issues with your project, see the oldgraph flag above.
 

--- a/src/config.js
+++ b/src/config.js
@@ -41,6 +41,11 @@ export const flags = {
     default: false,
     icon: '{}',
   },
+  sizewarning: {
+    description: 'Show a warning before rendering very large graphs',
+    default: true,
+    icon: '⚠️',
+  },
 };
 
 export const sidebar = {

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -12,6 +12,7 @@ import {
 } from '../config';
 
 const getOldgraphFlag = (state) => state.flags.oldgraph;
+const getSizeWarningFlag = (state) => state.flags.sizewarning;
 const getVisibleSidebar = (state) => state.visible.sidebar;
 const getVisibleCode = (state) => state.visible.code;
 const getFontLoaded = (state) => state.fontLoaded;
@@ -23,11 +24,18 @@ const getChartSizeState = (state) => state.chartSize;
  * Decide whether to show the large graph warning
  */
 export const getTriggerLargeGraphWarning = createSelector(
-  [getVisibleNodes, getVisibleEdges, getIgnoreLargeWarning, getGraphHasNodes],
-  (nodes, edges, ignoreLargeWarning, graphHasNodes) =>
+  [
+    getVisibleNodes,
+    getVisibleEdges,
+    getIgnoreLargeWarning,
+    getGraphHasNodes,
+    getSizeWarningFlag,
+  ],
+  (nodes, edges, ignoreLargeWarning, graphHasNodes, sizeWarningFlag) =>
     nodes.length + 1.5 * edges.length > largeGraphThreshold &&
     !ignoreLargeWarning &&
-    !graphHasNodes
+    !graphHasNodes &&
+    sizeWarningFlag
 );
 
 /**

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -23,7 +23,8 @@ const getChartSizeState = (state) => state.chartSize;
 /**
  * Show the large graph warning only if there are sufficient nodes + edges,
  * and it hasn't been toggled off (by clicking the Render Anyway button), and
- * the graph hasn't already previously rendered, and the flag isn't set to false.
+ * the graph layout hasn't already previously been calculated (due to a user
+ * filtering the graph to a smaller subset), and the flag isn't set to false.
  */
 export const getTriggerLargeGraphWarning = createSelector(
   [

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -21,7 +21,9 @@ const getGraphHasNodes = (state) => Boolean(state.graph?.nodes?.length);
 const getChartSizeState = (state) => state.chartSize;
 
 /**
- * Decide whether to show the large graph warning
+ * Show the large graph warning only if there are sufficient nodes + edges,
+ * and it hasn't been toggled off (by clicking the Render Anyway button), and
+ * the graph hasn't already previously rendered, and the flag isn't set to false.
  */
 export const getTriggerLargeGraphWarning = createSelector(
   [

--- a/src/selectors/layout.test.js
+++ b/src/selectors/layout.test.js
@@ -61,6 +61,9 @@ describe('Selectors', () => {
     });
 
     it('returns false if layout has already been calculated', () => {
+      // In cases where a user enables a filter to show the graph, then
+      // disables it again, the graph should still show, so that the user
+      // doesn't keep seeing the warning over and over again.
       const actions = [
         // Filter out all data nodes to reduce node-count below threshold
         () => toggleTypeDisabled('data', true),

--- a/src/selectors/layout.test.js
+++ b/src/selectors/layout.test.js
@@ -69,12 +69,14 @@ describe('Selectors', () => {
           const layout = state.flags.oldgraph ? graphDagre : graphNew;
           return updateGraph(layout(getGraphInput(state)));
         },
+        // Turn the filter back off
+        () => toggleTypeDisabled('data', false),
       ];
       const state = actions.reduce(
         (state, action) => reducer(state, action(state)),
         prepareState({ data: prepareLargeDataset() })
       );
-      expect(getTriggerLargeGraphWarning(state)).toEqual(false);
+      expect(getTriggerLargeGraphWarning(state)).toBe(false);
     });
   });
 

--- a/src/selectors/layout.test.js
+++ b/src/selectors/layout.test.js
@@ -36,12 +36,12 @@ describe('Selectors', () => {
     };
 
     it('returns false for a small dataset', () => {
-      expect(getTriggerLargeGraphWarning(mockState.animals)).toEqual(false);
+      expect(getTriggerLargeGraphWarning(mockState.animals)).toBe(false);
     });
 
     it('returns true for a large dataset', () => {
       const state = prepareState({ data: prepareLargeDataset() });
-      expect(getTriggerLargeGraphWarning(state)).toEqual(true);
+      expect(getTriggerLargeGraphWarning(state)).toBe(true);
     });
 
     it('returns false if the sizewarning flag is false', () => {
@@ -49,7 +49,7 @@ describe('Selectors', () => {
         prepareState({ data: prepareLargeDataset() }),
         changeFlag('sizewarning', false)
       );
-      expect(getTriggerLargeGraphWarning(state)).toEqual(false);
+      expect(getTriggerLargeGraphWarning(state)).toBe(false);
     });
 
     it('returns false if ignoreLargeWarning is true', () => {
@@ -57,7 +57,7 @@ describe('Selectors', () => {
         prepareState({ data: prepareLargeDataset() }),
         toggleIgnoreLargeWarning(true)
       );
-      expect(getTriggerLargeGraphWarning(state)).toEqual(false);
+      expect(getTriggerLargeGraphWarning(state)).toBe(false);
     });
 
     it('returns false if layout has already been calculated', () => {

--- a/src/selectors/layout.test.js
+++ b/src/selectors/layout.test.js
@@ -61,9 +61,9 @@ describe('Selectors', () => {
     });
 
     it('returns false if layout has already been calculated', () => {
-      // In cases where a user enables a filter to show the graph, then
-      // disables it again, the graph should still show, so that the user
-      // doesn't keep seeing the warning over and over again.
+      // The warning should only appear once on first load, if at all.
+      // i.e. in cases where a user enables filters to reveal the graph,
+      // then disables them again, the warning should not show repeatedly.
       const actions = [
         // Filter out all data nodes to reduce node-count below threshold
         () => toggleTypeDisabled('data', true),


### PR DESCRIPTION
## Description

1. Add a new 'sizewarning' flag for the large graph warning. This flag is enabled by default, but it's in place so that users can disable it if necessary, if the warning causes them problems. This will also allow us to add a "Don't show this message again" link/button, if we like.
2. Add new tests for the `getTriggerLargeGraphWarning` selector: Add a test for the flag case, but also add new tests to handle the `ignoreLargeWarning` and `graphHasNodes` cases too, which were missed out of #361.
3. Update getTriggerLargeGraphWarning JSDoc comment, to add a bit more detail explaining under what conditions it should return true (i.e. show the warning).


## Development notes

For the `graphHasNodes` test, I needed the state to have a sufficiently large dataset to cross the threshold and trigger the warning, but for the layout to have already been calculated so that the graph object has been updated and populated. In order to achieve this, I prepared the state with a large dataset, then ran it through a reducer with 3 actions: Toggling on a node-type filter to bring it under the threshold, updating the graph state, then toggling the filter back off again to bring the graph back above the threshold.

## QA notes

If you set `?sizewarning=0` in the URL with a very large pipeline, the large graph warning shouldn't display.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
