### PR TITLE
Remove 'id' reducer prop

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -62,7 +62,6 @@ const combinedReducer = combineReducers({
   // These props don't have any actions associated with them
   asyncDataSource: createReducer(false),
   edge: createReducer({}),
-  id: createReducer(null),
   modularPipeline: createReducer({}),
   // These props have very simple non-nested actions
   chartSize: createReducer({}, UPDATE_CHART_SIZE, 'chartSize'),


### PR DESCRIPTION
## Description

This reducer exists for a state prop that no longer exists and is no longer used. combineReducers requires that we add reducers for every state prop, even if they have no specific actions associated with them.

## Development notes

One-line deletion. I think the rest of it has already been deleted, this was just missed out.

## QA notes

No functionality changes

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
