### PR TITLE
Add test to ensure legacy dataset support

### DIFF
--- a/src/components/app/app.test.js
+++ b/src/components/app/app.test.js
@@ -14,32 +14,32 @@ describe('App', () => {
   const getState = (wrapper) => wrapper.instance().store.getState();
 
   describe('renders without crashing', () => {
-    it('when loading random data', () => {
+    test('when loading random data', () => {
       shallow(<App data={getRandomPipeline()} />);
     });
 
-    it('when loading json data', () => {
+    test('when loading json data', () => {
       shallow(<App data="json" />);
     });
 
-    it('when being passed data as a prop', () => {
+    test('when being passed data as a prop', () => {
       shallow(<App data={animals} />);
     });
   });
 
   describe('updates the store', () => {
-    it('when data prop is set on first load', () => {
+    test('when data prop is set on first load', () => {
       const wrapper = shallow(<App data={animals} />);
       expect(getState(wrapper).node).toEqual(mockState.animals.node);
     });
 
-    it('when data prop is updated', () => {
+    test('when data prop is updated', () => {
       const wrapper = shallow(<App data={demo} />);
       wrapper.setProps({ data: animals });
       expect(getState(wrapper).node).toEqual(mockState.animals.node);
     });
 
-    it('but does not override localStorage values', () => {
+    test('but does not override localStorage values', () => {
       const localState = { node: { disabled: { foo: true } } };
       saveState(localState);
       const wrapper = shallow(<App data={demo} />);
@@ -48,7 +48,7 @@ describe('App', () => {
       window.localStorage.clear();
     });
 
-    it('but does not override non-pipeline values', () => {
+    test('but does not override non-pipeline values', () => {
       const wrapper = shallow(<App data={demo} />);
       wrapper.setProps({ data: animals });
       expect(getState(wrapper)).toMatchObject(prepareNonPipelineState({}));
@@ -64,7 +64,7 @@ describe('App', () => {
   });
 
   describe('throws an error', () => {
-    it('when data prop is empty', () => {
+    test('when data prop is empty', () => {
       expect(() => shallow(<App />)).toThrow();
     });
   });

--- a/src/components/app/app.test.js
+++ b/src/components/app/app.test.js
@@ -25,6 +25,16 @@ describe('App', () => {
     test('when being passed data as a prop', () => {
       shallow(<App data={animals} />);
     });
+
+    test('when running on a legacy dataset', () => {
+      // Strip out all newer features from the test dataset and leave just
+      // the essential ones, to test backwards-compatibility:
+      const legacyDataset = {
+        nodes: animals.nodes.map(({ id, name, type }) => ({ id, name, type })),
+        edges: animals.edges.map(({ source, target }) => ({ source, target })),
+      };
+      shallow(<App data={legacyDataset} />);
+    });
   });
 
   describe('updates the store', () => {


### PR DESCRIPTION
## Description

Because it runs on different platforms which can potentially supply datasets from older versions of the API, Kedro-Viz needs to be able to support legacy datasets, and has typically tried to remain backwards-compatible when introducing new API features. This PR adds a test to ensure that this continues to be taken into account in future contributions.

## Development notes

I've also renamed 'it' to 'test' in most of the tests in this file, because it reads better - no other reason.

## QA notes

n/a

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
No functionality change, it just reads better