### PR TITLE
Update FE tests to match new animals dataset

### DIFF
--- a/src/components/node-list/node-list-items.test.js
+++ b/src/components/node-list/node-list-items.test.js
@@ -160,8 +160,8 @@ describe('node-list-selectors', () => {
     ]);
 
     it('filters expected number of items', () => {
-      expect(filteredItems.task).toHaveLength(2);
-      expect(filteredItems.data).toHaveLength(6);
+      expect(filteredItems.task).toHaveLength(3);
+      expect(filteredItems.data).toHaveLength(10);
       expect(filteredItems.parameters).toHaveLength(2);
       expect(filteredItems.tag).toHaveLength(2);
     });

--- a/src/components/node-list/node-list.test.js
+++ b/src/components/node-list/node-list.test.js
@@ -247,11 +247,12 @@ describe('NodeList', () => {
       changeRows(wrapper, ['Medium'], true);
 
       expect(elements(wrapper)).toEqual([
-        // Nodes (enabled)
+        // Tasks (enabled)
         ['shark', true],
-        // Nodes (disabled)
+        // Tasks (disabled)
         ['salmon', false],
         ['trout', false],
+        ['tuna', false],
         // Datasets (enabled)
         ['Bear', true],
         ['Cat', true],
@@ -262,8 +263,12 @@ describe('NodeList', () => {
         // Datasets (disabled)
         ['Dog', false],
         ['Horse', false],
+        ['Pipeline1.data Science.dolphin', false],
+        ['Pipeline1.data Science.sheep', false],
+        ['Pipeline2.data Science.pig', false],
+        ['Pipeline2.data Science.sheep', false],
+        ['Pipeline2.data Science.whale', false],
         ['Sheep', false],
-        ['Whale', false],
         // Parameters
         ['Parameters', false],
         ['Params:rabbit', false],

--- a/src/selectors/linked-nodes.test.js
+++ b/src/selectors/linked-nodes.test.js
@@ -15,12 +15,13 @@ describe('getLinkedNodes function', () => {
 
   describe('should return true for ancestor/descendant nodes', () => {
     test.each([
-      ['whale', '1769e230'],
-      ['horse', '091b5035'],
-      ['sheep', '6525f2e6'],
-      ['cat', '9d989e8d'],
+      ['salmon', '443cf06a'],
       ['dog', 'e4951252'],
+      ['params:rabbit', 'c38d4c6a'],
       ['parameters', 'f1f1425b'],
+      ['cat', '9d989e8d'],
+      ['sheep', '6525f2e6'],
+      ['horse', '091b5035'],
     ])('node %s should be true', (name, id) => {
       expect(linkedNodes[id]).toBe(true);
     });


### PR DESCRIPTION
## Description

Related ticket: [KED-2498](https://jira.quantumblack.com/browse/KED-2498)

This PR is created to fix the failing FE tests due to the updated animals data test set from the newly merged BE changes to match the new modular pipeline format. ( see this PR: https://github.com/quantumblacklabs/kedro-viz/pull/394)

Please note this is merged against the main development branch for the modular pipeline MVP work. 

## Development notes

The new animals testset causes the FE tests to fail due to the addition of 1 new task nodes, 4 new data nodes, and 1 renamed data node.

I have updated 3 tests that tests the sorted or filtered tags results for the sidebar to reflect those new changes. 

## QA notes

Please run the set of FE tests to ensure there are no failing tests. 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
