### PR TITLE
Refactor initial-state setup to reduce complexity

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "highlight.js": "^10.5.0",
     "kiwi.js": "^1.1.2",
     "konami-code": "^0.2.1",
+    "lodash.clonedeep": "^4.5.0",
     "react-custom-scrollbars": "^4.2.1",
     "react-redux": "^7.2.2",
     "react-test-renderer": "^17.0.1",

--- a/src/actions/pipelines.test.js
+++ b/src/actions/pipelines.test.js
@@ -1,6 +1,6 @@
 import { createStore } from 'redux';
 import reducer from '../reducers';
-import { mockState } from '../utils/state.mock';
+import { mockState, prepareState } from '../utils/state.mock';
 import { saveState } from '../store/helpers';
 import {
   updateActivePipeline,
@@ -110,7 +110,7 @@ describe('pipeline actions', () => {
 
       it("should reset the active pipeline if its ID isn't included in the list of pipeline IDs", async () => {
         saveState({ pipeline: { active: 'unknown-id' } });
-        const store = createStore(reducer, mockState.json);
+        const store = createStore(reducer, prepareState({ data: 'json' }));
         await loadInitialPipelineData()(store.dispatch, store.getState);
         const state = store.getState();
         expect(state.pipeline.active).toBe(state.pipeline.main);
@@ -121,7 +121,7 @@ describe('pipeline actions', () => {
         const { pipeline } = mockState.animals;
         const active = pipeline.ids.find((id) => id !== pipeline.main);
         saveState({ pipeline: { active } });
-        const store = createStore(reducer, mockState.json);
+        const store = createStore(reducer, prepareState({ data: 'json' }));
         await loadInitialPipelineData()(store.dispatch, store.getState);
         expect(store.getState().pipeline.active).toBe(active);
         expect(store.getState().node).toEqual(mockState.demo.node);
@@ -140,7 +140,7 @@ describe('pipeline actions', () => {
         const { pipeline } = mockState.animals;
         const active = pipeline.ids.find((id) => id !== pipeline.main);
         saveState({ pipeline: { active } });
-        const store = createStore(reducer, mockState.json);
+        const store = createStore(reducer, prepareState({ data: 'json' }));
         await loadInitialPipelineData()(store.dispatch, store.getState);
         expect(store.getState().node).toEqual(mockState.animals.node);
       });

--- a/src/components/app/app.test.js
+++ b/src/components/app/app.test.js
@@ -8,7 +8,7 @@ import demo from '../../utils/data/demo.mock.json';
 import { mockState } from '../../utils/state.mock';
 import { Flags } from '../../utils/flags';
 import { saveState } from '../../store/helpers';
-import { prepareNonPipelineState } from '../../store/initial-state';
+import { initialState } from '../../store/initial-state';
 
 describe('App', () => {
   const getState = (wrapper) => wrapper.instance().store.getState();
@@ -59,9 +59,14 @@ describe('App', () => {
     });
 
     test('but does not override non-pipeline values', () => {
+      const localState = { visible: { exportModal: true } };
+      saveState(localState);
       const wrapper = shallow(<App data={demo} />);
       wrapper.setProps({ data: animals });
-      expect(getState(wrapper)).toMatchObject(prepareNonPipelineState({}));
+      expect(getState(wrapper).visible).toMatchObject({
+        ...initialState.visible,
+        ...localState.visible,
+      });
     });
   });
 

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -5,6 +5,7 @@ import 'what-input';
 import '@quantumblack/kedro-ui/lib/styles/app-no-webfont.css';
 import LoadWebFont from '@quantumblack/kedro-ui/lib/utils/webfont.js';
 import configureStore from '../../store';
+import resetPipelineState from '../../store/reset';
 import { resetData, updateFontLoaded } from '../../actions';
 import { loadInitialPipelineData } from '../../actions/pipelines';
 import Wrapper from '../wrapper';
@@ -71,7 +72,10 @@ class App extends React.Component {
    * Dispatch an action to update the store with new pipeline data
    */
   updatePipelineData() {
-    const newState = normalizeData(this.store.getState(), this.props.data);
+    const newState = normalizeData(
+      resetPipelineState(this.store.getState()),
+      this.props.data
+    );
     this.store.dispatch(resetData(newState));
   }
 

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -8,9 +8,8 @@ import configureStore from '../../store';
 import { resetData, updateFontLoaded } from '../../actions';
 import { loadInitialPipelineData } from '../../actions/pipelines';
 import Wrapper from '../wrapper';
-import getInitialState, {
-  preparePipelineState,
-} from '../../store/initial-state';
+import getInitialState from '../../store/initial-state';
+import normalizeData from '../../store/normalize-data';
 import { getFlagsMessage } from '../../utils/flags';
 import './app.css';
 
@@ -72,7 +71,7 @@ class App extends React.Component {
    * Dispatch an action to update the store with new pipeline data
    */
   updatePipelineData() {
-    const newState = preparePipelineState(this.props.data, true);
+    const newState = normalizeData(this.store.getState(), this.props.data);
     this.store.dispatch(resetData(newState));
   }
 

--- a/src/store/helpers.js
+++ b/src/store/helpers.js
@@ -1,3 +1,4 @@
+import deepmerge from 'deepmerge';
 import { localStorageName } from '../config';
 
 const noWindow = typeof window === 'undefined';
@@ -42,6 +43,22 @@ export const saveState = (state) => {
   } catch (err) {
     console.error(err);
   }
+};
+
+/**
+ * Load values from localStorage and combine with existing state,
+ * but filter out any unused properties
+ * @param {object} state Initial/extant state
+ * @return {object} Combined state from localStorage
+ */
+export const mergeLocalStorage = (state) => {
+  const localStorageState = loadState();
+  Object.keys(localStorageState).forEach((key) => {
+    if (!state[key]) {
+      delete localStorageState[key];
+    }
+  });
+  return deepmerge(state, localStorageState);
 };
 
 /**

--- a/src/store/helpers.test.js
+++ b/src/store/helpers.test.js
@@ -1,4 +1,22 @@
-import { saveState, mergeLocalStorage } from './helpers';
+import {
+  loadState,
+  saveState,
+  mergeLocalStorage,
+  pruneFalseyKeys,
+} from './helpers';
+
+describe('loadState and saveState', () => {
+  it('saves and retrieves localStorage values', () => {
+    expect(loadState()).toEqual({});
+    const localStorageValues = {
+      textLabels: false,
+      theme: 'light',
+      tag: { enabled: 'medium' },
+    };
+    saveState(localStorageValues);
+    expect(loadState()).toEqual(localStorageValues);
+  });
+});
 
 describe('mergeLocalStorage', () => {
   it('overrides state values with localstorage values if provided', () => {
@@ -31,5 +49,19 @@ describe('mergeLocalStorage', () => {
     expect(
       mergeLocalStorage({ quz: 'quux', foo: { bar: 30, foo: 'foo' } })
     ).toMatchObject({ quz: 'quux', foo: { bar: 1, baz: 2, foo: 'foo' } });
+  });
+});
+
+describe('pruneFalseyKeys', () => {
+  it('removes only falsey keys from an object', () => {
+    expect(pruneFalseyKeys({})).toEqual({});
+    expect(pruneFalseyKeys({ foo: true, bar: false })).toEqual({ foo: true });
+    expect(pruneFalseyKeys({ foo: 'hello', bar: undefined })).toEqual({
+      foo: 'hello',
+    });
+    expect(pruneFalseyKeys({ foo: 1, bar: 0 })).toEqual({ foo: 1 });
+    expect(pruneFalseyKeys({ foo: Infinity, bar: null })).toEqual({
+      foo: Infinity,
+    });
   });
 });

--- a/src/store/helpers.test.js
+++ b/src/store/helpers.test.js
@@ -1,0 +1,35 @@
+import { saveState, mergeLocalStorage } from './helpers';
+
+describe('mergeLocalStorage', () => {
+  it('overrides state values with localstorage values if provided', () => {
+    const localStorageValues = {
+      textLabels: false,
+      theme: 'light',
+      tag: { enabled: 'medium' },
+    };
+    saveState(localStorageValues);
+    expect(
+      mergeLocalStorage({
+        textLabels: true,
+        theme: 'dark',
+        tag: { enabled: 'large' },
+      })
+    ).toMatchObject(localStorageValues);
+    window.localStorage.clear();
+  });
+
+  it('does not add values if localStorage keys do not match state values', () => {
+    const extraValues = {
+      additional: 1,
+      props: '2',
+    };
+    expect(mergeLocalStorage(extraValues)).toMatchObject(extraValues);
+  });
+
+  it('deep-merges nested objects', () => {
+    saveState({ foo: { bar: 1, baz: 2 } });
+    expect(
+      mergeLocalStorage({ quz: 'quux', foo: { bar: 30, foo: 'foo' } })
+    ).toMatchObject({ quz: 'quux', foo: { bar: 1, baz: 2, foo: 'foo' } });
+  });
+});

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -4,12 +4,7 @@ import normalizeData from './normalize-data';
 import { getFlagsFromUrl, Flags } from '../utils/flags';
 import { sidebarWidth } from '../config';
 
-/**
- * Create new default state instance for properties that aren't overridden
- * when the pipeline is reset with new data via the App component's data prop
- * @return {object} state
- */
-export const createInitialState = () => ({
+const initialState = {
   chartSize: {},
   edge: {
     ids: [],
@@ -87,7 +82,7 @@ export const createInitialState = () => ({
     miniMap: true,
   },
   zoom: {},
-});
+};
 
 /**
  * Load values from localStorage and combine with existing state,
@@ -113,10 +108,7 @@ export const mergeLocalStorage = (state) => {
  * @return {object} Initial state
  */
 const getInitialState = (props = {}) => {
-  const state = normalizeData(
-    mergeLocalStorage(createInitialState()),
-    props.data
-  );
+  const state = normalizeData(mergeLocalStorage(initialState), props.data);
   state.flags = { ...state.flags, ...getFlagsFromUrl() };
   state.theme = props.theme || state.theme;
   state.visible = { ...state.visible, ...props.visible };

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -4,7 +4,7 @@ import normalizeData from './normalize-data';
 import { getFlagsFromUrl, Flags } from '../utils/flags';
 import { sidebarWidth } from '../config';
 
-const initialState = {
+export const initialState = {
   chartSize: {},
   edge: {
     ids: [],

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -1,5 +1,4 @@
-import deepmerge from 'deepmerge';
-import { loadState } from './helpers';
+import { mergeLocalStorage } from './helpers';
 import normalizeData from './normalize-data';
 import { getFlagsFromUrl, Flags } from '../utils/flags';
 import { sidebarWidth } from '../config';
@@ -82,22 +81,6 @@ export const initialState = {
     miniMap: true,
   },
   zoom: {},
-};
-
-/**
- * Load values from localStorage and combine with existing state,
- * but filter out any unused values from localStorage
- * @param {object} state Initial/extant state
- * @return {object} Combined state from localStorage
- */
-export const mergeLocalStorage = (state) => {
-  const localStorageState = loadState();
-  Object.keys(localStorageState).forEach((key) => {
-    if (!state[key]) {
-      delete localStorageState[key];
-    }
-  });
-  return deepmerge(state, localStorageState);
 };
 
 /**

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -113,8 +113,9 @@ export const mergeLocalStorage = (state) => {
  * @return {object} Initial state
  */
 const getInitialState = (props = {}) => {
-  const state = mergeLocalStorage(
-    normalizeData(createInitialState(), props.data)
+  const state = normalizeData(
+    mergeLocalStorage(createInitialState()),
+    props.data
   );
   state.flags = { ...state.flags, ...getFlagsFromUrl() };
   state.theme = props.theme || state.theme;

--- a/src/store/initial-state.test.js
+++ b/src/store/initial-state.test.js
@@ -1,40 +1,6 @@
-import getInitialState, { mergeLocalStorage } from './initial-state';
+import getInitialState from './initial-state';
 import { saveState } from './helpers';
 import animals from '../utils/data/animals.mock.json';
-
-describe('mergeLocalStorage', () => {
-  it('overrides state values with localstorage values if provided', () => {
-    const localStorageValues = {
-      textLabels: false,
-      theme: 'light',
-      tag: { enabled: 'medium' },
-    };
-    saveState(localStorageValues);
-    expect(
-      mergeLocalStorage({
-        textLabels: true,
-        theme: 'dark',
-        tag: { enabled: 'large' },
-      })
-    ).toMatchObject(localStorageValues);
-    window.localStorage.clear();
-  });
-
-  it('does not add values if localStorage keys do not match state values', () => {
-    const extraValues = {
-      additional: 1,
-      props: '2',
-    };
-    expect(mergeLocalStorage(extraValues)).toMatchObject(extraValues);
-  });
-
-  it('deep-merges nested objects', () => {
-    saveState({ foo: { bar: 1, baz: 2 } });
-    expect(
-      mergeLocalStorage({ quz: 'quux', foo: { bar: 30, foo: 'foo' } })
-    ).toMatchObject({ quz: 'quux', foo: { bar: 1, baz: 2, foo: 'foo' } });
-  });
-});
 
 describe('getInitialState', () => {
   const props = { data: animals };

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -155,7 +155,7 @@ const addNode = (state) => (node) => {
  */
 const addEdge = (state) => ({ source, target }) => {
   const id = createEdgeID(source, target);
-  if (state.edge.ids.includes(id)) {
+  if (state.edge.sources[id]) {
     return;
   }
   state.edge.ids.push(id);
@@ -169,17 +169,22 @@ const addEdge = (state) => ({ source, target }) => {
  */
 const addTag = (state) => (tag) => {
   const { id } = tag;
+  if (state.tag.name[id]) {
+    return;
+  }
   state.tag.ids.push(id);
   state.tag.name[id] = tag.name;
 };
 
 /**
  * Add a new Layer if it doesn't already exist
- * @param {Object} layer - Layer object
+ * @param {string} layer - Layer ID
  */
 const addLayer = (state) => (layer) => {
-  // using layer name as both layerId and name.
-  // It futureproofs it if we need a separate layer ID in the future.
+  // Use layer name as both layer ID and name
+  if (state.layer.name[layer]) {
+    return;
+  }
   state.layer.ids.push(layer);
   state.layer.name[layer] = layer;
 };

--- a/src/store/normalize-data.test.js
+++ b/src/store/normalize-data.test.js
@@ -1,26 +1,33 @@
-import normalizeData, { createInitialPipelineState } from './normalize-data';
+import normalizeData from './normalize-data';
+import { initialState } from './initial-state';
 import animals from '../utils/data/animals.mock.json';
-
-const initialState = createInitialPipelineState();
 
 describe('normalizeData', () => {
   it('should throw an error when data prop is empty or false', () => {
-    expect(() => normalizeData(undefined)).toThrow();
-    expect(() => normalizeData(null)).toThrow();
-    expect(() => normalizeData(false)).toThrow();
+    expect(() => normalizeData(initialState, undefined)).toThrow();
+    expect(() => normalizeData(initialState, null)).toThrow();
+    expect(() => normalizeData(initialState, false)).toThrow();
   });
 
   it('should return initialState if input is invalid', () => {
-    expect(() => normalizeData({})).toThrow();
-    expect(() => normalizeData({ nodes: null, edges: {} })).toThrow();
-    expect(() => normalizeData({ nodes: true, edges: 100 })).toThrow();
+    expect(() => normalizeData(initialState, {})).toThrow();
+    expect(() =>
+      normalizeData(initialState, { nodes: null, edges: {} })
+    ).toThrow();
+    expect(() =>
+      normalizeData(initialState, { nodes: true, edges: 100 })
+    ).toThrow();
   });
 
   it('should return initialState if input is "json"', () => {
-    expect(normalizeData('json')).toEqual({
+    expect(normalizeData(initialState, 'json')).toEqual({
       ...initialState,
       dataSource: 'json',
     });
+  });
+
+  it('should return a clone of initialState and not mutate the original object', () => {
+    expect(normalizeData(initialState, animals)).not.toBe(initialState);
   });
 
   it('should not add tags if tags are not supplied', () => {
@@ -28,7 +35,7 @@ describe('normalizeData', () => {
     data.nodes.forEach((node) => {
       delete node.tags;
     });
-    expect(normalizeData(data).tag.ids).toHaveLength(0);
+    expect(normalizeData(initialState, data).tag.ids).toHaveLength(0);
   });
 
   it('should not add pipelines if pipelines are not supplied', () => {
@@ -36,7 +43,7 @@ describe('normalizeData', () => {
     data.nodes.forEach((node) => {
       delete node.pipelines;
     });
-    expect(normalizeData(data).pipeline.ids).toHaveLength(0);
+    expect(normalizeData(initialState, data).pipeline.ids).toHaveLength(0);
   });
 
   it('should not add an active pipeline if pipelines.length is 0', () => {
@@ -44,12 +51,14 @@ describe('normalizeData', () => {
     data.nodes.forEach((node) => {
       node.pipelines = [];
     });
-    expect(normalizeData(data).pipeline.active).toBe(undefined);
+    expect(normalizeData(initialState, data).pipeline.active).toBe(undefined);
   });
 
   it('should not add modular pipelines if modular pipelines are not supplied', () => {
     const data = Object.assign({}, animals, { modular_pipelines: undefined });
-    expect(normalizeData(data).modularPipeline.ids).toHaveLength(0);
+    expect(normalizeData(initialState, data).modularPipeline.ids).toHaveLength(
+      0
+    );
   });
 
   it('should not add duplicate modular pipelines', () => {
@@ -65,7 +74,9 @@ describe('normalizeData', () => {
         },
       ],
     });
-    expect(normalizeData(data).modularPipeline.ids).toHaveLength(1);
+    expect(normalizeData(initialState, data).modularPipeline.ids).toHaveLength(
+      1
+    );
   });
 
   it('should not add layers if layers are not supplied', () => {
@@ -73,16 +84,16 @@ describe('normalizeData', () => {
     data.nodes.forEach((node) => {
       delete node.layer;
     });
-    expect(normalizeData(data).layer.ids).toHaveLength(0);
+    expect(normalizeData(initialState, data).layer.ids).toHaveLength(0);
   });
 
   it('should not add duplicate nodes', () => {
-    const data = Object.assign({}, animals);
-    data.nodes.push(data.nodes[0]);
-    data.nodes.push(data.nodes[1]);
-    data.nodes.push(data.nodes[2]);
-    expect(normalizeData(data).node.ids.length).toEqual(
-      normalizeData(animals).node.ids.length
+    const { nodes } = animals;
+    const data = Object.assign({}, animals, {
+      nodes: [...nodes, nodes[0], nodes[1], nodes[2]],
+    });
+    expect(normalizeData(initialState, data).node.ids.length).toEqual(
+      normalizeData(initialState, animals).node.ids.length
     );
   });
 
@@ -92,11 +103,37 @@ describe('normalizeData', () => {
       node.name = node.name + '-name';
       delete node.full_name;
     });
-    const state = normalizeData(data);
+    const state = normalizeData(initialState, data);
     expect(
       state.node.ids.every(
         (nodeID) => state.node.fullName[nodeID] === state.node.name[nodeID]
       )
     ).toBe(true);
+  });
+
+  it('sets pipeline.main to be data.selected_pipeline', () => {
+    const state = normalizeData(initialState, animals);
+    expect(state.pipeline.main).toBe(animals.selected_pipeline);
+  });
+
+  it('sets pipeline.main to the first pipeline in the list if selected_pipeline is not supplied', () => {
+    const data = Object.assign({}, animals);
+    delete data.selected_pipeline;
+    const state = normalizeData(initialState, data);
+    expect(state.pipeline.main).toBe(animals.pipelines[0].id);
+  });
+
+  it('sets main pipeline as active if active pipeline from localStorage is not one of the pipelines in the current list', () => {
+    const state = normalizeData(
+      {
+        ...initialState,
+        pipeline: {
+          ...initialState.pipeline,
+          active: 'unknown pipeline id',
+        },
+      },
+      animals
+    );
+    expect(state.pipeline.active).toBe(animals.selected_pipeline);
   });
 });

--- a/src/store/reset.js
+++ b/src/store/reset.js
@@ -1,26 +1,30 @@
+import { mergeLocalStorage } from './initial-state';
+
 /**
- * Empty the store of all pipeline data
+ * Empty the store of all pipeline-related data entries,
+ * while maintaining stored values from localStorage
  * @param {object} state Full state snapshot
- * @returns state
+ * @returns state State with pipeline info removed
  */
 const resetPipelineState = (state) => {
   const { isArray } = Array;
   const isObject = (d) => typeof d === 'object' && d !== null && !isArray(d);
-  const keys = ['edge', 'layer', 'modularPipeline', 'node', 'pipeline', 'tag'];
+  // State data type keys that should be reset, e.g. state.edge
+  const types = ['edge', 'layer', 'modularPipeline', 'node', 'pipeline', 'tag'];
   const newState = { ...state };
-  for (const i of keys) {
-    const property = state[i];
-    const newProperty = { ...property };
-    for (const key of Object.keys(property)) {
-      if (isObject(property[key])) {
-        newProperty[key] = {};
-      } else if (isArray(property[key])) {
-        newProperty[key] = [];
+  for (const type of types) {
+    const typeData = { ...state[type] };
+    for (const key of Object.keys(typeData)) {
+      if (isObject(typeData[key])) {
+        typeData[key] = {};
+      } else if (isArray(typeData[key])) {
+        typeData[key] = [];
       }
     }
-    newState[i] = newProperty;
+    newState[type] = typeData;
   }
-  return newState;
+  // Reapply erased localStorage values:
+  return mergeLocalStorage(newState);
 };
 
 export default resetPipelineState;

--- a/src/store/reset.js
+++ b/src/store/reset.js
@@ -1,0 +1,26 @@
+/**
+ * Empty the store of all pipeline data
+ * @param {object} state Full state snapshot
+ * @returns state
+ */
+const resetPipelineState = (state) => {
+  const { isArray } = Array;
+  const isObject = (d) => typeof d === 'object' && d !== null && !isArray(d);
+  const keys = ['edge', 'layer', 'modularPipeline', 'node', 'pipeline', 'tag'];
+  const newState = { ...state };
+  for (const i of keys) {
+    const property = state[i];
+    const newProperty = { ...property };
+    for (const key of Object.keys(property)) {
+      if (isObject(property[key])) {
+        newProperty[key] = {};
+      } else if (isArray(property[key])) {
+        newProperty[key] = [];
+      }
+    }
+    newState[i] = newProperty;
+  }
+  return newState;
+};
+
+export default resetPipelineState;

--- a/src/store/reset.js
+++ b/src/store/reset.js
@@ -1,4 +1,9 @@
-import { mergeLocalStorage } from './helpers';
+import { loadState } from './helpers';
+
+const { isArray } = Array;
+
+// Determine whether something is an object literal (i.e. `{}`)
+const isObject = (d) => typeof d === 'object' && d !== null && !isArray(d);
 
 /**
  * Empty the store of all pipeline-related data entries,
@@ -7,15 +12,19 @@ import { mergeLocalStorage } from './helpers';
  * @returns state State with pipeline info removed
  */
 const resetPipelineState = (state) => {
-  const { isArray } = Array;
-  const isObject = (d) => typeof d === 'object' && d !== null && !isArray(d);
   // State data type keys that should be reset, e.g. state.edge
   const types = ['edge', 'layer', 'modularPipeline', 'node', 'pipeline', 'tag'];
   const newState = { ...state };
+  const localStorageState = loadState();
+
   for (const type of types) {
     const typeData = { ...state[type] };
+
     for (const key of Object.keys(typeData)) {
-      if (isObject(typeData[key])) {
+      if (localStorageState?.[type]?.[key]) {
+        // Don't overwrite properties that are present in localStorage
+        continue;
+      } else if (isObject(typeData[key])) {
         typeData[key] = {};
       } else if (isArray(typeData[key])) {
         typeData[key] = [];
@@ -23,8 +32,8 @@ const resetPipelineState = (state) => {
     }
     newState[type] = typeData;
   }
-  // Reapply erased localStorage values:
-  return mergeLocalStorage(newState);
+
+  return newState;
 };
 
 export default resetPipelineState;

--- a/src/store/reset.js
+++ b/src/store/reset.js
@@ -1,4 +1,4 @@
-import { mergeLocalStorage } from './initial-state';
+import { mergeLocalStorage } from './helpers';
 
 /**
  * Empty the store of all pipeline-related data entries,

--- a/src/store/reset.test.js
+++ b/src/store/reset.test.js
@@ -1,0 +1,38 @@
+import resetPipelineState from './reset';
+import { saveState } from './helpers';
+import { mockState, prepareState } from '../utils/state.mock';
+import animals from '../utils/data/animals.mock.json';
+import { initialState } from './initial-state';
+
+describe('resetPipelineState', () => {
+  it('resets pipeline data back to initial state', () => {
+    expect(resetPipelineState(mockState.animals)).toMatchObject(initialState);
+  });
+
+  it('only resets pipeline-related data', () => {
+    expect(
+      resetPipelineState({
+        theme: 'light',
+        visible: { sidebar: true },
+        node: { ids: ['one', 'two'] },
+      })
+    ).toMatchObject({
+      theme: 'light',
+      visible: { sidebar: true },
+      node: { ids: [] },
+    });
+  });
+
+  it('does not delete localStorage values', () => {
+    const active = animals.pipelines.find(
+      (pipeline) => pipeline.id !== animals.selected_pipeline
+    ).id;
+    const localStorageValues = {
+      node: { disabled: { foo: true } },
+      pipeline: { active },
+    };
+    saveState(localStorageValues);
+    const state = prepareState({ data: animals });
+    expect(resetPipelineState(state)).toMatchObject(localStorageValues);
+  });
+});


### PR DESCRIPTION
## Description

1. Remove the pipeline state initialisation (`createInitialPipelineState`) from `normalize-data.js` and combine it all with the main createInitialState. The data normalizer should be kept relatively pure.
2. Get rid of the separation between `prepareNonPipelineState` and `preparePipelineState`. Instead, when we want to reset the pipeline data (e.g. when loading a new pipeline), use a dedicated reset action that manually deletes the required properties from the overall state.

## Development notes

1. Based on a suggestion from @studioswong, the app no longer deletes existing pipeline data when loading new data from another pipeline endpoint. Instead, it relies on the pipeline selectors, and just adds the new data to the store so that it's ready immediately. We could capitalize on this further by checking whether a pipeline is loaded before making a new redundant request.
2. We'll need to update the Architecture docs & particularly the diagram, as it's now changed significantly. @studioswong I'll need your help with this!

## QA notes

These changes significantly affect the data loading and state initialisation, so we'll need to thoroughly QA how it interacts with localStorage application, switching pipelines, async/sync data loading, and resetting the state when running inside another application.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
Avoid array.includes for performance reasons