### PR TITLE
[KED-2593] Set sidebar visibility default to false on mobile

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,7 @@ export const metaSidebarWidth = {
 export const sidebarWidth = {
   open: 400,
   closed: 56,
+  breakpoint: 700,
 };
 export const codeSidebarWidth = {
   open: 480,

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -2,6 +2,7 @@ import deepmerge from 'deepmerge';
 import { loadState } from './helpers';
 import normalizeData from './normalize-data';
 import { getFlagsFromUrl, Flags } from '../utils/flags';
+import { sidebarWidth } from '../config';
 
 /**
  * Create new default state instance for properties that aren't overridden
@@ -25,7 +26,7 @@ export const createInitialState = () => ({
     layerBtn: true,
     exportBtn: true,
     exportModal: false,
-    sidebar: true,
+    sidebar: window.innerWidth > sidebarWidth.breakpoint,
     code: false,
     themeBtn: true,
     miniMapBtn: true,


### PR DESCRIPTION
## Description

On smaller devices, it makes most sense to hide the sidebar by default until the user chooses to open it.

## Development notes

This might break on SSR, I haven't properly checked it yet.

## QA notes

This change will mean that devices with a screen width of less than 700 pixels will start with the sidebar closed by default on first-load (with a clear localStorage cache).

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
