### PR TITLE
Add JS variable naming section to style guide

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -156,24 +156,57 @@ Prefer:
 
 ### Variable naming
 
-- Prefer camelCase over snake_case, except in JSON.
-- Try to use verbs for function/method names, and nouns for constant values.
-- Boolean variable names should give some indication of their state.
-- Prefer clarity over brevity, and avoid single-letter names and abbreviations unless they are well known for this domain (e.g. JSON).
+In order to allow Kedro-Viz to be worked on by many developers from different backgrounds, we try to follow a consistent set of naming conventions. Beyond consistency of form, element names must be easily understood and must convey the function of each element.
+
+✔️ DO choose easily readable identifier names.
+
+For example, a variable named `horizontalAlignment` is more English-readable than `alignmentHorizontal`.
+
+✔️ DO favour readability over brevity.
+
+The variable name `canScrollHorizontally` is better than `scrollableX`.
+
+✔️ DO use verbs in the imperative mood for function/method names.
+
+The function `getSidebarLength()` is better than `sidebarLength()`, as it indicates how it should be used.
+
+✔️ DO choose Boolean variable names that give some indication of their state.
+
+This helps the reader easily infer that this variable is a Boolean value.
 
 Avoid:
 
 ```js
-const actNode = true;
-const nodeState = (d) => actNode && d.node;
+let person = true;
+let age = true;
+let dance = true;
 ```
 
 Prefer:
 
 ```js
-const isActiveNode = true;
-const getNodeState = (state) => isActiveNode && state.node;
+let isPerson = true;
+let hasAge = true;
+let canDance = true;
 ```
+
+✔️ DO use camelCase for most variable names.
+
+✔️ DO use PascalCase for class names.
+
+✔️ DO use UPPER_CASE for constant values.
+
+✔️ DO use camel-case for file names.
+
+❌ DO NOT use snake_case, except in JSON APIs.
+
+❌ DO NOT use single letter variable names.
+
+There are a few exceptions to this rule as they can be useful when working with D3, or for some common function arguments (e.g. `i` for index). But you should try to use more informative names for the most part.
+
+❌ DO NOT use abbreviations, acronyms or contractions as part of identifier names.
+
+For example, use `getObject` rather than `getObj`. The exception to this is if the acronym is well known for this domain - e.g. JSON.
 
 ### Imports
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -154,6 +154,27 @@ Prefer:
 
 ## JavaScript
 
+### Variable naming
+
+- Prefer camelCase over snake_case, except in JSON.
+- Try to use verbs for function/method names, and nouns for constant values.
+- Boolean variable names should give some indication of their state.
+- Prefer clarity over brevity, and avoid single-letter names and abbreviations.
+
+Avoid:
+
+```js
+const actNode = true;
+const nodeState = (d) => actNode && d.node;
+```
+
+Prefer:
+
+```js
+const isActiveNode = true;
+const getNodeState = (state) => isActiveNode && state.node;
+```
+
 ### Imports
 
 Although it works in regular development (because this project uses React-Scripts), you should avoid importing non-standard file-types like `.scss` and `.svg` directly into JavaScript files. This is because these won't work without specific webpack loaders, and breaks when Kedro-Viz is imported into other projects. The `lib-test` testing suite exists partly for this reason, to check that Kedro-Viz still works when imported as a component library into a fairly standard JS app.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -158,19 +158,19 @@ Prefer:
 
 In order to allow Kedro-Viz to be worked on by many developers from different backgrounds, we try to follow a consistent set of naming conventions. Beyond consistency of form, element names must be easily understood and must convey the function of each element.
 
-✔️ DO choose easily readable identifier names.
+✅ DO choose easily readable identifier names.
 
 For example, a variable named `horizontalAlignment` is more English-readable than `alignmentHorizontal`.
 
-✔️ DO favour readability over brevity.
+✅ DO favour readability over brevity.
 
 The variable name `canScrollHorizontally` is better than `scrollableX`.
 
-✔️ DO use verbs in the imperative mood for function/method names.
+✅ DO use verbs in the imperative mood for function/method names.
 
 The function `getSidebarLength()` is better than `sidebarLength()`, as it indicates how it should be used.
 
-✔️ DO prefix Boolean variable names to indicate their type, and prefer positive names.
+✅ DO prefix Boolean variable names to indicate their type, and prefer positive names.
 
 This helps the reader easily infer that this variable is a Boolean value, and helps avoid complicated double-negatives.
 
@@ -192,13 +192,13 @@ let canDance = true;
 let isDancing = false;
 ```
 
-✔️ DO use camelCase for most variable names.
+✅ DO use camelCase for most variable names.
 
-✔️ DO use PascalCase for class names.
+✅ DO use PascalCase for class names.
 
-✔️ DO use UPPER_CASE for constant values.
+✅ DO use UPPER_CASE for constant values.
 
-✔️ DO use camel-case for file names.
+✅ DO use camel-case for file names.
 
 ❌ DO NOT use snake_case, except in JSON APIs.
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -206,9 +206,9 @@ let isDancing = false;
 
 There are a few exceptions to this rule as they can be useful when working with D3, or for some common function arguments (e.g. `i` for index). But you should try to use more informative names for the most part.
 
-❌ DO NOT use abbreviations, acronyms or contractions as part of identifier names.
+❌ AVOID using abbreviations, acronyms or contractions as part of identifier names.
 
-For example, use `getObject` rather than `getObj`. The exception to this is if the acronym is well known for this domain - e.g. JSON.
+For example, prefer `getObject` instead `getObj`, unless it is practically unavoidable. The exception is if the acronym or abbreviation is well known for this domain - e.g. JSON or ID.
 
 ### Imports
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -159,7 +159,7 @@ Prefer:
 - Prefer camelCase over snake_case, except in JSON.
 - Try to use verbs for function/method names, and nouns for constant values.
 - Boolean variable names should give some indication of their state.
-- Prefer clarity over brevity, and avoid single-letter names and abbreviations.
+- Prefer clarity over brevity, and avoid single-letter names and abbreviations unless they are well known for this domain (e.g. JSON).
 
 Avoid:
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -198,7 +198,7 @@ let isDancing = false;
 
 ✅ DO use UPPER_CASE for constant values.
 
-✅ DO use camel-case for file names.
+✅ DO use kebab-case for file names.
 
 ❌ DO NOT use snake_case, except in JSON APIs.
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -170,9 +170,9 @@ The variable name `canScrollHorizontally` is better than `scrollableX`.
 
 The function `getSidebarLength()` is better than `sidebarLength()`, as it indicates how it should be used.
 
-✔️ DO choose Boolean variable names that give some indication of their state.
+✔️ DO prefix Boolean variable names to indicate their type, and prefer positive names.
 
-This helps the reader easily infer that this variable is a Boolean value.
+This helps the reader easily infer that this variable is a Boolean value, and helps avoid complicated double-negatives.
 
 Avoid:
 
@@ -180,6 +180,7 @@ Avoid:
 let person = true;
 let age = true;
 let dance = true;
+let notDancing = true;
 ```
 
 Prefer:
@@ -188,6 +189,7 @@ Prefer:
 let isPerson = true;
 let hasAge = true;
 let canDance = true;
+let isDancing = false;
 ```
 
 ✔️ DO use camelCase for most variable names.


### PR DESCRIPTION
## Description

Add some guidelines about naming variables in JavaScript.

At Liam's suggestion, I've incorporated some elements from the .NET style guide.

## Development notes

n/a

## QA notes

n/a

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
