### PR TITLE
Delete modular pipeline flag and Bug fix

### DIFF
--- a/src/components/node-list/index.js
+++ b/src/components/node-list/index.js
@@ -28,12 +28,6 @@ const isModularPipelineType = (type) => type === 'modularPipeline';
 /**
  * Provides data from the store to populate a NodeList component.
  * Also handles user interaction and dispatches updates back to the store.
- *
- * The data are hierarchical but provided through flat lists in the form of:
- *
- * Sections (first level) e.g. Categories, Elements
- * Groups (second level) e.g. Tags, Nodes, Datasets, Parameters
- * Items (third level) e.g. 'Data Engineering', 'Content Optimisation'
  */
 const NodeListProvider = ({
   faded,

--- a/src/components/node-list/node-list-groups.test.js
+++ b/src/components/node-list/node-list-groups.test.js
@@ -9,7 +9,7 @@ describe('NodeListGroups', () => {
   const mockProps = () => {
     const items = getGroupedNodes(mockState.animals);
     const types = getNodeTypes(mockState.animals);
-    const sections = getSections({ flags: { modularpipeline: true } }).Elements;
+    const sections = getSections().Elements;
     const groups = getGroups({ types, items });
     return { items, sections, groups };
   };

--- a/src/components/node-list/node-list-items.js
+++ b/src/components/node-list/node-list-items.js
@@ -239,16 +239,10 @@ export const getFilteredNodeItems = createSelector(
  * @param {boolean} modularPipelineFlag Whether to include modular pipelines
  * @return {object} config
  */
-export const getSidebarConfig = createSelector(
-  (state) => state.flags.modularpipeline,
-  (modularPipelineFlag) => {
-    if (modularPipelineFlag) {
-      return sidebar;
-    }
-    const { ModularPipelines, ...Categories } = sidebar.Categories;
-    return Object.assign({}, sidebar, { Categories });
-  }
-);
+export const getSidebarConfig = createSelector(() => {
+  const { ModularPipelines, ...Categories } = sidebar.Categories;
+  return Object.assign({}, sidebar, { Categories });
+});
 
 /**
  * Get formatted list of sections
@@ -596,7 +590,6 @@ export const getFilteredModularPipelineNodes = createSelector(
       nodeItems[nodeTypeId]?.forEach((node, i) => {
         if (node.modularPipelines.length === 0) {
           modularPipelineNodes.main.push(node);
-          nodeItems[nodeTypeId].splice(i, 1);
         }
       });
     });

--- a/src/components/node-list/node-list-items.test.js
+++ b/src/components/node-list/node-list-items.test.js
@@ -130,7 +130,7 @@ describe('node-list-selectors', () => {
   });
 
   describe('getSections', () => {
-    const sections = getSections({ flags: { modularpipeline: false } });
+    const sections = getSections();
 
     const groupType = expect.objectContaining({
       name: expect.any(String),
@@ -530,7 +530,7 @@ describe('node-list-selectors', () => {
         });
 
         it('contains expected number of node and modular pipeline items', () => {
-          expect(nestedModularPipelines.nodes).toHaveLength(9);
+          expect(nestedModularPipelines.nodes).toHaveLength(13);
           expect(nestedModularPipelines.children).toHaveLength(3);
         });
       });

--- a/src/components/node-list/node-list.test.js
+++ b/src/components/node-list/node-list.test.js
@@ -171,9 +171,12 @@ describe('NodeList', () => {
         ['Pipeline2', true],
         ['salmon', true],
         ['Bull', true],
+        ['Cat', true],
         ['Dog', true],
+        ['Horse', true],
         ['Sheep', true],
         ['Parameters', true],
+        ['Params:rabbit', true],
       ]);
 
       changeRows(wrapper, ['Small', 'Large'], true);
@@ -183,11 +186,16 @@ describe('NodeList', () => {
         ['Pipeline2', true],
         ['salmon', true],
         ['Bear', true],
+        ['Bull', true],
         ['Cat', true],
+        ['Dog', true],
         ['Elephant', true],
+        ['Giraffe', true],
         ['Horse', true],
         ['Pig', true],
+        ['Sheep', true],
         ['Parameters', true],
+        ['Params:rabbit', true],
       ]);
     });
 
@@ -207,13 +215,17 @@ describe('NodeList', () => {
         ['salmon', true],
         ['Bear', true],
         // Datasets (enabled)
+        ['Bull', true],
         ['Cat', true],
+        ['Dog', true],
         ['Elephant', true],
+        ['Giraffe', true],
         ['Horse', true],
         ['Pig', true],
         ['Sheep', true],
         // Parameters(enabled)
         ['Parameters', true],
+        ['Params:pipeline100.data Science.plankton', true],
         ['Params:rabbit', true],
       ]);
     });
@@ -276,11 +288,11 @@ describe('NodeList', () => {
       expect(nodeList.length).toBe(tags.length);
     });
 
-    it('renders the correct number of modular pipelines and nodes in the tree panel', () => {
+    it('renders the correct number of modular pipelines and nodes in the tree sidepanel', () => {
       const wrapper = setup.mount(<NodeList />);
-      const nodeList = wrapper.find('.pipeline-nodelist__row');
+      const nodeList = wrapper.find('.pipeline-nodelist__row__text--tree');
 
-      // with the tree structure we now need extract nodes that are in the top level modular pipeline
+      // with the tree structure we now need to extract nodes that are in the top level modular pipeline
       const nodes = getNodeData(mockState.animals).filter(
         (node) => node.modularPipelines.length === 0
       );

--- a/src/config.js
+++ b/src/config.js
@@ -42,11 +42,6 @@ export const flags = {
     default: true,
     icon: '🐳',
   },
-  modularpipeline: {
-    description: 'Enable modular pipeline features',
-    default: false,
-    icon: '⛓️',
-  },
 };
 
 export const sidebar = {


### PR DESCRIPTION
## Description

During our discussion, @bru5 raised a good point about the modular pipeline flag - since the tree-list erases the old sidebar behaviour with the modular pipeline 'tags', we do not need the `modularpipeline` flag and hence it can be deleted. He raised an issue with a bug in the display of nodes on the main pipeline, whereby this ticket will also put in the fix as well as updating the tests to reflect the fix. 

## Development notes

I have made the following changes:

1. Deleted the `modularpipeline` flag and all its related references and usage in `getSections`
2. updated all related tests for `getSections`
3. fix for the bug on the display of nodes, as well as updating the tests to reflect the fix

## QA notes

please play around the the animals dataset to test the above fix

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
