### PR TITLE
Temporarily upgrade Flask before the new backend is merged

### DIFF
--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,4 +1,4 @@
 semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
-Flask>=1.0, <2.0
+Flask>=2.0
 kedro>=0.16.0
 ipython>=7.0.0, <8.0


### PR DESCRIPTION
## Description

Flask >= 2.0 causes Jinja2 >= 3.0 to be installed which conflicts with the cookiecutter version Kedro is using.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
