### PR TITLE
KED-2686 : Add metadata information to mock datasets 

### DIFF
--- a/src/actions/nodes.js
+++ b/src/actions/nodes.js
@@ -1,5 +1,5 @@
 import { getUrl } from '../utils';
-import loadJsonData from '../store/load-data';
+import { loadJsonData, loadMockNodeData } from '../store/load-data';
 
 export const TOGGLE_NODE_CLICKED = 'TOGGLE_NODE_CLICKED';
 
@@ -85,6 +85,12 @@ export function loadNodeData(nodeID) {
       const nodeData = await loadJsonData(url);
       dispatch(addNodeMetadata({ id: nodeID, data: nodeData }));
       dispatch(toggleNodeDataLoading(false));
+    } else {
+      const nodeData = loadMockNodeData(dataSource, nodeID);
+      if (nodeData) {
+        dispatch(addNodeMetadata({ id: nodeID, data: nodeData }));
+        dispatch(toggleNodeDataLoading(false));
+      }
     }
   };
 }

--- a/src/store/load-data.js
+++ b/src/store/load-data.js
@@ -1,6 +1,8 @@
 import { json } from 'd3-fetch';
 import { getUrl } from '../utils';
-
+import node_task from '../utils/data/node_task.mock.json';
+import node_plot from '../utils/data/node_plot.mock.json';
+import node_parameters from '../utils/data/node_parameters.mock.json';
 /**
  * Asynchronously load and parse data from json file using d3-fetch.
  * Throws an error if the request for `main` fails.
@@ -9,7 +11,7 @@ import { getUrl } from '../utils';
  * @param {object} fallback The fallback response object on request failure. Default `{}`.
  * @return {function} A promise that will return when the file is loaded and parsed
  */
-const loadJsonData = (path = getUrl('main'), fallback = {}) =>
+export const loadJsonData = (path = getUrl('main'), fallback = {}) =>
   json(path).catch(() => {
     const fullPath = `/public${path.substr(1)}`;
 
@@ -22,5 +24,20 @@ const loadJsonData = (path = getUrl('main'), fallback = {}) =>
 
     return new Promise((resolve) => resolve(fallback));
   });
+
+// Adds metadata information in utils/data to animals mock dataset
+export const loadMockNodeData = (dataSource, nodeId) => {
+  if (dataSource === 'animals') {
+    if (nodeId === 'f1f1425b') {
+      return node_parameters;
+    }
+    if (nodeId === 'c3p345ed') {
+      return node_plot;
+    }
+    if (nodeId === '443cf06a') {
+      return node_task;
+    }
+  }
+};
 
 export default loadJsonData;


### PR DESCRIPTION
## Description

Previously, if you ran kedro viz with mock datasets using data?=animals/demo/random, it wouldn't add additional node metadata information. So basically, if you wanted to test the new functionalities like 'Show Code' or 'Plotly' with mock datasets you couldn't. This PR adds metadata information when kedro-viz is loaded with animal dataset i.e. ?data=animals

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
