### PR TITLE
Make sure we don't apply a 0 transform on initial chart loading

### DIFF
--- a/src/utils/view.js
+++ b/src/utils/view.js
@@ -75,7 +75,7 @@ export const isOrigin = ({ x, y, k }) =>
  * @returns {Boolean} True if the transform is invalid else false
  */
 export const isInvalidTransform = ({ x, y, k }) =>
-  !isFinite(x + y + k) || isNaN(x + y + k);
+  !isFinite(x + y + k) || isNaN(x + y + k) || (x === 0 && y === 0 && k === 0);
 
 /**
  * Returns the current transform of the given view.

--- a/src/utils/view.test.js
+++ b/src/utils/view.test.js
@@ -84,7 +84,7 @@ describe('view', () => {
   });
 
   describe('isInvalidTransform', () => {
-    it('returns true if any component is infinite, `NaN` or `undefined` otherwise false', () => {
+    it('returns true if any component is infinite, `NaN` or `undefined` or `(0,0,0)` otherwise false', () => {
       expect(isInvalidTransform({})).toBe(true);
 
       expect(isInvalidTransform({ x: Infinity, y: 0, k: 0 })).toBe(true);
@@ -94,6 +94,7 @@ describe('view', () => {
       expect(isInvalidTransform({ x: NaN, y: 0, k: 0 })).toBe(true);
       expect(isInvalidTransform({ x: 0, y: NaN, k: 0 })).toBe(true);
       expect(isInvalidTransform({ x: 0, y: 0, k: NaN })).toBe(true);
+      expect(isInvalidTransform({ x: 0, y: 0, k: 0 })).toBe(true);
 
       expect(isInvalidTransform({ x: undefined, y: 0, k: 0 })).toBe(true);
       expect(isInvalidTransform({ x: 0, y: undefined, k: 0 })).toBe(true);
@@ -103,7 +104,6 @@ describe('view', () => {
         true
       );
 
-      expect(isInvalidTransform({ x: 0, y: 0, k: 0 })).toBe(false);
       expect(isInvalidTransform({ x: 1, y: 1, k: 1 })).toBe(false);
       expect(isInvalidTransform({ x: -1, y: -1, k: -1 })).toBe(false);
     });


### PR DESCRIPTION
## Description

I notice that if the chart size takes time to calculate, the transform in the first few frames is 0,0,0, which results in a broken viz.

<img width="1440" alt="Screenshot 2021-06-03 at 14 15 00" src="https://user-images.githubusercontent.com/2032984/120686457-e3bfc100-c498-11eb-9097-83314a9b7394.png">

We shouldn't apply the transform in this case. When a valid transform becomes available, it will be applied accordingly

![Screenshot 2021-06-03 at 18 21 46](https://user-images.githubusercontent.com/2032984/120686280-bd018a80-c498-11eb-8a81-ce89c493a63b.png)

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
