### PR TITLE
[KED-2453] Update large pipeline warning copy

### DIFF
--- a/src/components/large-pipeline-warning/index.js
+++ b/src/components/large-pipeline-warning/index.js
@@ -19,11 +19,13 @@ export const LargePipelineWarning = ({
       className={classnames('kedro', 'pipeline-warning', {
         'pipeline-warning--sidebar-visible': sidebarVisible,
       })}>
-      <h2 className="pipeline-warning__title">Your pipeline is large.</h2>
+      <h2 className="pipeline-warning__title">
+        Whoa, that’s a chonky pipeline!
+      </h2>
       <p className="pipeline-warning__subtitle">
-        Your pipeline might take a while to render because it has{' '}
-        <b>{nodes.length}</b> elements. Use the sidebar controls to select a
-        smaller graph, or click to render.
+        This graph contains <b>{nodes.length}</b> elements, which will take a
+        while to render. You can use the sidebar controls to select a smaller
+        graph.
       </p>
       <Button theme={theme} onClick={() => onToggleIgnoreLargeWarning(true)}>
         Render it anyway

--- a/src/components/large-pipeline-warning/large-pipeline-warning.scss
+++ b/src/components/large-pipeline-warning/large-pipeline-warning.scss
@@ -18,7 +18,6 @@
 
   %warning-text {
     width: 90%;
-    max-width: 500px;
     margin-right: auto;
     margin-left: auto;
   }
@@ -36,7 +35,8 @@
 
   &__subtitle {
     @extend %warning-text;
-    margin-bottom: 2.8em;
+    max-width: 30em;
+    margin-bottom: 2.4em;
     font-size: 1.4em;
 
     @media (min-width: $sidebar-width-breakpoint) {


### PR DESCRIPTION
## Description

1. Let's avoid saying "your pipeline" - we don't want to shame our users for their big-ass pipelines or make them look bad in front of a client. It's not a bad thing to be little on the large side, there's just more to love 😌
2. Let's inject a little levity and humanity into this message - [studies show that even in corporate environments, when people use humour in the workplace, they are 23% more respected and are seen as more competent and more confident](https://www.npr.org/2021/02/08/965572857/the-power-of-humor). Even executives have a sense of humour, they just don’t want us to imply that their work is of poor quality.
3. Let's use 'will' instead of 'might' - as @stichbury said, "I never like the 'might' word, because it implies doubt, and certainty is a nice thing for a reader."
4. Let's avoid needless repetition. There's no need to say "click to render", just show the button which says this anyway. Also, we prefer to avoid saying "click" because this implies that the user is navigating with a mouse, when they might be using a keyboard, touchpad or touchscreen.

![image](https://user-images.githubusercontent.com/1155816/108597317-54c2e900-7380-11eb-93ba-9b109a9c119d.png)

## Development notes

I've changed the max-width of the paragraph text to `30em`, as this is the ideal width to split the two sentences onto two lines, and it is dependent on the font-size so the line-split will remain constant if the text size changes.

## QA notes

Updated copy. The only thing worth checking is how this renders across screen widths and when the sidebar is open/closed.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
