### PR TITLE
Refactor node list selectors and modular pipeline config

### DIFF
--- a/src/components/node-list/index.js
+++ b/src/components/node-list/index.js
@@ -50,7 +50,6 @@ const NodeListProvider = ({
   onToggleTypeDisabled,
   modularPipelines,
   modularPipelinesEnabled,
-  modularPipelineFlag,
   sections,
 }) => {
   const [searchValue, updateSearchValue] = useState('');
@@ -203,7 +202,6 @@ export const mapStateToProps = (state) => ({
   types: getNodeTypes(state),
   modularPipelines: getModularPipelineData(state),
   modularPipelinesEnabled: state.modularPipeline.enabled,
-  modularPipelineFlag: state.flags.modularpipeline,
   sections: getSections(state),
 });
 

--- a/src/components/node-list/index.js
+++ b/src/components/node-list/index.js
@@ -38,7 +38,6 @@ const NodeListProvider = ({
   nodes,
   nodeSelected,
   tags,
-  tagsEnabled,
   types,
   onToggleNodesDisabled,
   onToggleNodeSelected,
@@ -49,16 +48,13 @@ const NodeListProvider = ({
   onToggleModularPipelineFilter,
   onToggleTypeDisabled,
   modularPipelines,
-  modularPipelinesEnabled,
   sections,
 }) => {
   const [searchValue, updateSearchValue] = useState('');
   const items = getFilteredItems({
     nodes,
     tags,
-    tagsEnabled,
     modularPipelines,
-    modularPipelinesEnabled,
     nodeSelected,
     searchValue,
   });
@@ -196,12 +192,10 @@ const NodeListProvider = ({
 
 export const mapStateToProps = (state) => ({
   tags: getTagData(state),
-  tagsEnabled: state.tag.enabled,
   nodes: getGroupedNodes(state),
   nodeSelected: getNodeSelected(state),
   types: getNodeTypes(state),
   modularPipelines: getModularPipelineData(state),
-  modularPipelinesEnabled: state.modularPipeline.enabled,
   sections: getSections(state),
 });
 

--- a/src/components/node-list/node-list-items.js
+++ b/src/components/node-list/node-list-items.js
@@ -101,12 +101,11 @@ export const getFilteredTags = createSelector(
 /**
  * Return filtered/highlighted tag list items
  * @param {object} filteredTags List of filtered tags
- * @param {object} tagsEnabled Map of enabled tags
  * @return {array} Node list items
  */
 export const getFilteredTagItems = createSelector(
-  [getFilteredTags, (state) => state.tagsEnabled],
-  (filteredTags, tagsEnabled) => ({
+  getFilteredTags,
+  (filteredTags) => ({
     tag: filteredTags.tag.map((tag) => ({
       ...tag,
       type: 'tag',
@@ -117,8 +116,8 @@ export const getFilteredTagItems = createSelector(
       faded: false,
       visible: true,
       disabled: false,
-      unset: typeof tagsEnabled[tag.id] === 'undefined',
-      checked: tagsEnabled[tag.id] === true,
+      unset: !tag.enabled,
+      checked: tag.enabled,
     })),
   })
 );
@@ -141,12 +140,11 @@ export const getFilteredModularPipelines = createSelector(
 /**
  * Return filtered/highlighted modular pipeline list items
  * @param {object} filteredModularPipelines List of filtered modularPipelines
- * @param {object} modularPipelinesEnabled Map of enabled modularPipelines
  * @return {array} Node list items
  */
 export const getFilteredModularPipelineItems = createSelector(
-  [getFilteredModularPipelines, (state) => state.modularPipelinesEnabled],
-  (filteredModularPipelines, modularPipelinesEnabled) => ({
+  getFilteredModularPipelines,
+  (filteredModularPipelines) => ({
     modularPipeline: filteredModularPipelines.modularPipeline.map(
       (modularPipeline) => ({
         ...modularPipeline,
@@ -158,9 +156,8 @@ export const getFilteredModularPipelineItems = createSelector(
         faded: false,
         visible: true,
         disabled: false,
-        unset:
-          typeof modularPipelinesEnabled[modularPipeline.id] === 'undefined',
-        checked: modularPipelinesEnabled[modularPipeline.id] === true,
+        unset: !modularPipeline.enabled,
+        checked: modularPipeline.enabled,
       })
     ),
   })

--- a/src/components/node-list/node-list-items.js
+++ b/src/components/node-list/node-list-items.js
@@ -217,18 +217,31 @@ export const getFilteredNodeItems = createSelector(
 );
 
 /**
+ * Get sidebar node-list sections
+ * @param {boolean} modularPipelineFlag Whether to include modular pipelines
+ * @return {object} config
+ */
+export const getSidebarConfig = createSelector(
+  (state) => state.flags.modularpipeline,
+  (modularPipelineFlag) => {
+    if (modularPipelineFlag) {
+      return sidebar;
+    }
+    const { ModularPipelines, ...Categories } = sidebar.Categories;
+    return Object.assign({}, sidebar, { Categories });
+  }
+);
+
+/**
  * Get formatted list of sections
  * @param {boolean} flag value of modularpipeline flag
  * @return {array} List of sections
  */
-
-export const getSections = createSelector(
-  (state) => sidebar(state.flags.modularpipeline),
-  (sidebarObject) =>
-    Object.keys(sidebarObject).map((name) => ({
-      name,
-      types: Object.values(sidebarObject[name]),
-    }))
+export const getSections = createSelector(getSidebarConfig, (sidebarConfig) =>
+  Object.keys(sidebarConfig).map((name) => ({
+    name,
+    types: Object.values(sidebarConfig[name]),
+  }))
 );
 
 /**

--- a/src/components/node-list/node-list-items.js
+++ b/src/components/node-list/node-list-items.js
@@ -217,7 +217,7 @@ export const getFilteredNodeItems = createSelector(
 );
 
 /**
- * Get sidebar node-list sections
+ * Get sidebar node-list section config object, with/without modular pipelines
  * @param {boolean} modularPipelineFlag Whether to include modular pipelines
  * @return {object} config
  */

--- a/src/components/node-list/node-list-items.test.js
+++ b/src/components/node-list/node-list-items.test.js
@@ -75,7 +75,6 @@ describe('node-list-selectors', () => {
     const filteredTagItems = getFilteredTagItems({
       tags,
       searchValue,
-      tagsEnabled: {},
     }).tag;
 
     const tagItems = expect.arrayContaining([
@@ -140,8 +139,6 @@ describe('node-list-selectors', () => {
       nodes: getGroupedNodes(mockState.animals),
       tags: getTagData(mockState.animals),
       modularPipelines: getModularPipelineData(mockState.animals),
-      tagsEnabled: {},
-      modularPipelinesEnabled: {},
       nodeSelected: {},
       searchValue,
     });
@@ -189,8 +186,6 @@ describe('node-list-selectors', () => {
       nodes: getGroupedNodes(mockState.animals),
       tags: getTagData(mockState.animals),
       modularPipelines: getModularPipelineData(mockState.animals),
-      tagsEnabled: {},
-      modularPipelinesEnabled: {},
       nodeSelected: {},
       searchValue: '',
     });

--- a/src/components/node-list/node-list.test.js
+++ b/src/components/node-list/node-list.test.js
@@ -391,7 +391,6 @@ describe('NodeList', () => {
     ]);
     const expectedResult = expect.objectContaining({
       tags: expect.any(Object),
-      tagsEnabled: expect.any(Object),
       nodes: expect.objectContaining({
         data: nodeList,
         task: nodeList,
@@ -399,7 +398,6 @@ describe('NodeList', () => {
       nodeSelected: expect.any(Object),
       types: expect.any(Array),
       modularPipelines: expect.any(Object),
-      modularPipelinesEnabled: expect.any(Object),
       sections: expect.any(Object),
     });
     expect(mapStateToProps(mockState.animals)).toEqual(expectedResult);

--- a/src/components/node-list/node-list.test.js
+++ b/src/components/node-list/node-list.test.js
@@ -400,7 +400,6 @@ describe('NodeList', () => {
       types: expect.any(Array),
       modularPipelines: expect.any(Object),
       modularPipelinesEnabled: expect.any(Object),
-      modularPipelineFlag: expect.any(Boolean),
       sections: expect.any(Object),
     });
     expect(mapStateToProps(mockState.animals)).toEqual(expectedResult);

--- a/src/config.js
+++ b/src/config.js
@@ -20,7 +20,7 @@ export const codeSidebarWidth = {
 
 export const chartMinWidthScale = 0.25;
 
-// this value is used to determine the amount of nodes and edges in pipeline to trigger large warning
+// Determine the number of nodes and edges in pipeline to trigger size warning
 export const largeGraphThreshold = 1000;
 
 // Remember to update the 'Flags' section in the README when updating these:
@@ -44,29 +44,17 @@ export const flags = {
 };
 
 /**
- * returns the sidebar config object
+ * Return the sidebar config object
  * @param {string} modularPipelineFlag the modular pipeline flag
  */
-export const sidebar = (modularPipelineFlag) =>
-  modularPipelineFlag
-    ? {
-        Categories: {
-          Tags: 'tag',
-          ModularPipelines: 'modularPipeline',
-        },
-        Elements: {
-          Nodes: 'task',
-          Datasets: 'data',
-          Parameters: 'parameters',
-        },
-      }
-    : {
-        Categories: {
-          Tags: 'tag',
-        },
-        Elements: {
-          Nodes: 'task',
-          Datasets: 'data',
-          Parameters: 'parameters',
-        },
-      };
+export const sidebar = (modularPipelineFlag) => ({
+  Categories: {
+    Tags: 'tag',
+    ...(modularPipelineFlag ? { ModularPipelines: 'modularPipeline' } : {}),
+  },
+  Elements: {
+    Nodes: 'task',
+    Datasets: 'data',
+    Parameters: 'parameters',
+  },
+});

--- a/src/config.js
+++ b/src/config.js
@@ -43,18 +43,15 @@ export const flags = {
   },
 };
 
-/**
- * Return the sidebar config object
- * @param {string} modularPipelineFlag the modular pipeline flag
- */
-export const sidebar = (modularPipelineFlag) => ({
+// Sidebar node list sections
+export const sidebar = {
   Categories: {
     Tags: 'tag',
-    ...(modularPipelineFlag ? { ModularPipelines: 'modularPipeline' } : {}),
+    ModularPipelines: 'modularPipeline',
   },
   Elements: {
     Nodes: 'task',
     Datasets: 'data',
     Parameters: 'parameters',
   },
-});
+};


### PR DESCRIPTION
## Description

1. Remove unused `modularPipelineFlag` prop, which doesn't appear to be used for anything - idk why it didn't throw a linter error.
2. Simplify modular pipeline flag config, and Move utility functions and flag manipulation to a selector in the component so that the config file contains pure config objects/properties.
3. Simplify node-list filter selectors: The separate 'enabled' arguments don't seem to be necessary here, as  these values are already passed down in the main list data argument.
4. Fix a bug in the filter behaviour, where if you toggle on all nodes via the toggle-all button, then manually disabling each one individually, it would not previously revert to the default state, and now it does. This behaviour change was kind of accidental, but apparently this is how it was supposed to work all along anyway, so I don't think it's a problem.

## QA notes

Please compare the behaviour in the [demo](https://quantumblacklabs.github.io/kedro-viz/?data=animals&modularpipeline=1) to ensure that nothing is broken.

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
This prop doesn't appear to be used for anything - idk why it doesn't throw a linter error