### PR TITLE
[KED 2535] - Delete lazy flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ As a JavaScript React component, the project is designed to be used in two diffe
 
 The following flags are available to toggle experimental features:
 
-- `lazy` - From release v3.8.0. Improved sidebar performance. (default `false`)
 - `oldgraph` - From release v3.8.0. Display old version of graph (dagre algorithm) without improved graphing algorithm. (default `false`)
 - `sizewarning` - From release v3.9.1. Show a warning before rendering very large graphs. (default `true`)
 

--- a/src/components/flowchart/draw.js
+++ b/src/components/flowchart/draw.js
@@ -108,7 +108,7 @@ const updateNodeRects = (nodeRects) =>
  */
 export const drawNodes = function (changed) {
   const {
-    centralNode,
+    clickedNode,
     linkedNodes,
     nodeActive,
     nodeSelected,
@@ -188,14 +188,14 @@ export const drawNodes = function (changed) {
   }
 
   if (
-    changed('nodes', 'nodeActive', 'nodeSelected', 'centralNode', 'linkedNodes')
+    changed('nodes', 'nodeActive', 'nodeSelected', 'clickedNode', 'linkedNodes')
   ) {
     allNodes
       .classed('pipeline-node--active', (node) => nodeActive[node.id])
       .classed('pipeline-node--selected', (node) => nodeSelected[node.id])
       .classed(
         'pipeline-node--faded',
-        (node) => centralNode && !linkedNodes[node.id]
+        (node) => clickedNode && !linkedNodes[node.id]
       );
   }
 
@@ -244,7 +244,7 @@ export const drawNodes = function (changed) {
  * Render edge lines
  */
 export const drawEdges = function (changed) {
-  const { edges, centralNode, linkedNodes } = this.props;
+  const { edges, clickedNode, linkedNodes } = this.props;
 
   if (changed('edges')) {
     this.el.edges = this.el.edgeGroup
@@ -299,12 +299,12 @@ export const drawEdges = function (changed) {
     this.el.edges = this.el.edgeGroup.selectAll('.pipeline-edge');
   }
 
-  if (changed('edges', 'centralNode', 'linkedNodes')) {
+  if (changed('edges', 'clickedNode', 'linkedNodes')) {
     allEdges.classed(
       'pipeline-edge--faded',
       (edge) =>
         edge &&
-        centralNode &&
+        clickedNode &&
         (!linkedNodes[edge.source] || !linkedNodes[edge.target])
     );
   }

--- a/src/components/flowchart/flowchart.test.js
+++ b/src/components/flowchart/flowchart.test.js
@@ -293,7 +293,6 @@ describe('FlowChart', () => {
   it('maps state to props', () => {
     const expectedResult = {
       clickedNode: expect.any(Object),
-      centralNode: expect.any(Object),
       chartSize: expect.any(Object),
       chartZoom: expect.any(Object),
       edges: expect.any(Array),

--- a/src/components/flowchart/index.js
+++ b/src/components/flowchart/index.js
@@ -7,7 +7,7 @@ import { loadNodeData, toggleNodeHovered } from '../../actions/nodes';
 import { getNodeActive, getNodeSelected } from '../../selectors/nodes';
 import { getChartSize, getChartZoom } from '../../selectors/layout';
 import { getLayers } from '../../selectors/layers';
-import { getCentralNode, getLinkedNodes } from '../../selectors/linked-nodes';
+import { getLinkedNodes } from '../../selectors/linked-nodes';
 import { getVisibleMetaSidebar } from '../../selectors/metadata';
 import { drawNodes, drawEdges, drawLayers, drawLayerNames } from './draw';
 import {
@@ -97,14 +97,14 @@ export class FlowChart extends Component {
       drawLayerNames.call(this);
     }
 
-    if (changed('edges', 'centralNode', 'linkedNodes')) {
+    if (changed('edges', 'clickedNode', 'linkedNodes')) {
       drawEdges.call(this, changed);
     }
 
     if (
       changed(
         'nodes',
-        'centralNode',
+        'clickedNode',
         'linkedNodes',
         'nodeActive',
         'nodeSelected'
@@ -549,7 +549,6 @@ const emptyGraphSize = {};
 
 export const mapStateToProps = (state, ownProps) => ({
   clickedNode: state.node.clicked,
-  centralNode: getCentralNode(state),
   chartSize: getChartSize(state),
   chartZoom: getChartZoom(state),
   edges: state.graph.edges || emptyEdges,

--- a/src/components/minimap/draw.js
+++ b/src/components/minimap/draw.js
@@ -27,7 +27,7 @@ export const drawViewport = function () {
  */
 export const drawNodes = function () {
   const {
-    centralNode,
+    clickedNode,
     linkedNodes,
     nodeActive,
     nodeSelected,
@@ -63,7 +63,7 @@ export const drawNodes = function () {
     .classed('pipeline-minimap-node--selected', (node) => nodeSelected[node.id])
     .classed(
       'pipeline-minimap-node--faded',
-      (node) => centralNode && !linkedNodes[node.id]
+      (node) => clickedNode && !linkedNodes[node.id]
     );
 
   this.el.nodes

--- a/src/components/minimap/index.js
+++ b/src/components/minimap/index.js
@@ -5,7 +5,7 @@ import { select } from 'd3-selection';
 import { getNodeActive, getNodeSelected } from '../../selectors/nodes';
 import { updateZoom } from '../../actions';
 import { getChartSize, getChartZoom } from '../../selectors/layout';
-import { getCentralNode, getLinkedNodes } from '../../selectors/linked-nodes';
+import { getLinkedNodes } from '../../selectors/linked-nodes';
 import {
   viewing,
   isOrigin,
@@ -104,7 +104,7 @@ export class MiniMap extends Component {
         changed(
           'visible',
           'nodes',
-          'centralNode',
+          'clickedNodes',
           'linkedNodes',
           'nodesActive',
           'nodeSelected'
@@ -398,7 +398,7 @@ const emptyGraphSize = {};
 export const mapStateToProps = (state, ownProps) => ({
   visible: state.visible.miniMap,
   mapSize: getMapSize(state),
-  centralNode: getCentralNode(state),
+  clickedNode: state.node.clicked,
   chartSize: getChartSize(state),
   chartZoom: getChartZoom(state),
   graphSize: state.graph.size || emptyGraphSize,

--- a/src/components/minimap/minimap.test.js
+++ b/src/components/minimap/minimap.test.js
@@ -147,7 +147,7 @@ describe('MiniMap', () => {
     const expectedResult = {
       visible: expect.any(Boolean),
       mapSize: expect.any(Object),
-      centralNode: null,
+      clickedNode: null,
       chartSize: expect.any(Object),
       chartZoom: expect.any(Object),
       graphSize: expect.any(Object),

--- a/src/components/node-list/node-list-row-list.js
+++ b/src/components/node-list/node-list-row-list.js
@@ -1,51 +1,7 @@
 import React from 'react';
 import modifiers from '../../utils/modifiers';
-import { connect } from 'react-redux';
 import NodeListRow, { nodeListRowHeight } from './node-list-row';
 import LazyList from '../lazy-list';
-
-const NodeRowList = ({
-  items = [],
-  group,
-  collapsed,
-  onItemClick,
-  onItemChange,
-  onItemMouseEnter,
-  onItemMouseLeave,
-}) => (
-  <ul
-    className={modifiers(
-      'pipeline-nodelist__children',
-      { closed: collapsed },
-      'pipeline-nodelist__list pipeline-nodelist__list--nested'
-    )}>
-    {items.map((item) => (
-      <NodeListRow
-        container="li"
-        key={item.id}
-        id={item.id}
-        kind={group.kind}
-        label={item.highlightedLabel}
-        name={item.name}
-        type={item.type}
-        active={item.active}
-        checked={item.checked}
-        disabled={item.disabled}
-        faded={item.faded}
-        visible={item.visible}
-        selected={item.selected}
-        unset={item.unset}
-        allUnset={group.allUnset}
-        visibleIcon={item.visibleIcon}
-        invisibleIcon={item.invisibleIcon}
-        onClick={() => onItemClick(item)}
-        onMouseEnter={() => onItemMouseEnter(item)}
-        onMouseLeave={() => onItemMouseLeave(item)}
-        onChange={(e) => onItemChange(item, !e.target.checked)}
-      />
-    ))}
-  </ul>
-);
 
 const NodeRowLazyList = ({
   items = [],
@@ -122,11 +78,4 @@ const NodeRowLazyList = ({
   </LazyList>
 );
 
-export const mapStateToProps = (state, ownProps) => ({
-  lazy: state.flags.lazy,
-  ...ownProps,
-});
-
-export default connect(mapStateToProps)((props) =>
-  props.lazy ? <NodeRowLazyList {...props} /> : <NodeRowList {...props} />
-);
+export default NodeRowLazyList;

--- a/src/components/node-list/node-list-row-list.js
+++ b/src/components/node-list/node-list-row-list.js
@@ -3,7 +3,7 @@ import modifiers from '../../utils/modifiers';
 import NodeListRow, { nodeListRowHeight } from './node-list-row';
 import LazyList from '../lazy-list';
 
-const NodeRowLazyList = ({
+const NodeRowList = ({
   items = [],
   group,
   collapsed,
@@ -78,4 +78,4 @@ const NodeRowLazyList = ({
   </LazyList>
 );
 
-export default NodeRowLazyList;
+export default NodeRowList;

--- a/src/config.js
+++ b/src/config.js
@@ -31,11 +31,6 @@ export const flags = {
     private: false,
     icon: '📈',
   },
-  lazy: {
-    description: 'Improved sidebar performance',
-    default: false,
-    icon: '😴',
-  },
   sizewarning: {
     description: 'Show a warning before rendering very large graphs',
     default: true,

--- a/src/selectors/linked-nodes.js
+++ b/src/selectors/linked-nodes.js
@@ -1,9 +1,7 @@
 import { createSelector } from 'reselect';
 import { getVisibleEdges } from './edges';
 
-const getClickedNode = (state) => state.node.clicked;
-const getHoveredNode = (state) => state.node.hovered;
-const getLazyFlag = (state) => state.flags.lazy;
+export const getClickedNode = (state) => state.node.clicked;
 
 /**
  * Get the node that should be used as the center of the set of linked nodes
@@ -11,9 +9,8 @@ const getLazyFlag = (state) => state.flags.lazy;
  * @param {string} nodeID
  */
 export const getCentralNode = createSelector(
-  [getClickedNode, getHoveredNode, getLazyFlag],
-  (clickedNode, hoveredNode, lazy) =>
-    lazy ? clickedNode : clickedNode || hoveredNode
+  [getClickedNode],
+  (clickedNode) => clickedNode
 );
 
 /**

--- a/src/selectors/linked-nodes.js
+++ b/src/selectors/linked-nodes.js
@@ -1,18 +1,7 @@
 import { createSelector } from 'reselect';
 import { getVisibleEdges } from './edges';
 
-export const getClickedNode = (state) => state.node.clicked;
-
-/**
- * Get the node that should be used as the center of the set of linked nodes
- * @param {Array} edges
- * @param {string} nodeID
- */
-export const getCentralNode = createSelector(
-  [getClickedNode],
-  (clickedNode) => clickedNode
-);
-
+const getClickedNode = (state) => state.node.clicked;
 /**
  * Gets a map of visible nodeIDs to successors nodeIDs in both directions
  * @param {Array} edges
@@ -68,7 +57,7 @@ const findLinkedNodes = (nodeID, edgesByNode, visited) => {
  * @param {string} nodeID
  */
 export const getLinkedNodes = createSelector(
-  [getVisibleEdgesByNode, getCentralNode],
+  [getVisibleEdgesByNode, getClickedNode],
   ({ sourceEdges, targetEdges }, nodeID) => {
     if (!nodeID) {
       return {};


### PR DESCRIPTION
## Description

Lazy flag is no longer required as the feature is now going to be available by default. 

## Development notes

- Lazy flag has been removed 
- The code associated with  non-lazy functionality have also been removed.
  - the NodeRowList component
  - the centralnode selector (which has been replaced my clicknode selector)

## QA notes

Ran npm t successfully

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
