### PR TITLE
[KED-2655] Removed namespace from datasets

### DIFF
--- a/package/kedro_viz/models/graph.py
+++ b/package/kedro_viz/models/graph.py
@@ -51,6 +51,10 @@ def _pretty_name(name: str) -> str:
     return " ".join(parts)
 
 
+def _strip_namespace(name: str) -> str:
+    return name.split('.')[-1]
+
+
 @dataclass
 class RegisteredPipeline:
     """Represent a registered pipeline in a Kedro project"""
@@ -201,7 +205,7 @@ class GraphNode(abc.ABC):
         """
         return DataNode(
             id=cls._hash(full_name),
-            name=_pretty_name(full_name),
+            name=_pretty_name(_strip_namespace(full_name)),
             full_name=full_name,
             tags=tags,
             layer=layer,

--- a/package/kedro_viz/models/graph.py
+++ b/package/kedro_viz/models/graph.py
@@ -32,6 +32,7 @@ import hashlib
 import inspect
 import json
 import logging
+import re
 from dataclasses import InitVar, dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -51,7 +52,8 @@ def _pretty_name(name: str) -> str:
 
 
 def _strip_namespace(name: str) -> str:
-    return name.split(".")[-1]
+    pattern = re.compile(r"[A-Za-z0-9-_]+\.")
+    return re.sub(pattern, "", name)
 
 
 @dataclass
@@ -234,7 +236,7 @@ class GraphNode(abc.ABC):
         """
         return ParametersNode(
             id=cls._hash(full_name),
-            name=_pretty_name(full_name),
+            name=_pretty_name(_strip_namespace(full_name)),
             full_name=full_name,
             tags=tags,
             layer=layer,

--- a/package/kedro_viz/models/graph.py
+++ b/package/kedro_viz/models/graph.py
@@ -30,8 +30,8 @@
 import abc
 import hashlib
 import inspect
-import logging
 import json
+import logging
 from dataclasses import InitVar, dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -40,7 +40,6 @@ from typing import Any, Dict, List, Optional, Set, Union, cast
 from kedro.io import AbstractDataSet
 from kedro.io.core import get_filepath_str
 from kedro.pipeline.node import Node as KedroNode
-
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +51,7 @@ def _pretty_name(name: str) -> str:
 
 
 def _strip_namespace(name: str) -> str:
-    return name.split('.')[-1]
+    return name.split(".")[-1]
 
 
 @dataclass

--- a/package/tests/example_pipelines.json
+++ b/package/tests/example_pipelines.json
@@ -12,7 +12,7 @@
     },
     {
       "id": "13399a82",
-      "name": "Uk.data Processing.raw Data",
+      "name": "Raw Data",
       "full_name": "uk.data_processing.raw_data",
       "tags": ["split"],
       "pipelines": ["__default__", "data_processing"],
@@ -66,7 +66,7 @@
     },
     {
       "id": "d5a8b994",
-      "name": "Uk.data Science.model",
+      "name": "Model",
       "full_name": "uk.data_science.model",
       "tags": ["train"],
       "pipelines": ["__default__", "data_science"],

--- a/package/tests/test_api/test_apps.py
+++ b/package/tests/test_api/test_apps.py
@@ -104,7 +104,7 @@ def assert_example_data(response_data):
         },
         {
             "id": "13399a82",
-            "name": "Uk.data Processing.raw Data",
+            "name": "Raw Data",
             "full_name": "uk.data_processing.raw_data",
             "tags": ["split"],
             "pipelines": ["__default__", "data_processing"],
@@ -158,7 +158,7 @@ def assert_example_data(response_data):
         },
         {
             "id": "d5a8b994",
-            "name": "Uk.data Science.model",
+            "name": "Model",
             "full_name": "uk.data_science.model",
             "tags": ["train"],
             "pipelines": ["__default__", "data_science"],
@@ -287,7 +287,7 @@ class TestSinglePipelineEndpoint:
             },
             {
                 "id": "d5a8b994",
-                "name": "Uk.data Science.model",
+                "name": "Model",
                 "full_name": "uk.data_science.model",
                 "tags": ["train"],
                 "pipelines": ["__default__", "data_science"],

--- a/package/tests/test_models/test_graph/test_graph_nodes.py
+++ b/package/tests/test_models/test_graph/test_graph_nodes.py
@@ -27,7 +27,7 @@
 # limitations under the License.
 from pathlib import Path
 from textwrap import dedent
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from kedro.extras.datasets.pandas import CSVDataSet
@@ -45,7 +45,6 @@ from kedro_viz.models.graph import (
     TaskNode,
     TaskNodeMetadata,
 )
-
 
 orig_import = __import__
 

--- a/package/tests/test_models/test_graph/test_graph_nodes.py
+++ b/package/tests/test_models/test_graph/test_graph_nodes.py
@@ -100,7 +100,7 @@ class TestGraphNodeCreation:
             ("dataset", "Dataset", []),
             (
                 "uk.data_science.model_training.dataset",
-                "Uk.data Science.model Training.dataset",
+                "Dataset",
                 [
                     "uk",
                     "uk.data_science",


### PR DESCRIPTION
## Description

Datasets in modular pipeline had the entire namespace visible as the front-end name which wasn't user-friendly hence we decided to remove the namespace and just show the node name (the namespace can be figured through the tree navigation) 

For example - 
Before implementation -- the name displayed for the given node was as below 

![image](https://user-images.githubusercontent.com/37628668/121393834-a3ed5380-c948-11eb-8637-1f8bce46bdb7.png)


After implementation -- the name displayed for the given node will be 

<img width="700" alt="Screenshot 2021-06-09 at 17 30 46" src="https://user-images.githubusercontent.com/37628668/121393881-afd91580-c948-11eb-85b4-7f2c36161a5b.png">


## Development notes

The ruleset for front-end naming is to remove any dots, underscores or hyphens in the name and capitalize all the words. 

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
