### PR TITLE
Remove leftover visible layer reducer

### DIFF
--- a/src/reducers/visible.js
+++ b/src/reducers/visible.js
@@ -1,7 +1,6 @@
 import {
   TOGGLE_GRAPH,
   TOGGLE_EXPORT_MODAL,
-  TOGGLE_LAYERS,
   TOGGLE_SIDEBAR,
   TOGGLE_CODE,
   TOGGLE_MINIMAP,
@@ -18,12 +17,6 @@ function visibleReducer(visibleState = {}, action) {
     case TOGGLE_EXPORT_MODAL: {
       return Object.assign({}, visibleState, {
         exportModal: action.visible,
-      });
-    }
-
-    case TOGGLE_LAYERS: {
-      return Object.assign({}, visibleState, {
-        layers: action.visible,
       });
     }
 


### PR DESCRIPTION
## Description

This was an unused reducer in the visible.js. that was leftover from a previous change. 
We currently use layers.visible reducer to store the state of layers and the app work's fine if we remove the above code. 

## Development notes

Couple of line deletion.

## QA notes

No functionality changes


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
