### PR TITLE
Visualise selector hierarchy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,6 +96,8 @@ Redux reducers are placed in `/src/reducers/`. We use a [combineReducers](https:
 
 Selectors can be found in `/src/selectors/`. We use [Reselect](https://github.com/reduxjs/reselect) to derive data from the state and translate it into useful data structures while keeping it memoised in order to prevent repeated calculations when the original values have not changed. In order to avoid circular imports, we've occasionally needed to get creative with file naming, hence the low-level 'disabled' selectors are separated into different files from the rest of the node/edge/tag selectors.
 
+We have used Kedro-Viz to visualize the selector dependency graph - [visit the demo to see it in action](https://quantumblacklabs.github.io/kedro-viz/?data=selectors).
+
 ## Utils
 
 The `/src/utils/` directory contains miscellaneous reusable utility functions.

--- a/src/selectors/layout.js
+++ b/src/selectors/layout.js
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect';
 import { getVisibleNodes } from './nodes';
 import { getVisibleEdges } from './edges';
 import { getVisibleLayerIDs } from './disabled';
-import { getVisibleMetaSidebar } from '../selectors/metadata';
+import { getVisibleMetaSidebar } from './metadata';
 import {
   sidebarWidth,
   metaSidebarWidth,

--- a/src/utils/data-source.js
+++ b/src/utils/data-source.js
@@ -1,6 +1,7 @@
 import getRandomPipeline from './random-data';
 import animals from './data/animals.mock.json';
 import demo from './data/demo.mock.json';
+import selectors from './data/selectors.mock.json';
 
 /**
  * Determine the data source ID from the URL query string, or an environment
@@ -46,6 +47,9 @@ export const getDataValue = (source) => {
     case 'demo':
       // Use data from the 'demo' test dataset
       return nameSource(demo);
+    case 'selectors':
+      // Use data from the 'selectors' test dataset
+      return nameSource(selectors);
     case 'random':
       // Use procedurally-generated data
       return nameSource(getRandomPipeline());
@@ -54,7 +58,7 @@ export const getDataValue = (source) => {
       return source;
     default:
       throw new Error(
-        `Unexpected data source value '${source}'. Your input should be one of the following values: 'animals', 'demo', 'json', or 'random'`
+        `Unexpected data source value '${source}'. Your input should be one of the following values: 'animals', 'demo', 'json', 'selectors', or 'random'`
       );
   }
 };

--- a/src/utils/data/selectors.mock.json
+++ b/src/utils/data/selectors.mock.json
@@ -1,0 +1,98 @@
+{
+  "edges": [
+    { "source": "pipeline", "target": "modular-pipelines" },
+    { "source": "pipeline", "target": "tags" },
+    { "source": "pipeline", "target": "disabled" },
+    { "source": "modular-pipelines", "target": "disabled" },
+    { "source": "tags", "target": "disabled" },
+    { "source": "pipeline", "target": "edges" },
+    { "source": "modular-pipelines", "target": "edges" },
+    { "source": "disabled", "target": "edges" },
+    { "source": "disabled", "target": "ranks" },
+    { "source": "edges", "target": "ranks" },
+    { "source": "disabled", "target": "layers" },
+    { "source": "disabled", "target": "node-types" },
+    { "source": "pipeline", "target": "nodes" },
+    { "source": "modular-pipelines", "target": "nodes" },
+    { "source": "disabled", "target": "nodes" },
+    { "source": "ranks", "target": "nodes" },
+    { "source": "nodes", "target": "layout" },
+    { "source": "edges", "target": "layout" },
+    { "source": "disabled", "target": "layout" },
+    { "source": "nodes", "target": "metadata" },
+    { "source": "edges", "target": "linked-nodes" },
+    { "source": "metadata", "target": "layout" }
+  ],
+  "nodes": [
+    {
+      "id": "pipeline",
+      "name": "pipeline",
+      "type": "task"
+    },
+    {
+      "id": "modular-pipelines",
+      "name": "modular-pipelines",
+      "type": "task"
+    },
+    {
+      "id": "tags",
+      "name": "tags",
+      "type": "task"
+    },
+    {
+      "id": "disabled",
+      "name": "disabled",
+      "type": "task"
+    },
+    {
+      "id": "edges",
+      "name": "edges",
+      "type": "task"
+    },
+    {
+      "id": "ranks",
+      "name": "ranks",
+      "type": "task"
+    },
+    {
+      "id": "nodes",
+      "name": "nodes",
+      "type": "task"
+    },
+    {
+      "id": "layers",
+      "name": "layers",
+      "type": "task"
+    },
+    {
+      "id": "layout",
+      "name": "layout",
+      "type": "task"
+    },
+    {
+      "id": "linked-nodes",
+      "name": "linked-nodes",
+      "type": "task"
+    },
+    {
+      "id": "loading",
+      "name": "loading",
+      "type": "task"
+    },
+    {
+      "id": "metadata",
+      "name": "metadata",
+      "type": "task"
+    },
+    {
+      "id": "node-types",
+      "name": "node-types",
+      "type": "task"
+    },
+    {
+      "id": "loading",
+      "name": "loading",
+      "type": "task"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

While working on the selectors for #430, I kept losing track of which bit of selector code depends on which. So in a moment of frustration, I decided to use Kedro-Viz to make a dependency tree graph of its own selectors, which makes it a lot easier to see how they all interconnect:

![image](https://user-images.githubusercontent.com/1155816/116258022-78355600-a76c-11eb-9144-90c07343a256.png)

## Development notes

Pros: Easy to update
Cons: Difficult to remember to maintain

## QA notes

You will note that the link to the demo doesn't work, because the demo hasn't been updated yet :)

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
