### PR TITLE
[KED-2466] Add stylelint 'rule-empty-line-before': 'always'

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,6 +2,13 @@
   extends: ['stylelint-prettier/recommended'],
   plugins: ['stylelint-order', 'stylelint-config-rational-order/plugin'],
   rules: {
+    'rule-empty-line-before': [
+      'always',
+      {
+        except: ['first-nested'],
+        ignore: ['after-comment']
+      }
+    ],
     'order/properties-order': [[], { severity: 'warning' }],
     'plugin/rational-order': [
       true,

--- a/src/components/easter-egg/easter-egg.scss
+++ b/src/components/easter-egg/easter-egg.scss
@@ -21,12 +21,14 @@
     content: '';
     pointer-events: none;
   }
+
   &:before {
     left: 0;
     border-right: 80vmax solid transparent;
     transform-origin: 0 0;
     animation: spotlight-left 3s infinite alternate ease;
   }
+
   &:after {
     right: 0;
     border-left: 80vmax solid transparent;
@@ -39,6 +41,7 @@
   from {
     transform: rotate(-5deg);
   }
+
   to {
     transform: rotate(-40deg);
   }
@@ -48,6 +51,7 @@
   from {
     transform: rotate(5deg);
   }
+
   to {
     transform: rotate(40deg);
   }
@@ -57,6 +61,7 @@
   from {
     filter: saturate(10) hue-rotate(0deg);
   }
+
   to {
     filter: saturate(10) hue-rotate(360deg);
   }
@@ -84,6 +89,7 @@
   0% {
     transform: perspective(400px) rotateY(20deg) rotateX(10deg);
   }
+
   100% {
     transform: perspective(400px) rotateY(-20deg) rotateX(10deg);
   }
@@ -93,6 +99,7 @@
   0% {
     transform: translateX(-10vw);
   }
+
   100% {
     transform: translateX(110vw);
   }
@@ -102,27 +109,35 @@
   0% {
     transform: rotate(10deg);
   }
+
   20% {
     transform: rotate(10deg);
   }
+
   25% {
     transform: rotate(0deg) translateY(-10px);
   }
+
   45% {
     transform: rotate(0deg) translateY(-10px);
   }
+
   50% {
     transform: rotate(-10deg);
   }
+
   70% {
     transform: rotate(-10deg);
   }
+
   75% {
     transform: rotate(0deg) translateY(-10px);
   }
+
   95% {
     transform: rotate(0deg) translateY(-10px);
   }
+
   100% {
     transform: rotate(10deg);
   }

--- a/src/components/icons/loading.scss
+++ b/src/components/icons/loading.scss
@@ -47,6 +47,7 @@ $path2-gap: $section-length + $section-gap-2x;
   from {
     stroke-dashoffset: $spin1-offset-start;
   }
+
   to {
     stroke-dashoffset: $spin1-offset-end;
   }
@@ -56,6 +57,7 @@ $path2-gap: $section-length + $section-gap-2x;
   from {
     stroke-dashoffset: $spin2-offset-start;
   }
+
   to {
     stroke-dashoffset: $spin2-offset-end;
   }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -33,6 +33,7 @@
   .kui-theme--light {
     #{$var-name}: #{rgba($color-light, 0)};
   }
+
   .kui-theme--dark {
     #{$var-name}: #{rgba($color-dark, 0)};
   }


### PR DESCRIPTION
## Description

[Always enforce an empty line before SCSS rule blocks](https://stylelint.io/user-guide/rules/rule-empty-line-before), except for the first one nested in another. And make it optional for blocks following a comment.

## Development notes

Once I changed the config, I ran stylelint over the directory to update any files that didn't conform:
```
npx stylelint --fix "src/**/*.scss"
```

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
