### PR TITLE
Send correct format for modular pipelines from /pipelines endpoint

### DIFF
--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -353,14 +353,7 @@ def format_pipelines_data(pipelines: Dict[str, "Pipeline"]) -> Dict[str, Any]:
         else pipelines_list[0]["id"]
     )
 
-    sorted_modular_pipelines = [
-        {
-            "id": modular_pipeline,
-            "name": _pretty_modular_pipeline_name(modular_pipeline),
-        }
-        for modular_pipeline in sorted(modular_pipelines)
-    ]
-
+    sorted_modular_pipelines = _sort_and_format_modular_pipelines(modular_pipelines)
     _remove_non_modular_pipelines(nodes_list, modular_pipelines)
 
     return {
@@ -491,9 +484,13 @@ def format_pipeline_data(
             _JSON_NODES[node_id]["parameter_name"] = parameter_name
 
         if is_param:
-            dataset_modular_pipelines = _expand_namespaces(_get_namespace(parameter_name))
+            dataset_modular_pipelines = _expand_namespaces(
+                _get_namespace(parameter_name)
+            )
         else:
-            dataset_modular_pipelines = _expand_namespaces(_get_namespace(dataset_full_name))
+            dataset_modular_pipelines = _expand_namespaces(
+                _get_namespace(dataset_full_name)
+            )
             modular_pipelines.update(dataset_modular_pipelines)
 
         if node_id not in nodes:
@@ -577,6 +574,16 @@ def _get_parameter_values(node: Dict) -> Any:
     return parameter_values
 
 
+def _sort_and_format_modular_pipelines(modular_pipelines):
+    return [
+        {
+            "id": modular_pipeline,
+            "name": _pretty_modular_pipeline_name(modular_pipeline),
+        }
+        for modular_pipeline in sorted(modular_pipelines)
+    ]
+
+
 @app.route("/api/main")
 def nodes_json():
     """Serve the data from all Kedro pipelines in the project.
@@ -607,6 +614,8 @@ def pipeline_data(pipeline_id):
         if {edge["source"], edge["target"]} <= pipeline_node_ids:
             pipeline_edges.append(edge)
 
+    sorted_modular_pipelines = _sort_and_format_modular_pipelines(modular_pipelines)
+
     return jsonify(
         {
             "nodes": pipeline_nodes,
@@ -615,7 +624,7 @@ def pipeline_data(pipeline_id):
             "layers": _DATA["layers"],
             "pipelines": _DATA["pipelines"],
             "selected_pipeline": current_pipeline["id"],
-            "modular_pipelines": sorted(modular_pipelines),
+            "modular_pipelines": sorted_modular_pipelines,
         }
     )
 

--- a/package/tests/test_server.py
+++ b/package/tests/test_server.py
@@ -384,7 +384,10 @@ def test_pipelines_endpoint(cli_runner, client):
     assert data["tags"] == EXPECTED_PIPELINE_DATA["tags"]
 
     # make sure only the list of modular pipelines is returned for the selected pipeline
-    assert data["modular_pipelines"] == ["pipeline2", "pipeline2.data_science"]
+    assert data["modular_pipelines"] == [
+        {"id": "pipeline2", "name": "Pipeline2"},
+        {"id": "pipeline2.data_science", "name": "Data Science"},
+    ]
 
 
 @_USE_PATCHED_CONTEXT


### PR DESCRIPTION
## Description

The `pipelines` endpoint was incorrectly sending a list of modular pipeline ids, instead of a list of dict with name and id.

## QA notes

Updated the tests to show correct behaviour.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
