### PR TITLE
[KED-2471] Add "Don't show this again" message to large-pipeline-warning

### DIFF
--- a/src/components/large-pipeline-warning/index.js
+++ b/src/components/large-pipeline-warning/index.js
@@ -32,7 +32,9 @@ export const LargePipelineWarning = ({
         Render it anyway
       </Button>
       <div className="pipeline-warning__disable">
-        <button onClick={onDisable}>Don't show this again</button>
+        <button className="pipeline-warning__disable__btn" onClick={onDisable}>
+          Don't show this again
+        </button>
       </div>
     </div>
   ) : null;

--- a/src/components/large-pipeline-warning/index.js
+++ b/src/components/large-pipeline-warning/index.js
@@ -31,11 +31,14 @@ export const LargePipelineWarning = ({
       <Button theme={theme} onClick={onHide}>
         Render it anyway
       </Button>
-      <div className="pipeline-warning__disable">
-        <button className="pipeline-warning__disable__btn" onClick={onDisable}>
-          Don't show this again
-        </button>
-      </div>
+      <Button
+        theme={theme}
+        onClick={onDisable}
+        size="small"
+        mode="secondary"
+        animation="wipe">
+        Don't show this again
+      </Button>
     </div>
   ) : null;
 };

--- a/src/components/large-pipeline-warning/index.js
+++ b/src/components/large-pipeline-warning/index.js
@@ -1,17 +1,18 @@
 import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { toggleIgnoreLargeWarning } from '../../actions';
+import { changeFlag, toggleIgnoreLargeWarning } from '../../actions';
 import { getVisibleNodes } from '../../selectors/nodes';
 import { getTriggerLargeGraphWarning } from '../../selectors/layout';
 import Button from '@quantumblack/kedro-ui/lib/components/button';
 import './large-pipeline-warning.css';
 
 export const LargePipelineWarning = ({
-  theme,
+  onDisable,
+  onHide,
   nodes,
-  onToggleIgnoreLargeWarning,
   sidebarVisible,
+  theme,
   visible,
 }) => {
   return visible ? (
@@ -27,9 +28,12 @@ export const LargePipelineWarning = ({
         while to render. You can use the sidebar controls to select a smaller
         graph.
       </p>
-      <Button theme={theme} onClick={() => onToggleIgnoreLargeWarning(true)}>
+      <Button theme={theme} onClick={onHide}>
         Render it anyway
       </Button>
+      <div className="pipeline-warning__disable">
+        <button onClick={onDisable}>Don't show this again</button>
+      </div>
     </div>
   ) : null;
 };
@@ -42,8 +46,11 @@ export const mapStateToProps = (state) => ({
 });
 
 export const mapDispatchToProps = (dispatch) => ({
-  onToggleIgnoreLargeWarning: (value) => {
-    dispatch(toggleIgnoreLargeWarning(value));
+  onDisable: () => {
+    dispatch(changeFlag('sizewarning', false));
+  },
+  onHide: () => {
+    dispatch(toggleIgnoreLargeWarning(true));
   },
 });
 

--- a/src/components/large-pipeline-warning/large-pipeline-warning.scss
+++ b/src/components/large-pipeline-warning/large-pipeline-warning.scss
@@ -48,33 +48,6 @@
   }
 }
 
-.pipeline-warning__disable {
-  margin-top: 2.4em;
-}
-
-.pipeline-warning__disable__btn {
-  padding: 0.1em 0.6em 0.2em;
-  color: inherit;
-  font-size: 1.4em;
-  font-family: inherit;
-  text-decoration: underline;
-  background: none;
-  border: none;
-  cursor: pointer;
-
-  &:hover {
-    text-decoration: none;
-  }
-
-  &:focus {
-    outline: none;
-
-    [data-whatintent='keyboard'] & {
-      outline: 3px solid $color-link;
-    }
-  }
-
-  &:active {
-    transform: translateY(1px);
-  }
+.pipeline-warning .kui-button:first-of-type {
+  margin-bottom: 1.2em;
 }

--- a/src/components/large-pipeline-warning/large-pipeline-warning.scss
+++ b/src/components/large-pipeline-warning/large-pipeline-warning.scss
@@ -50,31 +50,31 @@
 
 .pipeline-warning__disable {
   margin-top: 2.4em;
+}
 
-  button {
-    padding: 0.1em 0.6em 0.2em;
-    color: inherit;
-    font-size: 1.4em;
-    font-family: inherit;
-    text-decoration: underline;
-    background: none;
-    border: none;
-    cursor: pointer;
+.pipeline-warning__disable__btn {
+  padding: 0.1em 0.6em 0.2em;
+  color: inherit;
+  font-size: 1.4em;
+  font-family: inherit;
+  text-decoration: underline;
+  background: none;
+  border: none;
+  cursor: pointer;
 
-    &:hover {
-      text-decoration: none;
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:focus {
+    outline: none;
+
+    [data-whatintent='keyboard'] & {
+      outline: 3px solid $color-link;
     }
+  }
 
-    &:focus {
-      outline: none;
-
-      [data-whatintent='keyboard'] & {
-        outline: 3px solid $color-link;
-      }
-    }
-
-    &:active {
-      transform: translateY(1px);
-    }
+  &:active {
+    transform: translateY(1px);
   }
 }

--- a/src/components/large-pipeline-warning/large-pipeline-warning.scss
+++ b/src/components/large-pipeline-warning/large-pipeline-warning.scss
@@ -2,7 +2,7 @@
 
 .pipeline-warning {
   position: absolute;
-  top: calc(50% - 14em);
+  top: calc(50% - 16em);
   left: 0;
   width: calc((100% - #{$sidebar-width-closed}));
   text-align: center;
@@ -15,32 +15,63 @@
       transform: translateX($sidebar-width-open);
     }
   }
+}
 
-  %warning-text {
-    width: 90%;
-    margin-right: auto;
-    margin-left: auto;
+%warning-text {
+  width: 90%;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.pipeline-warning__title {
+  @extend %warning-text;
+  margin-bottom: 0.6em;
+  font-weight: normal;
+  font-size: 2.8em;
+
+  @media (min-width: $sidebar-width-breakpoint) {
+    font-size: 3.8em;
   }
+}
 
-  &__title {
-    @extend %warning-text;
-    margin-bottom: 0.6em;
-    font-weight: normal;
-    font-size: 2.8em;
+.pipeline-warning__subtitle {
+  @extend %warning-text;
+  max-width: 30em;
+  margin-bottom: 2.4em;
+  font-size: 1.4em;
 
-    @media (min-width: $sidebar-width-breakpoint) {
-      font-size: 3.8em;
-    }
+  @media (min-width: $sidebar-width-breakpoint) {
+    font-size: 1.5em;
   }
+}
 
-  &__subtitle {
-    @extend %warning-text;
-    max-width: 30em;
-    margin-bottom: 2.4em;
+.pipeline-warning__disable {
+  margin-top: 2.4em;
+
+  button {
+    padding: 0.1em 0.6em 0.2em;
+    color: inherit;
     font-size: 1.4em;
+    font-family: inherit;
+    text-decoration: underline;
+    background: none;
+    border: none;
+    cursor: pointer;
 
-    @media (min-width: $sidebar-width-breakpoint) {
-      font-size: 1.5em;
+    &:hover {
+      text-decoration: none;
+    }
+
+    &:focus {
+      outline: none;
+
+      [data-whatintent='keyboard'] & {
+        outline: 3px solid $color-link;
+      }
+    }
+
+    &:active {
+      transform: translateY(1px);
     }
   }
 }

--- a/src/components/large-pipeline-warning/large-pipeline-warning.scss
+++ b/src/components/large-pipeline-warning/large-pipeline-warning.scss
@@ -2,9 +2,13 @@
 
 .pipeline-warning {
   position: absolute;
-  top: calc(50% - 16em);
+  top: 0;
   left: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   width: calc((100% - #{$sidebar-width-closed}));
+  height: 100%;
   text-align: center;
   transform: translateX($sidebar-width-closed);
   transition: transform 0.4s ease, width ease 0.4s;
@@ -19,8 +23,7 @@
 
 %warning-text {
   width: 90%;
-  margin-right: auto;
-  margin-left: auto;
+  margin: 0 auto;
 }
 
 .pipeline-warning__title {

--- a/src/components/large-pipeline-warning/large-pipeline-warning.test.js
+++ b/src/components/large-pipeline-warning/large-pipeline-warning.test.js
@@ -28,8 +28,7 @@ describe('LargePipelineWarning', () => {
       visible: true,
     };
     const wrapper = setup.mount(<LargePipelineWarning {...props} />);
-
-    wrapper.find('.kui-button__btn').simulate('click');
+    wrapper.find('.kui-button__btn').at(0).simulate('click');
     expect(mockFn.mock.calls.length).toBe(1);
   });
 
@@ -42,8 +41,7 @@ describe('LargePipelineWarning', () => {
       visible: true,
     };
     const wrapper = setup.mount(<LargePipelineWarning {...props} />);
-
-    wrapper.find('.pipeline-warning__disable__btn').simulate('click');
+    wrapper.find('.kui-button__btn').at(1).simulate('click');
     expect(mockFn.mock.calls.length).toBe(1);
   });
 

--- a/src/components/large-pipeline-warning/large-pipeline-warning.test.js
+++ b/src/components/large-pipeline-warning/large-pipeline-warning.test.js
@@ -1,16 +1,17 @@
 import React from 'react';
-import ConnectedModal, {
+import {
   LargePipelineWarning,
   mapStateToProps,
   mapDispatchToProps,
 } from './index';
 import { mockState, setup } from '../../utils/state.mock';
 
-describe('large modal', () => {
+describe('LargePipelineWarning', () => {
   it('renders without crashing', () => {
     const mockFn = jest.fn();
     const props = {
-      onToggleIgnoreLargeWarning: mockFn,
+      onDisable: mockFn,
+      onHide: mockFn,
       nodes: [],
       visible: true,
     };
@@ -18,16 +19,31 @@ describe('large modal', () => {
     expect(wrapper.find('.pipeline-warning').length).toBe(1);
   });
 
-  it('clicking the render anyways button will toggle the graph to display', () => {
+  it('will call onHide upon clicking the "render anyway" button', () => {
     const mockFn = jest.fn();
     const props = {
-      onToggleIgnoreLargeWarning: mockFn,
+      onDisable: () => {},
+      onHide: mockFn,
       nodes: [],
       visible: true,
     };
     const wrapper = setup.mount(<LargePipelineWarning {...props} />);
 
     wrapper.find('.kui-button__btn').simulate('click');
+    expect(mockFn.mock.calls.length).toBe(1);
+  });
+
+  it('will call onDisable upon clicking the "Don\'t show this again" button', () => {
+    const mockFn = jest.fn();
+    const props = {
+      onDisable: mockFn,
+      onHide: () => {},
+      nodes: [],
+      visible: true,
+    };
+    const wrapper = setup.mount(<LargePipelineWarning {...props} />);
+
+    wrapper.find('.pipeline-warning__disable__btn').simulate('click');
     expect(mockFn.mock.calls.length).toBe(1);
   });
 
@@ -41,10 +57,11 @@ describe('large modal', () => {
     expect(mapStateToProps(mockState.animals)).toEqual(expectedResult);
   });
 
-  it('mapDispatchToProps', () => {
+  it('maps dispatch to props', () => {
     const dispatch = jest.fn();
     const expectedResult = {
-      onToggleIgnoreLargeWarning: expect.any(Function),
+      onDisable: expect.any(Function),
+      onHide: expect.any(Function),
     };
     expect(mapDispatchToProps(dispatch)).toEqual(expectedResult);
   });

--- a/src/config.js
+++ b/src/config.js
@@ -44,7 +44,7 @@ export const flags = {
   sizewarning: {
     description: 'Show a warning before rendering very large graphs',
     default: true,
-    icon: '⚠️',
+    icon: '🐳',
   },
 };
 


### PR DESCRIPTION
## Description

Allow users to turn off the large-pipeline-warning permanently via the UI. They can reenable it using the 'sizewarning' flag.

![image](https://user-images.githubusercontent.com/1155816/108886696-2dc71a00-7601-11eb-92e5-c8dbe8f1da83.png)

## Development notes

I also did some slight refactoring of the CSS:

- Rename some component props to simplify them.
- Changed nested BEM child modifiers to be standalone - I'll document it in the style-guide, but we try to avoid this with children (as opposed to modifiers). It's very much a stylistic thing, it doesn't actually matter.
- I changed the vertical centring from position:absolute to flexbox.

## QA notes

Test on a large pipeline. Clicking the new button (which looks like a link) should hide the warning and turn off the flag.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
