### PR TITLE
Add data loader for 0.17.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,12 @@ Please follow the established format:
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
 
+# Release 3.12.1
+
+## Bug fixes and other changes
+
+- Fix compatibility with `kedro==0.17.0`
+
 # Release 3.12.0
 
 ## Major features and improvements

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -89,14 +89,15 @@ def create_project_with_starter(context, starter):
         env=context.env,
         cwd=str(context.temp_dir),
     )
-    # add a consent file to prevent telemetry from prompting for input during e2e test
-    telemetry_file = context.root_project_dir / ".telemetry"
-    telemetry_file.write_text("consent: false", encoding="utf-8")
 
     if res.returncode != OK_EXIT_CODE:
         print(res.stdout)
         print(res.stderr)
         assert False
+
+    # add a consent file to prevent telemetry from prompting for input during e2e test
+    telemetry_file = context.root_project_dir / ".telemetry"
+    telemetry_file.write_text("consent: false", encoding="utf-8")
     assert res.returncode == OK_EXIT_CODE
 
 

--- a/package/features/viz.feature
+++ b/package/features/viz.feature
@@ -39,7 +39,7 @@ Feature: Viz plugin in new project
         Then kedro-viz should start successfully
 
     Scenario: Execute viz with latest Kedro
-        Given I have installed kedro version "latest"
+        Given I have installed kedro version "0.17.3"
         And I have run a non-interactive kedro new with pandas-iris starter
         And I have executed the kedro command "install"
         When I execute the kedro viz command "viz"

--- a/package/kedro_viz/integrations/kedro/data_loader.py
+++ b/package/kedro_viz/integrations/kedro/data_loader.py
@@ -94,6 +94,21 @@ def load_data(
         context = session.load_context()
         return context.catalog, context.pipelines
 
+    if KEDRO_VERSION.match("==0.17.0"):
+        from kedro.framework.session import KedroSession
+        from kedro.framework.startup import _get_project_metadata
+
+        metadata = _get_project_metadata(project_path)
+        session = KedroSession.create(
+            package_name=metadata.package_name,
+            project_path=project_path,
+            env=env,
+            save_on_close=False,
+        )
+
+        context = session.load_context()
+        return context.catalog, context.pipelines
+
     # pre-0.17 load_context version
     from kedro.framework.context import load_context
 


### PR DESCRIPTION
## Description

Currently latest Kedro viz isn't compatible with 0.17.0. This PR fixes the issue.

## Development notes

To release this patch, I will cherry pick this commit on top of `v3.12.0`

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
