### PR TITLE
[KED-2492] Update store functions for new modular pipeline data

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -63,6 +63,7 @@ const combinedReducer = combineReducers({
   asyncDataSource: createReducer(false),
   edge: createReducer({}),
   id: createReducer(null),
+  modularPipeline: createReducer({}),
   // These props have very simple non-nested actions
   chartSize: createReducer({}, UPDATE_CHART_SIZE, 'chartSize'),
   zoom: createReducer({}, UPDATE_ZOOM, 'zoom'),

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -9,6 +9,10 @@ export const createInitialPipelineState = () => ({
     ids: [],
     name: {},
   },
+  modularPipeline: {
+    ids: [],
+    name: {},
+  },
   node: {
     ids: [],
     name: {},
@@ -26,6 +30,7 @@ export const createInitialPipelineState = () => ({
     parameters: {},
     filepath: {},
     datasetType: {},
+    modularPipelines: {},
   },
   nodeType: {
     ids: ['task', 'data', 'parameters'],
@@ -100,6 +105,20 @@ const addPipeline = (state) => (pipeline) => {
 };
 
 /**
+ * Add a new modular pipeline
+ * @param {string} modularPipeline.id - Unique namespace of the modular pipeline
+ * @param {string} modularPipeline.name - modular pipeline name
+ */
+const addModularPipeline = (state) => (modularPipeline) => {
+  const { id, name } = modularPipeline;
+  if (state.modularPipeline.name[id]) {
+    return;
+  }
+  state.modularPipeline.ids.push(id);
+  state.modularPipeline.name[id] = name;
+};
+
+/**
  * Add a new node if it doesn't already exist
  * @param {string} name - Default node name
  * @param {string} type - 'data' or 'task'
@@ -125,6 +144,7 @@ const addNode = (state) => (node) => {
   state.node.parameters[id] = node.parameters;
   state.node.filepath[id] = node.filepath;
   state.node.datasetType[id] = node.datasetType;
+  state.node.modularPipelines[id] = node.modular_pipelines;
 };
 
 /**
@@ -187,6 +207,9 @@ const normalizeData = (data) => {
       state.pipeline.main = data.selected_pipeline || state.pipeline.ids[0];
       state.pipeline.active = state.pipeline.main;
     }
+  }
+  if (data.modular_pipelines) {
+    data.modular_pipelines.forEach(addModularPipeline(state));
   }
   if (data.tags) {
     data.tags.forEach(addTag(state));

--- a/src/store/normalize-data.test.js
+++ b/src/store/normalize-data.test.js
@@ -47,6 +47,11 @@ describe('normalizeData', () => {
     expect(normalizeData(data).pipeline.active).toBe(undefined);
   });
 
+  it('should not add modular pipelines if modular pipelines are not supplied', () => {
+    const data = Object.assign({}, animals, { modular_pipelines: undefined });
+    expect(normalizeData(data).modularPipeline.ids).toHaveLength(0);
+  });
+
   it('should not add layers if layers are not supplied', () => {
     const data = Object.assign({}, animals, { layers: undefined });
     data.nodes.forEach((node) => {

--- a/src/store/normalize-data.test.js
+++ b/src/store/normalize-data.test.js
@@ -52,6 +52,22 @@ describe('normalizeData', () => {
     expect(normalizeData(data).modularPipeline.ids).toHaveLength(0);
   });
 
+  it('should not add duplicate modular pipelines', () => {
+    const data = Object.assign({}, animals, {
+      modular_pipelines: [
+        {
+          id: 'pipeline1',
+          name: 'Pipeline 1',
+        },
+        {
+          id: 'pipeline1',
+          name: 'Pipeline 1',
+        },
+      ],
+    });
+    expect(normalizeData(data).modularPipeline.ids).toHaveLength(1);
+  });
+
   it('should not add layers if layers are not supplied', () => {
     const data = Object.assign({}, animals, { layers: undefined });
     data.nodes.forEach((node) => {


### PR DESCRIPTION
## Description

related ticket: [KED-2492](https://jira.quantumblack.com/browse/KED-2492)

This is the initial set up work to update the store functions to allow the newly added `modular_pipeline` field from the pipeline data to be added in the state as well ( as a seperate field as well as part of the node data)

## Development notes

I have added:
1. A new `modular_pipeline` field under the state to store the modular pipeline data ( naming following how we named 'pipeline`), and a new `modular_pipelines` field for the node state data ( naming of this field also following the pattern of how other fields are name for the node fields, such as `pipelines`)
2. A `addModularPipeline` function to add the modular pipeline by id - it will also check if any existing modular pipelines with the same id exists. 
3. Modified the reducer to include the newly added modular pipeline field in the state
4. tests to test the newly added modular pipeline field.

Please note that I had not added any tests relating to the addition of the `modular_pipelines` field in the node as I observed that there are no existing test to test the specifics of `addNode` function (nor any node data) within `normalize-data.js` - in following the existing pattern in the codebase, the existence of this additional field will be covered by further tests set up under the tests for the selectors that will be set up in the ticket for the proceeding work under [KED-2436](https://jira.quantumblack.com/browse/KED-2436)

## QA notes

This could be tested by testing the state data after the pipeline data has been loaded. 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
