### PR TITLE
Fixes on plotly - Remove legend from preview + fix legend on modal

### DIFF
--- a/src/utils/plot-templates/dark.js
+++ b/src/utils/plot-templates/dark.js
@@ -187,13 +187,16 @@ const darkTemplate = {
 
 export const darkPreviewTemplate = {
   ...darkTemplate,
-  title: '',
+  height: 300,
   margin: {
     l: 100,
     r: 40,
     t: 40,
     b: 70,
   },
+  showlegend: false,
+  title: '',
+  width: 400,
   xaxis: {
     ...darkTemplate.xaxis,
     title: {
@@ -224,8 +227,6 @@ export const darkPreviewTemplate = {
     },
     nticks: 5,
   },
-  height: 300,
-  width: 400,
 };
 
 export const darkModalTemplate = {

--- a/src/utils/plot-templates/dark.js
+++ b/src/utils/plot-templates/dark.js
@@ -22,13 +22,11 @@ const darkTemplate = {
       ticklen: 12,
       tickfont: {
         color: 'rgba(255,255,255,0.55)',
-        family: ['sans-serif'],
         size: 12,
       },
       ticklabelposition: 'outside',
       title: {
         font: {
-          family: ['Titillium Web:400', 'sans-serif'],
           color: 'rgba(255,255,255,0.55)',
           size: 12,
         },
@@ -81,7 +79,6 @@ const darkTemplate = {
     '#F8E979',
   ],
   font: {
-    family: 'Titillium+Web:400',
     color: 'rgba(255,255,255,0.55)',
   },
   height: null,
@@ -92,12 +89,10 @@ const darkTemplate = {
   legend: {
     title: {
       font: {
-        family: 'Titillium+Web:400',
         color: 'rgba(255,255,255,0.55)',
       },
     },
     font: {
-      family: 'Titillium+Web:400',
       color: 'rgba(255,255,255,0.55)',
     },
   },
@@ -108,7 +103,6 @@ const darkTemplate = {
   plot_bgcolor: '#111111',
   title: {
     font: {
-      family: 'Titillium+Web:400',
       color: 'rgba(255,255,255,0.85)',
       size: 16,
     },
@@ -134,13 +128,11 @@ const darkTemplate = {
     ticklen: 12,
     tickfont: {
       color: 'rgba(255,255,255,0.55)',
-      family: 'Titillium+Web:400',
       size: 12,
     },
     ticklabelposition: 'outside',
     title: {
       font: {
-        family: 'Titillium+Web:400',
         color: 'rgba(255,255,255,0.55)',
         size: 16,
       },
@@ -163,13 +155,11 @@ const darkTemplate = {
     ticklen: 12,
     tickfont: {
       color: 'rgba(255,255,255,0.55)',
-      family: 'Titillium+Web:400',
       size: 12,
     },
     ticklabelposition: 'outside',
     title: {
       font: {
-        family: 'Titillium+Web:400',
         color: 'rgba(255,255,255,0.55)',
         size: 16,
       },

--- a/src/utils/plot-templates/light.js
+++ b/src/utils/plot-templates/light.js
@@ -22,13 +22,11 @@ const lightTemplate = {
       ticklen: 12,
       tickfont: {
         color: 'rgba(0,0,0,0.55)',
-        family: 'Titillium+Web:400',
         size: 12,
       },
       ticklabelposition: 'outside',
       title: {
         font: {
-          family: 'Titillium+Web:400',
           color: 'rgba(0,0,0,0.55)',
           size: 12,
         },
@@ -81,7 +79,6 @@ const lightTemplate = {
     '#F8E979',
   ],
   font: {
-    family: 'Titillium+Web:400',
     color: 'rgba(0,0,0,0.55)',
   },
   height: null,
@@ -92,12 +89,10 @@ const lightTemplate = {
   legend: {
     title: {
       font: {
-        family: 'Titillium+Web:400',
         color: 'rgba(0,0,0,0.55)',
       },
     },
     font: {
-      family: 'Titillium+Web:400',
       color: 'rgba(0,0,0,0.55)',
     },
   },
@@ -108,7 +103,6 @@ const lightTemplate = {
   plot_bgcolor: '#EEEEEE',
   title: {
     font: {
-      family: 'Titillium+Web:400',
       color: 'rgba(0,0,0,0.85)',
       size: 16,
     },
@@ -134,13 +128,11 @@ const lightTemplate = {
     ticklen: 12,
     tickfont: {
       color: 'rgba(0,0,0,0.55)',
-      family: 'Titillium+Web:400',
       size: 12,
     },
     ticklabelposition: 'outside',
     title: {
       font: {
-        family: 'Titillium+Web:400',
         color: 'rgba(0,0,0,0.55)',
         size: 16,
       },
@@ -163,13 +155,11 @@ const lightTemplate = {
     ticklen: 12,
     tickfont: {
       color: 'rgba(0,0,0,0.55)',
-      family: 'Titillium+Web:400',
       size: 12,
     },
     ticklabelposition: 'outside',
     title: {
       font: {
-        family: 'Titillium+Web:400',
         color: 'rgba(0,0,0,0.55)',
         size: 16,
       },

--- a/src/utils/plot-templates/light.js
+++ b/src/utils/plot-templates/light.js
@@ -187,13 +187,16 @@ const lightTemplate = {
 
 export const lightPreviewTemplate = {
   ...lightTemplate,
-  title: '',
+  height: 300,
   margin: {
     l: 100,
     r: 40,
     t: 40,
     b: 70,
   },
+  showlegend: false,
+  title: '',
+  width: 400,
   xaxis: {
     ...lightTemplate.xaxis,
     title: {
@@ -224,8 +227,6 @@ export const lightPreviewTemplate = {
     },
     nticks: 5,
   },
-  height: 300,
-  width: 400,
 };
 
 export const lightModalTemplate = {


### PR DESCRIPTION
## Description

This PR has two fixes for recently merged plotly feature. 
- it basically hides legend in the preview mode on metadata panel
- it fixes the legend text cutting off by removing the 'Titilium' font from the plotly templates. 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
