### PR TITLE
Use full namespace as name for modular pipeline

### DIFF
--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -296,12 +296,11 @@ def _pretty_name(name: str) -> str:
     return " ".join(parts)
 
 
-def _pretty_modular_pipeline_name(modular_pipeline: str) -> str:
-    """Takes the namespace of a modular pipeline and prettifies the
-    last part to show as the modular pipeline name."""
-    chunks = modular_pipeline.split(".")
-    last_chunk = chunks[-1]
-    return _pretty_name(last_chunk)
+def _pretty_modular_pipeline_name(modular_pipeline_name: str) -> str:
+    """Takes the namespace of a modular pipeline and prettifies it
+     to show as the human readable modular pipeline name."""
+    modular_pipeline_name = modular_pipeline_name.replace(".", " ")
+    return _pretty_name(modular_pipeline_name)
 
 
 def format_pipelines_data(pipelines: Dict[str, "Pipeline"]) -> Dict[str, Any]:

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -508,7 +508,7 @@ def test_pipeline_flag(cli_runner, client):
         "layers": [],
         "modular_pipelines": [
             {"id": "pipeline2", "name": "Pipeline2"},
-            {"id": "pipeline2.data_science", "name": "Data Science"},
+            {"id": "pipeline2.data_science", "name": "Pipeline2 Data Science"},
         ],
         "nodes": [
             {
@@ -968,4 +968,4 @@ def test_expand_namespaces():
 def test_pretty_modular_pipeline_name():
     modular_pipeline_name = "main_pipeline.sub_pipeline.deepest_pipeline"
     result = _pretty_modular_pipeline_name(modular_pipeline_name)
-    assert result == "Deepest Pipeline"
+    assert result == "Main Pipeline Sub Pipeline Deepest Pipeline"

--- a/src/utils/data/animals.mock.json
+++ b/src/utils/data/animals.mock.json
@@ -26,11 +26,11 @@
     },
     {
       "id": "pipeline1.data_engineering",
-      "name": "Data Engineering"
+      "name": "Pipeline1 Data Engineering"
     },
     {
       "id": "pipeline1.data_science",
-      "name": "Data Science"
+      "name": "Pipeline1 Data Science"
     },
     {
       "id": "pipeline2",
@@ -38,7 +38,7 @@
     },
     {
       "id": "pipeline2.data_science",
-      "name": "Data Science"
+      "name": "Pipeline2 Data Science"
     }
   ],
   "nodes": [


### PR DESCRIPTION
## Description

Only sending the last part of the modular pipeline as the name can lead to having the same name show up on the viz side multiple times.  

## Development notes

Prettify full modular pipeline namespace and send it to the frontend. 

## QA notes

Updated test data to match this. 

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
