### PR TITLE
Refactor - Metadata selector

### DIFF
--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -35,7 +35,7 @@ const getRunCommand = (node) => {
 };
 
 /**
- * Gets metadata for the nodes
+ * Gets metadata for a node
  */
 
 export const getNodeMetaData = (nodeId, nodes, state) => {

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -1,6 +1,8 @@
 import { createSelector } from 'reselect';
 import { getGraphNodes } from './nodes';
+import { arrayToObject } from '../utils';
 
+const getNodeIDs = (state) => state.node.ids;
 const getClickedNode = (state) => state.node.clicked;
 
 /**
@@ -35,11 +37,11 @@ const getRunCommand = (node) => {
 };
 
 /**
- * Gets metadata for the currently clicked node if any
+ * Gets metadata for the nodes
  */
-export const getClickedNodeMetaData = createSelector(
+export const getNodesMetaData = createSelector(
   [
-    getClickedNode,
+    getNodeIDs,
     getGraphNodes,
     (state) => state.node.tags,
     (state) => state.tag.name,
@@ -51,7 +53,7 @@ export const getClickedNodeMetaData = createSelector(
     (state) => state.node.datasetType,
   ],
   (
-    nodeId,
+    nodeIDs,
     nodes = {},
     nodeTags,
     tagNames,
@@ -61,43 +63,52 @@ export const getClickedNodeMetaData = createSelector(
     nodeParameters,
     nodePlot,
     nodeDatasetTypes
-  ) => {
-    const node = nodes[nodeId];
+  ) =>
+    arrayToObject(nodeIDs, (nodeID) => {
+      const node = nodes[nodeID];
 
-    if (!node) {
-      return null;
-    }
+      if (!node) {
+        return null;
+      }
 
-    const parameters =
-      nodeParameters[node.id] &&
-      Object.entries(nodeParameters[node.id]).map(
-        ([key, value]) => `${key}: ${value}`
-      );
+      const parameters =
+        nodeParameters[node.id] &&
+        Object.entries(nodeParameters[node.id]).map(
+          ([key, value]) => `${key}: ${value}`
+        );
 
-    const metadata = {
-      node,
-      tags: [...nodeTags[node.id]]
-        .map((tagId) => tagNames[tagId])
-        .sort(sortAlpha),
-      pipeline: pipeline.name[pipeline.active],
-      parameters,
-      runCommand: getRunCommand(node),
-      code: nodeCodes[node.id],
-      filepath: nodeFilepaths[node.id],
-      plot: nodePlot[node.id],
-      datasetType: nodeDatasetTypes[node.id],
-    };
+      const metadata = {
+        node,
+        tags: [...nodeTags[node.id]]
+          .map((tagId) => tagNames[tagId])
+          .sort(sortAlpha),
+        pipeline: pipeline.name[pipeline.active],
+        parameters,
+        runCommand: getRunCommand(node),
+        code: nodeCodes[node.id],
+        filepath: nodeFilepaths[node.id],
+        plot: nodePlot[node.id],
+        datasetType: nodeDatasetTypes[node.id],
+      };
 
-    // Note: node.sources node.targets require oldgraph enabled
-    if (node.sources && node.targets) {
-      metadata.inputs = node.sources
-        .map((edge) => nodes[edge.source])
-        .sort(sortAlpha);
-      metadata.outputs = node.targets
-        .map((edge) => nodes[edge.target])
-        .sort(sortAlpha);
-    }
+      // Note: node.sources node.targets require oldgraph enabled
+      if (node.sources && node.targets) {
+        metadata.inputs = node.sources
+          .map((edge) => nodes[edge.source])
+          .sort(sortAlpha);
+        metadata.outputs = node.targets
+          .map((edge) => nodes[edge.target])
+          .sort(sortAlpha);
+      }
 
-    return metadata;
-  }
+      return metadata;
+    })
+);
+
+/**
+ * Gets metadata for the current clicked node if any
+ */
+export const getClickedNodeMetaData = createSelector(
+  [getClickedNode, getNodesMetaData],
+  (nodeID, nodesMetaData) => nodesMetaData[nodeID]
 );

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -1,8 +1,6 @@
 import { createSelector } from 'reselect';
 import { getGraphNodes } from './nodes';
-import { arrayToObject } from '../utils';
 
-const getNodeIDs = (state) => state.node.ids;
 const getClickedNode = (state) => state.node.clicked;
 
 /**
@@ -39,76 +37,59 @@ const getRunCommand = (node) => {
 /**
  * Gets metadata for the nodes
  */
-export const getNodesMetaData = createSelector(
-  [
-    getNodeIDs,
-    getGraphNodes,
-    (state) => state.node.tags,
-    (state) => state.tag.name,
-    (state) => state.pipeline,
-    (state) => state.node.filepath,
-    (state) => state.node.code,
-    (state) => state.node.parameters,
-    (state) => state.node.plot,
-    (state) => state.node.datasetType,
-  ],
-  (
-    nodeIDs,
-    nodes = {},
-    nodeTags,
-    tagNames,
-    pipeline,
-    nodeFilepaths,
-    nodeCodes,
-    nodeParameters,
-    nodePlot,
-    nodeDatasetTypes
-  ) =>
-    arrayToObject(nodeIDs, (nodeID) => {
-      const node = nodes[nodeID];
 
-      if (!node) {
-        return null;
-      }
+export const getNodeMetaData = (nodeId, nodes, state) => {
+  const node = nodes[nodeId];
+  const nodeTags = state.node.tags;
+  const tagNames = state.tag.name;
+  const pipeline = state.pipeline;
+  const nodeFilepaths = state.node.filepath;
+  const nodeCodes = state.node.code;
+  const nodeParameters = state.node.parameters;
+  const nodePlot = state.node.plot;
+  const nodeDatasetTypes = state.node.datasetType;
 
-      const parameters =
-        nodeParameters[node.id] &&
-        Object.entries(nodeParameters[node.id]).map(
-          ([key, value]) => `${key}: ${value}`
-        );
+  const parameters =
+    nodeParameters[node.id] &&
+    Object.entries(nodeParameters[node.id]).map(
+      ([key, value]) => `${key}: ${value}`
+    );
 
-      const metadata = {
-        node,
-        tags: [...nodeTags[node.id]]
-          .map((tagId) => tagNames[tagId])
-          .sort(sortAlpha),
-        pipeline: pipeline.name[pipeline.active],
-        parameters,
-        runCommand: getRunCommand(node),
-        code: nodeCodes[node.id],
-        filepath: nodeFilepaths[node.id],
-        plot: nodePlot[node.id],
-        datasetType: nodeDatasetTypes[node.id],
-      };
+  const metadata = {
+    node,
+    tags: [...nodeTags[node.id]]
+      .map((tagId) => tagNames[tagId])
+      .sort(sortAlpha),
+    pipeline: pipeline.name[pipeline.active],
+    parameters,
+    runCommand: getRunCommand(node),
+    code: nodeCodes[node.id],
+    filepath: nodeFilepaths[node.id],
+    plot: nodePlot[node.id],
+    datasetType: nodeDatasetTypes[node.id],
+  };
 
-      // Note: node.sources node.targets require oldgraph enabled
-      if (node.sources && node.targets) {
-        metadata.inputs = node.sources
-          .map((edge) => nodes[edge.source])
-          .sort(sortAlpha);
-        metadata.outputs = node.targets
-          .map((edge) => nodes[edge.target])
-          .sort(sortAlpha);
-      }
-
-      return metadata;
-    })
-);
+  // Note: node.sources node.targets require oldgraph enabled
+  if (node.sources && node.targets) {
+    metadata.inputs = node.sources
+      .map((edge) => nodes[edge.source])
+      .sort(sortAlpha);
+    metadata.outputs = node.targets
+      .map((edge) => nodes[edge.target])
+      .sort(sortAlpha);
+  }
+  return metadata;
+};
 
 /**
  * Gets metadata for the current clicked node if any
  */
 export const getClickedNodeMetaData = createSelector(
-  [getClickedNode, getNodesMetaData],
-  (nodeID, nodesMetaData) => nodesMetaData[nodeID]
+  [getClickedNode, getGraphNodes, (state) => state],
+  (nodeID, nodes, state) => {
+    if (!nodeID) {
+      return null;
+    }
+    return getNodeMetaData(nodeID, nodes, state);
+  }
 );


### PR DESCRIPTION
## Description

This PR refactors/splits the metadata selector into two functions (getNodeMetaData and getClickedNodeMetaData). Previously we only had getClickedNodeMetaData selector which provided metadata info when the node was clicked. However we recently came across a use-case where we needed metadata info when the parameter indicator was hovered over. This made us realise that there was a need to create a reusable getNodeMetaData function. 

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
