### PR TITLE
Only look at target nodes when finding nearest node with layers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,7 @@ Please follow the established format:
 
 ## Bug fixes and other changes
 
-<!-- Add release notes for the upcoming release here -->
+- Fix layers visualisation to only look for target nodes when building layers dependency.
 
 # Release 3.10.1
 

--- a/src/utils/graph/graph.js
+++ b/src/utils/graph/graph.js
@@ -110,13 +110,6 @@ const addNearestLayers = (nodes, layers) => {
 const targetNodes = (node) => node.targets.map((edge) => edge.targetNode);
 
 /**
- * Returns the list of source nodes directly connected to the given node
- * @param {object} node The input node
- * @returns {array} The source nodes
- */
-const sourceNodes = (node) => node.sources.map((edge) => edge.sourceNode);
-
-/**
  * Returns the distance between the two nodes using their assigned rank
  * @param {object} nodeA The first input node
  * @param {object} nodeB The second input node

--- a/src/utils/graph/graph.js
+++ b/src/utils/graph/graph.js
@@ -93,7 +93,7 @@ const addNearestLayers = (nodes, layers) => {
     for (const node of nodes) {
       const layerNode = findNodeBy(
         node,
-        targetThenSourceNodes,
+        targetNodes,
         nodeDistance,
         hasValidLayer
       );
@@ -101,14 +101,6 @@ const addNearestLayers = (nodes, layers) => {
     }
   }
 };
-
-/**
- * Returns the list of the node's connected target nodes followed by its connected source nodes
- * @param {object} node The input node
- * @returns {array} The connected nodes
- */
-const targetThenSourceNodes = (node) =>
-  targetNodes(node).concat(sourceNodes(node));
 
 /**
  * Returns the list of target nodes directly connected to the given node


### PR DESCRIPTION
Since layers dependency flows one way, we want to make sure that when finding nearest node with layers, we must also follow the one-way direction from source to target.

## Description

Imagine this pipeline shape:

![Screenshot 2021-03-18 at 15 03 13](https://user-images.githubusercontent.com/2032984/111649430-44c1ec00-87fc-11eb-82e1-52021df4897e.png)

There is a dataset in the `raw` layer that serves as the input to the `models` layer. Therefore, the current behaviour is that nodes in the `models` layer will think the closest node with layer to them is in `raw` and create a direct constraint between `raw` and `models`, which is incorrect. When looking for nearest nodes with layer, we should only look ahead along the layers dependency flow, not behind. 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

I have manually tested this.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
