### PR TITLE
Integrate with kedro-telemetry

### DIFF
--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -89,6 +89,10 @@ def create_project_with_starter(context, starter):
         env=context.env,
         cwd=str(context.temp_dir),
     )
+    # add a consent file to prevent telemetry from prompting for input during e2e test
+    telemetry_file = context.root_project_dir / ".telemetry"
+    telemetry_file.write_text("consent: false", encoding="utf-8")
+
     if res.returncode != OK_EXIT_CODE:
         print(res.stdout)
         print(res.stderr)

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -31,11 +31,13 @@ This data could either come from a real Kedro project or a file.
 import json
 from pathlib import Path
 
-from fastapi import FastAPI
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 
 from kedro_viz import __version__
+from kedro_viz.integrations.kedro import telemetry as kedro_telemetry
 
 from .router import router
 
@@ -48,15 +50,27 @@ def _create_base_api_app() -> FastAPI:
     )
 
 
-def create_api_app_from_project() -> FastAPI:
+def create_api_app_from_project(project_path: Path) -> FastAPI:
     """Create an API from a real Kedro project by adding the router to the FastAPI app."""
     app = _create_base_api_app()
     app.include_router(router)
     app.mount("/static", StaticFiles(directory=_HTML_DIR / "static"), name="static")
 
+    templates = Jinja2Templates(directory=_HTML_DIR)
+
     @app.get("/")
-    async def index():
-        return FileResponse(_HTML_DIR / "index.html")
+    async def index(request: Request):
+        heap_app_id = kedro_telemetry.get_heap_app_id(project_path)
+        heap_user_identity = kedro_telemetry.get_heap_identity()
+        return templates.TemplateResponse(
+            "index.html",
+            {
+                "request": request,
+                "should_add_telemetry": bool(heap_app_id) and bool(heap_user_identity),
+                "heap_app_id": heap_app_id,
+                "heap_user_identity": heap_user_identity,
+            },
+        )
 
     return app
 

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -56,7 +56,7 @@ def create_api_app_from_project(project_path: Path) -> FastAPI:
     app.include_router(router)
     app.mount("/static", StaticFiles(directory=_HTML_DIR / "static"), name="static")
 
-    templates = Jinja2Templates(directory=_HTML_DIR)
+    templates = Jinja2Templates(directory=str(_HTML_DIR))
 
     @app.get("/")
     async def index(request: Request):

--- a/package/kedro_viz/integrations/kedro/telemetry.py
+++ b/package/kedro_viz/integrations/kedro/telemetry.py
@@ -1,0 +1,59 @@
+# Copyright 2021 QuantumBlack Visual Analytics Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+# NONINFRINGEMENT. IN NO EVENT WILL THE LICENSOR OR OTHER CONTRIBUTORS
+# BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# The QuantumBlack Visual Analytics Limited ("QuantumBlack") name and logo
+# (either separately or in combination, "QuantumBlack Trademarks") are
+# trademarks of QuantumBlack. The License does not grant you any right or
+# license to the QuantumBlack Trademarks. You may not use the QuantumBlack
+# Trademarks or any confusingly similar mark as a trademark for your product,
+# or use the QuantumBlack Trademarks in any other manner that might cause
+# confusion in the marketplace, including but not limited to in advertising,
+# on websites, or on software.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""`kedro_viz.integrations.kedro.telemetry` helps integrate Kedro Viz with Kedro-Telemetry
+"""
+import hashlib
+import logging
+import socket
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from kedro_telemetry.plugin import _get_heap_app_id, _is_valid_syntax
+
+logger = logging.getLogger(__name__)
+
+
+def get_heap_app_id(project_path: Path) -> Optional[str]:
+    """Return the Heap App ID used for Kedro telemetry if user has given consent."""
+    telemetry_file_path = project_path / ".telemetry"
+    if not telemetry_file_path.exists():
+        return None
+    with open(telemetry_file_path) as telemetry_file:
+        telemetry = yaml.safe_load(telemetry_file)
+        if _is_valid_syntax(telemetry) and telemetry["consent"]:
+            return _get_heap_app_id()
+    return None
+
+
+def get_heap_identity() -> Optional[str]:  # pragma: no cover
+    """Return the user ID in heap identical to the id used by kedro-telemetry plugin."""
+    try:
+        return hashlib.sha512(bytes(socket.gethostname(), encoding="utf8")).hexdigest()
+    except socket.timeout:
+        return None

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -100,7 +100,7 @@ def run_server(
             res = responses.get_default_response()
             Path(save_file).write_text(res.json(indent=4, sort_keys=True))
 
-        app = apps.create_api_app_from_project()
+        app = apps.create_api_app_from_project(path)
     else:
         app = apps.create_api_app_from_file(load_file)
 

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,5 +1,6 @@
 semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
 kedro>=0.16.0
+kedro-telemetry>=0.1.0
 ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
 fastapi>=0.63.0, <1.0

--- a/package/tests/test_integrations/test_telemetry.py
+++ b/package/tests/test_integrations/test_telemetry.py
@@ -1,0 +1,55 @@
+# Copyright 2021 QuantumBlack Visual Analytics Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+# NONINFRINGEMENT. IN NO EVENT WILL THE LICENSOR OR OTHER CONTRIBUTORS
+# BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# The QuantumBlack Visual Analytics Limited ("QuantumBlack") name and logo
+# (either separately or in combination, "QuantumBlack Trademarks") are
+# trademarks of QuantumBlack. The License does not grant you any right or
+# license to the QuantumBlack Trademarks. You may not use the QuantumBlack
+# Trademarks or any confusingly similar mark as a trademark for your product,
+# or use the QuantumBlack Trademarks in any other manner that might cause
+# confusion in the marketplace, including but not limited to in advertising,
+# on websites, or on software.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+from unittest import mock
+
+from kedro_viz.integrations.kedro import telemetry as kedro_telemetry
+
+
+def test_get_heap_app_id_no_telemetry_file():
+    assert kedro_telemetry.get_heap_app_id(Path.cwd()) is None
+
+
+def test_get_heap_app_id_invalid_telemetry_file(tmpdir):
+    telemetry_file = tmpdir / ".telemetry"
+    telemetry_file.write_text("foo", encoding="utf-8")
+    assert kedro_telemetry.get_heap_app_id(tmpdir) is None
+
+
+def test_get_heap_app_id_no_consent(tmpdir):
+    telemetry_file = tmpdir / ".telemetry"
+    telemetry_file.write_text("consent: false", encoding="utf-8")
+    assert kedro_telemetry.get_heap_app_id(tmpdir) is None
+
+
+@mock.patch("kedro_viz.integrations.kedro.telemetry._get_heap_app_id")
+def test_get_heap_app_id_with_consent(original_get_heap_app_id, tmpdir):
+    original_get_heap_app_id.return_value = "my_heap_id"
+    telemetry_file = tmpdir / ".telemetry"
+    telemetry_file.write_text("consent: true", encoding="utf-8")
+    assert kedro_telemetry.get_heap_app_id(tmpdir) == "my_heap_id"

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,13 @@
     <meta name="theme-color" content="#000000" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+    {% if should_add_telemetry %}
+    <script type="text/javascript">   
+      window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
+      heap.load("{{ heap_app_id }}"); 
+      heap.identify("{{ heap_user_identity }}");
+      </script>
+    {% endif %}
     <title>Kedro Viz</title>
   </head>
 


### PR DESCRIPTION
## Description

With the release of [kedro-telemetry](https://github.com/quantumblack/kedro-telemetry), once user has opted into sending telemetry to us, we want to enable automatic tracking of features usage on Kedro-Viz as well. This is done by including [Heap SDK](https://heap.io/) if and only if user's consent has been previously acquired by kedro-telemetry. 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

If you want to test this:

* Make sure you have the environment variable `HEAP_APPID_DEV` set to our Heap dev account.
* Check out this branch and run `make install`
* When you open Heap, you should be able to see your events sent to Heap successfully both in the Live view and the Analyze view.

![Screenshot 2021-06-14 at 18 15 01](https://user-images.githubusercontent.com/2032984/121945762-0e88ff80-cd4c-11eb-919a-a6fe88fdd7c5.png)


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
