### PR TITLE
[KED-2367] Add metadata to random data generator

### DIFF
--- a/src/actions/nodes.js
+++ b/src/actions/nodes.js
@@ -75,11 +75,11 @@ export function addNodeMetadata(data) {
  */
 export function loadNodeData(nodeID) {
   return async function (dispatch, getState) {
-    const { asyncDataSource, node } = getState();
+    const { dataSource, node } = getState();
 
     dispatch(toggleNodeClicked(nodeID));
 
-    if (asyncDataSource && nodeID && !node.fetched[nodeID]) {
+    if (dataSource === 'json' && nodeID && !node.fetched[nodeID]) {
       dispatch(toggleNodeDataLoading(true));
       const url = getUrl('nodes', nodeID);
       const nodeData = await loadJsonData(url);

--- a/src/actions/pipelines.js
+++ b/src/actions/pipelines.js
@@ -82,7 +82,7 @@ export function loadInitialPipelineData() {
     // Get a copy of the full state from the store
     const state = getState();
     // If data is passed synchronously then this process isn't necessary
-    if (!state.asyncDataSource) {
+    if (state.dataSource !== 'json') {
       return;
     }
     dispatch(toggleLoading(true));
@@ -110,11 +110,11 @@ export function loadInitialPipelineData() {
  */
 export function loadPipelineData(pipelineID) {
   return async function (dispatch, getState) {
-    const { asyncDataSource, pipeline } = getState();
+    const { dataSource, pipeline } = getState();
     if (pipelineID && pipelineID === pipeline.active) {
       return;
     }
-    if (asyncDataSource) {
+    if (dataSource === 'json') {
       dispatch(toggleLoading(true));
       // Remove the previous graph to show that a new pipeline is being loaded
       dispatch(toggleGraph(false));

--- a/src/actions/pipelines.test.js
+++ b/src/actions/pipelines.test.js
@@ -184,7 +184,7 @@ describe('pipeline actions', () => {
       it('should hide the current graph before loading the new pipeline', () => {
         const store = createStore(reducer, {
           ...mockState.animals,
-          asyncDataSource: true,
+          dataSource: 'json',
         });
         expect(store.getState().visible.graph).toBe(true);
         loadPipelineData(active)(store.dispatch, store.getState);

--- a/src/components/metadata/metadata-code.js
+++ b/src/components/metadata/metadata-code.js
@@ -3,28 +3,23 @@ import { connect } from 'react-redux';
 import hljs from 'highlight.js/lib/core';
 import python from 'highlight.js/lib/languages/python';
 import yaml from 'highlight.js/lib/languages/yaml';
+import javascript from 'highlight.js/lib/languages/javascript';
 import modifiers from '../../utils/modifiers';
 import './styles/metadata-code.css';
 
-let javascript;
 hljs.registerLanguage('python', python);
 hljs.registerLanguage('yaml', yaml);
+hljs.registerLanguage('javascript', javascript);
 
 /**
  * A highlighted code panel
  */
 export const MetaDataCode = ({
-  dataIsRandom,
   sidebarVisible,
   visible = true,
   value = '',
 }) => {
   const codeRef = useRef();
-
-  if (dataIsRandom && !javascript) {
-    javascript = require('highlight.js/lib/languages/javascript');
-    hljs.registerLanguage('javascript', javascript);
-  }
 
   const highlighted = useMemo(() => {
     const detected = hljs.highlightAuto(value);
@@ -48,7 +43,6 @@ export const MetaDataCode = ({
 };
 
 const mapStateToProps = (state) => ({
-  dataIsRandom: state.dataSource === 'random',
   sidebarVisible: state.visible.sidebar,
 });
 

--- a/src/components/metadata/metadata-code.js
+++ b/src/components/metadata/metadata-code.js
@@ -6,6 +6,7 @@ import yaml from 'highlight.js/lib/languages/yaml';
 import modifiers from '../../utils/modifiers';
 import './styles/metadata-code.css';
 
+let javascript;
 hljs.registerLanguage('python', python);
 hljs.registerLanguage('yaml', yaml);
 
@@ -13,11 +14,17 @@ hljs.registerLanguage('yaml', yaml);
  * A highlighted code panel
  */
 export const MetaDataCode = ({
+  randomData,
+  sidebarVisible,
   visible = true,
   value = '',
-  sidebarVisible,
 }) => {
   const codeRef = useRef();
+
+  if (randomData && !javascript) {
+    javascript = require('highlight.js/lib/languages/javascript');
+    hljs.registerLanguage('javascript', javascript);
+  }
 
   const highlighted = useMemo(() => {
     const detected = hljs.highlightAuto(value);
@@ -41,6 +48,7 @@ export const MetaDataCode = ({
 };
 
 const mapStateToProps = (state) => ({
+  randomData: state.randomData,
   sidebarVisible: state.visible.sidebar,
 });
 

--- a/src/components/metadata/metadata-code.js
+++ b/src/components/metadata/metadata-code.js
@@ -14,14 +14,14 @@ hljs.registerLanguage('yaml', yaml);
  * A highlighted code panel
  */
 export const MetaDataCode = ({
-  randomData,
+  dataIsRandom,
   sidebarVisible,
   visible = true,
   value = '',
 }) => {
   const codeRef = useRef();
 
-  if (randomData && !javascript) {
+  if (dataIsRandom && !javascript) {
     javascript = require('highlight.js/lib/languages/javascript');
     hljs.registerLanguage('javascript', javascript);
   }
@@ -48,7 +48,7 @@ export const MetaDataCode = ({
 };
 
 const mapStateToProps = (state) => ({
-  randomData: state.randomData,
+  dataIsRandom: state.dataSource === 'random',
   sidebarVisible: state.visible.sidebar,
 });
 

--- a/src/components/pipeline-list/index.js
+++ b/src/components/pipeline-list/index.js
@@ -49,7 +49,7 @@ export const PipelineList = ({
 };
 
 export const mapStateToProps = (state) => ({
-  asyncDataSource: state.asyncDataSource,
+  asyncDataSource: state.dataSource === 'json',
   pipeline: state.pipeline,
   theme: state.theme,
 });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -64,6 +64,7 @@ const combinedReducer = combineReducers({
   edge: createReducer({}),
   id: createReducer(null),
   modularPipeline: createReducer({}),
+  randomData: createReducer(false),
   // These props have very simple non-nested actions
   chartSize: createReducer({}, UPDATE_CHART_SIZE, 'chartSize'),
   zoom: createReducer({}, UPDATE_ZOOM, 'zoom'),

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -60,11 +60,10 @@ const combinedReducer = combineReducers({
   tag,
   visible,
   // These props don't have any actions associated with them
-  asyncDataSource: createReducer(false),
+  dataSource: createReducer(null),
   edge: createReducer({}),
   id: createReducer(null),
   modularPipeline: createReducer({}),
-  randomData: createReducer(false),
   // These props have very simple non-nested actions
   chartSize: createReducer({}, UPDATE_CHART_SIZE, 'chartSize'),
   zoom: createReducer({}, UPDATE_ZOOM, 'zoom'),

--- a/src/selectors/pipeline.js
+++ b/src/selectors/pipeline.js
@@ -5,15 +5,15 @@ const getNodeIDs = (state) => state.node.ids;
 const getNodePipelines = (state) => state.node.pipelines;
 const getActivePipeline = (state) => state.pipeline.active;
 const getNodeTags = (state) => state.node.tags;
-const getAsyncDataSource = (state) => state.asyncDataSource;
+const getDataSource = (state) => state.dataSource;
 
 /**
  * Calculate whether nodes should be disabled based on their tags
  */
 export const getNodeDisabledPipeline = createSelector(
-  [getNodeIDs, getNodePipelines, getActivePipeline, getAsyncDataSource],
-  (nodeIDs, nodePipelines, activePipeline, asyncDataSource) => {
-    if (asyncDataSource || !activePipeline) {
+  [getNodeIDs, getNodePipelines, getActivePipeline, getDataSource],
+  (nodeIDs, nodePipelines, activePipeline, dataSource) => {
+    if (dataSource === 'json' || !activePipeline) {
       return {};
     }
     return arrayToObject(

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -194,6 +194,9 @@ const normalizeData = (data) => {
   if (data === 'json') {
     state.asyncDataSource = true;
   }
+  if (data.randomData) {
+    state.randomData = true;
+  }
 
   if (!validateInput(data)) {
     return state;

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -192,10 +192,9 @@ const normalizeData = (data) => {
   const state = createInitialPipelineState();
 
   if (data === 'json') {
-    state.asyncDataSource = true;
-  }
-  if (data.randomData) {
-    state.randomData = true;
+    state.dataSource = 'json';
+  } else if (data.source) {
+    state.dataSource = data.source;
   }
 
   if (!validateInput(data)) {

--- a/src/store/normalize-data.test.js
+++ b/src/store/normalize-data.test.js
@@ -19,7 +19,7 @@ describe('normalizeData', () => {
   it('should return initialState if input is "json"', () => {
     expect(normalizeData('json')).toEqual({
       ...initialState,
-      asyncDataSource: true,
+      dataSource: 'json',
     });
   });
 

--- a/src/utils/data-source.js
+++ b/src/utils/data-source.js
@@ -36,16 +36,19 @@ export const getSourceID = () => {
  * @return {object|string} Either raw data itself, or 'json'
  */
 export const getDataValue = (source) => {
+  // Add data source string to data object
+  const nameSource = (data) => Object.assign(data, { source });
+
   switch (source) {
     case 'animals':
       // Use data from the 'animals' test dataset
-      return animals;
+      return nameSource(animals);
     case 'demo':
       // Use data from the 'demo' test dataset
-      return demo;
+      return nameSource(demo);
     case 'random':
       // Use procedurally-generated data
-      return getRandomPipeline();
+      return nameSource(getRandomPipeline());
     case 'json':
       // Load data asynchronously later
       return source;

--- a/src/utils/random-data.js
+++ b/src/utils/random-data.js
@@ -425,7 +425,6 @@ class Pipeline {
    */
   all() {
     return {
-      source: 'random',
       edges: this.edges,
       layers: LAYERS,
       nodes: this.nodes,

--- a/src/utils/random-data.js
+++ b/src/utils/random-data.js
@@ -414,7 +414,7 @@ class Pipeline {
    */
   all() {
     return {
-      randomData: true,
+      source: 'random',
       edges: this.edges,
       layers: LAYERS,
       nodes: this.nodes,

--- a/src/utils/random-data.js
+++ b/src/utils/random-data.js
@@ -201,7 +201,7 @@ class Pipeline {
     } else if (node.type === 'data') {
       node.datasetType = getRandomName(randomNumber(2));
     }
-    node.filepath = getRandomName(randomNumber(10, '/'));
+    node.filepath = getRandomName(randomNumber(10), '/');
     node.parameters = arrayToObject(
       getNumberArray(this.utils.randomNumber(10)).map(() =>
         getRandomName(randomNumber(2), '_')

--- a/src/utils/random-data.js
+++ b/src/utils/random-data.js
@@ -203,7 +203,7 @@ class Pipeline {
     }
     node.filepath = getRandomName(randomNumber(10), '/');
     node.parameters = arrayToObject(
-      getNumberArray(this.utils.randomNumber(10)).map(() =>
+      getNumberArray(randomNumber(10)).map(() =>
         getRandomName(randomNumber(2), '_')
       ),
       () => this.utils.randomNumber(50) / 10

--- a/src/utils/random-data.js
+++ b/src/utils/random-data.js
@@ -193,12 +193,10 @@ class Pipeline {
    * @param {object} node A single node object
    */
   getNodeMetaData(node) {
-    const { getRandom, getRandomName, randomNumber } = this.utils;
+    const { getRandomName, randomNumber } = this.utils;
 
     if (node.type === 'task') {
-      node.code = Pipeline.prototype[
-        getRandom(Object.getOwnPropertyNames(Pipeline.prototype))
-      ].toString();
+      node.code = this.generateCodeSnippet();
       node.docstring = getRandomName(randomNumber(10), '/');
     } else if (node.type === 'data') {
       node.datasetType = getRandomName(randomNumber(2));
@@ -210,6 +208,19 @@ class Pipeline {
       ),
       () => this.utils.randomNumber(50) / 10
     );
+  }
+
+  /**
+   * Use one of the methods of this class as a code example
+   */
+  generateCodeSnippet() {
+    const methods = Object.getOwnPropertyNames(Pipeline.prototype);
+    const index = this.utils.randomIndex(methods.length);
+    let code = Pipeline.prototype[methods[index]].toString();
+    if (index > 0) {
+      code = 'function ' + code.replace(/\n\s\s/g, '\n');
+    }
+    return code;
   }
 
   /**

--- a/src/utils/random-data.js
+++ b/src/utils/random-data.js
@@ -189,6 +189,30 @@ class Pipeline {
   }
 
   /**
+   * Generate node metadata panel info
+   * @param {object} node A single node object
+   */
+  getNodeMetaData(node) {
+    const { getRandom, getRandomName, randomNumber } = this.utils;
+
+    if (node.type === 'task') {
+      node.code = Pipeline.prototype[
+        getRandom(Object.getOwnPropertyNames(Pipeline.prototype))
+      ].toString();
+      node.docstring = getRandomName(randomNumber(10), '/');
+    } else if (node.type === 'data') {
+      node.datasetType = getRandomName(randomNumber(2));
+    }
+    node.filepath = getRandomName(randomNumber(10, '/'));
+    node.parameters = arrayToObject(
+      getNumberArray(this.utils.randomNumber(10)).map(() =>
+        getRandomName(randomNumber(2), '_')
+      ),
+      () => this.utils.randomNumber(50) / 10
+    );
+  }
+
+  /**
    * Create a list of the pipelines that the node will be included in
    * @returns {array} Node piplines
    */
@@ -360,6 +384,7 @@ class Pipeline {
           /\s/g,
           '_'
         );
+        this.getNodeMetaData(node);
       }
     }
   }
@@ -389,6 +414,7 @@ class Pipeline {
    */
   all() {
     return {
+      randomData: true,
       edges: this.edges,
       layers: LAYERS,
       nodes: this.nodes,


### PR DESCRIPTION
## Description

Add fields from custom node endpoints to the randomly-generated data. e.g.

* filepath
* docstring
* code
* type
* parameters

## Development notes

I've generated the code snippets by converting methods from the random Pipeline class itself into strings. It seems to work reasonably well! :)

I've also changed `state.asyncDataSource` to just `state.dataSource` so we can use this for other data sources.

## QA notes

Set `?data=random&code=1` and try it out on some different nodes!

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
