### PR TITLE
3.10.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,6 +17,18 @@ Please follow the established format:
 
 <!-- Add release notes for the upcoming release here -->
 
+# Release 3.10.0
+
+## Major features and improvements
+
+- Display a prompt before rendering very large graphs (#361, #376, #377, #381)
+
+## Bug fixes and other changes
+
+- Clean up SCSS tech debt (#380)
+- Add Container component to simplify app/lib entrypoint (#379)
+- Add stylelint 'rule-empty-line-before': 'always' (#378)
+
 # Release 3.9.0
 
 ## Major features and improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantumblack/kedro-viz",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantumblack/kedro-viz",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "main": "lib/components/app/index.js",
   "files": [
     "lib"

--- a/package/kedro_viz/__init__.py
+++ b/package/kedro_viz/__init__.py
@@ -28,7 +28,7 @@
 
 """ Kedro plugin for vizualising a Kedro pipeline """
 
-__version__ = "3.9.0"
+__version__ = "3.10.0"
 
 
 from kedro_viz.server import format_pipeline_data  # noqa


### PR DESCRIPTION
# Release 3.10.0

## Major features and improvements

- Display a prompt before rendering very large graphs (#361, #376, #377, #381)

## Bug fixes and other changes

- Clean up SCSS tech debt (#380)
- Add Container component to simplify app/lib entrypoint (#379)
- Add stylelint 'rule-empty-line-before': 'always' (#378)

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
