### PR TITLE
[KED-2720] Fix run command suggestion

### DIFF
--- a/package/kedro_viz/api/responses.py
+++ b/package/kedro_viz/api/responses.py
@@ -115,6 +115,7 @@ class TaskNodeMetadataAPIResponse(BaseAPIResponse):
     code: str
     filepath: str
     parameters: Dict
+    run_command: str
 
     class Config:
         schema_extra = {

--- a/package/kedro_viz/api/responses.py
+++ b/package/kedro_viz/api/responses.py
@@ -115,7 +115,7 @@ class TaskNodeMetadataAPIResponse(BaseAPIResponse):
     code: str
     filepath: str
     parameters: Dict
-    run_command: str
+    run_command: Optional[str]
 
     class Config:
         schema_extra = {
@@ -123,6 +123,7 @@ class TaskNodeMetadataAPIResponse(BaseAPIResponse):
                 "code": "def split_data(data: pd.DataFrame, parameters: Dict) -> Tuple:",
                 "filepath": "proj/src/new_kedro_project/pipelines/data_science/nodes.py",
                 "parameters": {"test_size": 0.2},
+                "run_command": 'kedro run --to-nodes="split_data"',
             }
         }
 
@@ -131,12 +132,14 @@ class DataNodeMetadataAPIResponse(BaseAPIResponse):
     filepath: str
     type: str
     plot: Optional[Dict]
+    run_command: Optional[str]
 
     class Config:
         schema_extra = {
             "example": {
                 "filepath": "/my-kedro-project/data/03_primary/master_table.csv",
                 "type": "kedro.extras.datasets.pandas.csv_dataset.CSVDataSet",
+                "run_command": 'kedro run --to-outputs="master_table"',
             }
         }
 

--- a/package/kedro_viz/data_access/managers.py
+++ b/package/kedro_viz/data_access/managers.py
@@ -82,12 +82,16 @@ class DataAccessManager:
 
     def add_pipeline(self, pipeline_key: str, pipeline: KedroPipeline):
         self.registered_pipelines.add_pipeline(pipeline_key)
+        free_inputs = pipeline.inputs()
         for node in sorted(pipeline.nodes, key=lambda n: n.name):
             task_node = self.add_node(pipeline_key, node)
             self.registered_pipelines.add_node(pipeline_key, task_node.id)
 
             for input_ in node.inputs:
-                input_node = self.add_node_input(pipeline_key, input_, task_node)
+                is_free_input = input_ in free_inputs
+                input_node = self.add_node_input(
+                    pipeline_key, input_, task_node, is_free_input
+                )
                 self.registered_pipelines.add_node(pipeline_key, input_node.id)
 
             for output in node.outputs:
@@ -102,9 +106,15 @@ class DataAccessManager:
         return task_node
 
     def add_node_input(
-        self, pipeline_key: str, input_dataset: str, task_node: TaskNode
+        self,
+        pipeline_key: str,
+        input_dataset: str,
+        task_node: TaskNode,
+        is_free_input: bool,
     ) -> Union[DataNode, ParametersNode]:
-        graph_node = self.add_dataset(pipeline_key, input_dataset)
+        graph_node = self.add_dataset(
+            pipeline_key, input_dataset, is_free_input=is_free_input
+        )
         graph_node.tags.update(task_node.tags)
         self.edges.add_edge(GraphEdge(source=graph_node.id, target=task_node.id))
         self.node_dependencies[graph_node.id].add(task_node.id)
@@ -118,14 +128,15 @@ class DataAccessManager:
     def add_node_output(
         self, pipeline_key: str, output_dataset: str, task_node: TaskNode
     ) -> Union[DataNode, ParametersNode]:
-        graph_node = self.add_dataset(pipeline_key, output_dataset)
+        # output is never a free input
+        graph_node = self.add_dataset(pipeline_key, output_dataset, is_free_input=False)
         graph_node.tags.update(task_node.tags)
         self.edges.add_edge(GraphEdge(source=task_node.id, target=graph_node.id))
         self.node_dependencies[task_node.id].add(graph_node.id)
         return graph_node
 
     def add_dataset(
-        self, pipeline_key: str, dataset_name: str
+        self, pipeline_key: str, dataset_name: str, is_free_input: bool
     ) -> Union[DataNode, ParametersNode]:
         obj = self.catalog.get_dataset(dataset_name)
         layer = self.catalog.get_layer_for_dataset(dataset_name)
@@ -143,6 +154,7 @@ class DataAccessManager:
                 layer=layer,
                 tags=set(),
                 dataset=obj,
+                is_free_input=is_free_input,
             )
             self.modular_pipelines.add_modular_pipeline(graph_node.modular_pipelines)
         graph_node = self.nodes.add_node(graph_node)

--- a/package/kedro_viz/data_access/managers.py
+++ b/package/kedro_viz/data_access/managers.py
@@ -110,7 +110,7 @@ class DataAccessManager:
         pipeline_key: str,
         input_dataset: str,
         task_node: TaskNode,
-        is_free_input: bool,
+        is_free_input: bool = False,
     ) -> Union[DataNode, ParametersNode]:
         graph_node = self.add_dataset(
             pipeline_key, input_dataset, is_free_input=is_free_input
@@ -128,15 +128,14 @@ class DataAccessManager:
     def add_node_output(
         self, pipeline_key: str, output_dataset: str, task_node: TaskNode
     ) -> Union[DataNode, ParametersNode]:
-        # output is never a free input
-        graph_node = self.add_dataset(pipeline_key, output_dataset, is_free_input=False)
+        graph_node = self.add_dataset(pipeline_key, output_dataset)
         graph_node.tags.update(task_node.tags)
         self.edges.add_edge(GraphEdge(source=task_node.id, target=graph_node.id))
         self.node_dependencies[task_node.id].add(graph_node.id)
         return graph_node
 
     def add_dataset(
-        self, pipeline_key: str, dataset_name: str, is_free_input: bool
+        self, pipeline_key: str, dataset_name: str, is_free_input: bool = False
     ) -> Union[DataNode, ParametersNode]:
         obj = self.catalog.get_dataset(dataset_name)
         layer = self.catalog.get_layer_for_dataset(dataset_name)

--- a/package/kedro_viz/models/graph.py
+++ b/package/kedro_viz/models/graph.py
@@ -308,6 +308,9 @@ class TaskNodeMetadata(GraphNodeMetadata):
     # parameters of the node, if available
     parameters: Dict = field(init=False)
 
+    # command to run the pipeline to this node
+    run_command: Optional[str] = field(init=False, default=None)
+
     # the task node to which this metadata belongs
     task_node: InitVar[TaskNode]
 
@@ -326,6 +329,12 @@ class TaskNodeMetadata(GraphNodeMetadata):
             filepath = code_full_path
         self.filepath = str(filepath)
         self.parameters = task_node.parameters
+
+        # if a node doesn't have a user-supplied `_name` attribute,
+        # a human-readable run command `kedro run --to-nodes/nodes` is not available
+        if kedro_node._name is not None:
+            self.run_command = f'kedro run --to-nodes="{kedro_node._name}"'
+            print(self.run_command)
 
 
 @dataclass

--- a/package/kedro_viz/models/graph.py
+++ b/package/kedro_viz/models/graph.py
@@ -192,6 +192,7 @@ class GraphNode(abc.ABC):
         layer: Optional[str],
         tags: Set[str],
         dataset: AbstractDataSet,
+        is_free_input: bool,
     ) -> "DataNode":
         """Create a graph node of type DATA for a given Kedro DataSet instance.
 
@@ -202,6 +203,7 @@ class GraphNode(abc.ABC):
             tags: The set of tags assigned to assign to the graph representation
                 of this dataset. N.B. currently it's derived from the node's tags.
             dataset: A dataset in a Kedro pipeline.
+            is_free_input: Whether the dataset is a free input in the pipeline
         Returns:
             An instance of DataNode.
         """
@@ -213,6 +215,7 @@ class GraphNode(abc.ABC):
             layer=layer,
             pipelines=[],
             kedro_obj=dataset,
+            is_free_input=is_free_input,
         )
 
     @classmethod
@@ -341,6 +344,9 @@ class TaskNodeMetadata(GraphNodeMetadata):
 class DataNode(GraphNode):
     """Represent a graph node of type DATA"""
 
+    # whether the data node is a free input
+    is_free_input: bool
+
     # the layer that this data node belongs to
     layer: Optional[str]
 
@@ -352,6 +358,9 @@ class DataNode(GraphNode):
 
     # the list of modular pipelines this data node belongs to
     modular_pipelines: List[str] = field(init=False)
+
+    # command to run the pipeline to this node
+    run_command: Optional[str] = field(init=False, default=None)
 
     # the type of this graph node, which is DATA
     type: str = GraphNodeType.DATA.value
@@ -400,6 +409,9 @@ class DataNodeMetadata(GraphNodeMetadata):
     # currently only applicable for PlotlyDataSet
     plot: Optional[Dict] = field(init=False)
 
+    # command to run the pipeline to this data node
+    run_command: Optional[str] = field(init=False, default=None)
+
     def __post_init__(self, data_node: DataNode):
         self.type = data_node.dataset_type
         dataset = cast(AbstractDataSet, data_node.kedro_obj)
@@ -419,6 +431,10 @@ class DataNodeMetadata(GraphNodeMetadata):
             load_path = get_filepath_str(dataset._get_load_path(), dataset._protocol)
             with dataset._fs.open(load_path, **dataset._fs_open_args_load) as fs_file:
                 self.plot = json.load(fs_file)
+
+        # Run command is only available if a node is an output, i.e. not a free input
+        if not data_node.is_free_input:
+            self.run_command = f'kedro run --to-outputs="{data_node.full_name}"'
 
 
 @dataclass

--- a/package/kedro_viz/models/graph.py
+++ b/package/kedro_viz/models/graph.py
@@ -339,6 +339,7 @@ class TaskNodeMetadata(GraphNodeMetadata):
             self.run_command = f'kedro run --to-nodes="{kedro_node._name}"'
 
 
+# pylint: disable=too-many-instance-attributes
 @dataclass
 class DataNode(GraphNode):
     """Represent a graph node of type DATA"""

--- a/package/kedro_viz/models/graph.py
+++ b/package/kedro_viz/models/graph.py
@@ -192,7 +192,7 @@ class GraphNode(abc.ABC):
         layer: Optional[str],
         tags: Set[str],
         dataset: AbstractDataSet,
-        is_free_input: bool,
+        is_free_input: bool = False,
     ) -> "DataNode":
         """Create a graph node of type DATA for a given Kedro DataSet instance.
 
@@ -337,7 +337,6 @@ class TaskNodeMetadata(GraphNodeMetadata):
         # a human-readable run command `kedro run --to-nodes/nodes` is not available
         if kedro_node._name is not None:
             self.run_command = f'kedro run --to-nodes="{kedro_node._name}"'
-            print(self.run_command)
 
 
 @dataclass

--- a/package/tests/test_api/test_apps.py
+++ b/package/tests/test_api/test_apps.py
@@ -229,12 +229,21 @@ class TestNodeMetadataEndpoint:
             == "def process_data(raw_data, train_test_split):\n        ...\n"
         )
         assert metadata["parameters"] == {"train_test_split": 0.1}
+        assert metadata["run_command"] == 'kedro run --to-nodes="process_data"'
         assert str(Path("package/tests/conftest.py")) in metadata["filepath"]
 
     def test_data_node_metadata(self, client):
         response = client.get("/api/nodes/0ecea0de")
         assert response.json() == {
             "filepath": "model_inputs.csv",
+            "type": "kedro.extras.datasets.pandas.csv_dataset.CSVDataSet",
+            "run_command": 'kedro run --to-outputs="model_inputs"',
+        }
+
+    def test_data_node_metadata_for_free_input(self, client):
+        response = client.get("/api/nodes/13399a82")
+        assert response.json() == {
+            "filepath": "raw_data.csv",
             "type": "kedro.extras.datasets.pandas.csv_dataset.CSVDataSet",
         }
 

--- a/package/tests/test_models/test_graph/test_graph_nodes.py
+++ b/package/tests/test_models/test_graph/test_graph_nodes.py
@@ -257,6 +257,19 @@ class TestGraphNodeMetadata:
             Path(__file__).relative_to(Path.cwd().parent).expanduser()
         )
         assert task_node_metadata.parameters == {}
+        assert task_node_metadata.run_command == 'kedro run --to-nodes="identity_node"'
+
+    def test_task_node_metadata_no_run_command(self):
+        kedro_node = node(
+            identity,
+            inputs="x",
+            outputs="y",
+            tags={"tag"},
+            namespace="namespace",
+        )
+        task_node = GraphNode.create_task_node(kedro_node)
+        task_node_metadata = TaskNodeMetadata(task_node=task_node)
+        assert task_node_metadata.run_command is None
 
     def test_task_node_metadata_with_decorated_func(self):
         kedro_node = node(
@@ -295,6 +308,7 @@ class TestGraphNodeMetadata:
             == "kedro.extras.datasets.pandas.csv_dataset.CSVDataSet"
         )
         assert data_node_metadata.filepath == "/tmp/dataset.csv"
+        assert data_node_metadata.run_command == 'kedro run --to-outputs="dataset"'
 
     @patch("builtins.__import__", side_effect=import_mock)
     @patch("json.load")

--- a/src/components/metadata/index.js
+++ b/src/components/metadata/index.js
@@ -40,6 +40,7 @@ const MetaData = ({
   const nodeTypeIcon = getShortType(metadata?.datasetType, metadata?.node.type);
   const hasPlot = Boolean(metadata?.plot);
   const hasCode = Boolean(metadata?.code);
+  const hasRunCommand = Boolean(metadata?.runCommand);
   const showCodePanel = visible && visibleCode && hasCode;
   const showCodeSwitch = hasCode;
 
@@ -136,9 +137,7 @@ const MetaData = ({
                   visible={Boolean(metadata.pipeline)}
                   value={metadata.pipeline}
                 />
-                <MetaDataRow
-                  label="Run Command:"
-                  visible={Boolean(metadata.runCommand)}>
+                <MetaDataRow label="Run Command:" visible={hasRunCommand}>
                   <div className="pipeline-metadata__toolbox-container">
                     <MetaDataValue
                       container={'code'}

--- a/src/components/metadata/index.js
+++ b/src/components/metadata/index.js
@@ -40,12 +40,16 @@ const MetaData = ({
   const nodeTypeIcon = getShortType(metadata?.datasetType, metadata?.node.type);
   const hasPlot = Boolean(metadata?.plot);
   const hasCode = Boolean(metadata?.code);
-  const hasRunCommand = Boolean(metadata?.runCommand);
   const showCodePanel = visible && visibleCode && hasCode;
   const showCodeSwitch = hasCode;
+  const runCommand = Boolean(metadata?.runCommand)
+    ? metadata.runCommand
+    : isTaskNode
+    ? 'Please provide a name argument for this node in order to see a run command.'
+    : null;
 
   const onCopyClick = () => {
-    window.navigator.clipboard.writeText(metadata.runCommand);
+    window.navigator.clipboard.writeText(runCommand);
     setShowCopied(true);
     setTimeout(() => setShowCopied(false), 1500);
   };
@@ -137,7 +141,7 @@ const MetaData = ({
                   visible={Boolean(metadata.pipeline)}
                   value={metadata.pipeline}
                 />
-                <MetaDataRow label="Run Command:" visible={hasRunCommand}>
+                <MetaDataRow label="Run Command:" visible={Boolean(runCommand)}>
                   <div className="pipeline-metadata__toolbox-container">
                     <MetaDataValue
                       container={'code'}
@@ -147,9 +151,9 @@ const MetaData = ({
                           visible: !showCopied,
                         }
                       )}
-                      value={metadata.runCommand}
+                      value={runCommand}
                     />
-                    {window.navigator.clipboard && (
+                    {window.navigator.clipboard && metadata.runCommand && (
                       <>
                         <span
                           className={modifiers(

--- a/src/components/metadata/index.js
+++ b/src/components/metadata/index.js
@@ -42,11 +42,13 @@ const MetaData = ({
   const hasCode = Boolean(metadata?.code);
   const showCodePanel = visible && visibleCode && hasCode;
   const showCodeSwitch = hasCode;
-  const runCommand = Boolean(metadata?.runCommand)
-    ? metadata.runCommand
-    : isTaskNode
-    ? 'Please provide a name argument for this node in order to see a run command.'
-    : null;
+  let runCommand = metadata?.runCommand;
+  if (!runCommand) {
+    // provide a help text for user to know why the run command is not available for the task node
+    runCommand = isTaskNode
+      ? 'Please provide a name argument for this node in order to see a run command.'
+      : null;
+  }
 
   const onCopyClick = () => {
     window.navigator.clipboard.writeText(runCommand);

--- a/src/components/metadata/metadata.test.js
+++ b/src/components/metadata/metadata.test.js
@@ -139,26 +139,55 @@ describe('MetaData', () => {
       const row = rowByLabel(wrapper, 'Pipeline:');
       expect(textOf(rowValue(row))).toEqual(['Default']);
     });
-
-    it('shows the node run command', () => {
-      const wrapper = mount({ nodeId: salmonTaskNodeId });
-      const row = rowByLabel(wrapper, 'Run Command:');
-      expect(textOf(rowValue(row))).toEqual(['kedro run --to-nodes salmon']);
+    describe('when there is no runCommand returned by the backend', () => {
+      it('should show a help message asking user to provide a name property', () => {
+        const wrapper = mount({ nodeId: salmonTaskNodeId });
+        const row = rowByLabel(wrapper, 'Run Command:');
+        expect(textOf(rowValue(row))).toEqual([
+          'Please provide a name argument for this node in order to see a run command.',
+        ]);
+      });
     });
 
-    it('copies run command when button clicked', () => {
-      window.navigator.clipboard = {
-        writeText: jest.fn(),
-      };
-
-      const wrapper = mount({ nodeId: salmonTaskNodeId });
-      const copyButton = wrapper.find('button.pipeline-metadata__copy-button');
-
-      copyButton.simulate('click');
-
-      expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-        'kedro run --to-nodes salmon'
+    describe('when there is a runCommand returned by the backend', () => {
+      const metadata = getClickedNodeMetaData(
+        prepareState({
+          data: animals,
+          afterLayoutActions: [() => toggleNodeClicked(salmonTaskNodeId)],
+        })
       );
+      // Add runCommand which would be returned by the server
+      metadata.runCommand = 'kedro run --to-nodes="salmon"';
+
+      it('shows the node run command', () => {
+        const wrapper = setup.mount(
+          <MetaData visible={true} metadata={metadata} />
+        );
+
+        const row = rowByLabel(wrapper, 'Run Command:');
+        expect(textOf(rowValue(row))).toEqual([
+          'kedro run --to-nodes="salmon"',
+        ]);
+      });
+
+      it('copies run command when button clicked', () => {
+        window.navigator.clipboard = {
+          writeText: jest.fn(),
+        };
+
+        const wrapper = setup.mount(
+          <MetaData visible={true} metadata={metadata} />
+        );
+        const copyButton = wrapper.find(
+          'button.pipeline-metadata__copy-button'
+        );
+
+        copyButton.simulate('click');
+
+        expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+          'kedro run --to-nodes="salmon"'
+        );
+      });
     });
   });
 
@@ -205,25 +234,42 @@ describe('MetaData', () => {
       expect(textOf(rowValue(row))).toEqual(['Default']);
     });
 
-    it('shows the node run command', () => {
-      const wrapper = mount({ nodeId: catDatasetNodeId });
-      const row = rowByLabel(wrapper, 'Run Command:');
-      expect(textOf(rowValue(row))).toEqual(['kedro run --to-inputs cat']);
-    });
-
-    it('copies run command when button clicked', () => {
-      window.navigator.clipboard = {
-        writeText: jest.fn(),
-      };
-
-      const wrapper = mount({ nodeId: catDatasetNodeId });
-      const copyButton = wrapper.find('button.pipeline-metadata__copy-button');
-
-      copyButton.simulate('click');
-
-      expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-        'kedro run --to-inputs cat'
+    describe('when there is a runCommand returned by the backend', () => {
+      const metadata = getClickedNodeMetaData(
+        prepareState({
+          data: animals,
+          afterLayoutActions: [() => toggleNodeClicked(catDatasetNodeId)],
+        })
       );
+      // Add runCommand which would be returned by the server
+      metadata.runCommand = 'kedro run --to-outputs="cat"';
+
+      it('shows the node run command', () => {
+        const wrapper = setup.mount(
+          <MetaData visible={true} metadata={metadata} />
+        );
+        const row = rowByLabel(wrapper, 'Run Command:');
+        expect(textOf(rowValue(row))).toEqual(['kedro run --to-outputs="cat"']);
+      });
+
+      it('copies run command when button clicked', () => {
+        window.navigator.clipboard = {
+          writeText: jest.fn(),
+        };
+
+        const wrapper = setup.mount(
+          <MetaData visible={true} metadata={metadata} />
+        );
+        const copyButton = wrapper.find(
+          'button.pipeline-metadata__copy-button'
+        );
+
+        copyButton.simulate('click');
+
+        expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+          'kedro run --to-outputs="cat"'
+        );
+      });
     });
   });
 

--- a/src/reducers/nodes.js
+++ b/src/reducers/nodes.js
@@ -66,6 +66,9 @@ function nodeReducer(nodeState = {}, action) {
         plot: Object.assign({}, nodeState.plot, {
           [id]: data.plot,
         }),
+        runCommand: Object.assign({}, nodeState.runCommand, {
+          [id]: data.run_command,
+        }),
       });
     }
 

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -30,6 +30,7 @@ const runCommandTemplates = {
  * @returns {?string} The run command for the node, if applicable
  */
 const getRunCommand = (node) => {
+  console.log(node);
   const template = runCommandTemplates[node.type];
   return template ? template(node.fullName) : null;
 };
@@ -49,6 +50,7 @@ export const getClickedNodeMetaData = createSelector(
     (state) => state.node.parameters,
     (state) => state.node.plot,
     (state) => state.node.datasetType,
+    (state) => state.node.runCommand,
   ],
   (
     nodeId,
@@ -60,7 +62,8 @@ export const getClickedNodeMetaData = createSelector(
     nodeCodes,
     nodeParameters,
     nodePlot,
-    nodeDatasetTypes
+    nodeDatasetTypes,
+    nodeRunCommand
   ) => {
     const node = nodes[nodeId];
 
@@ -81,7 +84,8 @@ export const getClickedNodeMetaData = createSelector(
         .sort(sortAlpha),
       pipeline: pipeline.name[pipeline.active],
       parameters,
-      runCommand: getRunCommand(node),
+      // runCommand: getRunCommand(node),
+      runCommand: nodeRunCommand[node.id],
       code: nodeCodes[node.id],
       filepath: nodeFilepaths[node.id],
       plot: nodePlot[node.id],

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -17,25 +17,6 @@ export const getVisibleMetaSidebar = createSelector(
 );
 
 /**
- * Templates for run commands
- */
-const runCommandTemplates = {
-  data: (name) => `kedro run --to-inputs ${name}`,
-  task: (name) => `kedro run --to-nodes ${name}`,
-};
-
-/**
- * Returns run command for the node, if applicable to the node type
- * @param {object} node The node
- * @returns {?string} The run command for the node, if applicable
- */
-const getRunCommand = (node) => {
-  console.log(node);
-  const template = runCommandTemplates[node.type];
-  return template ? template(node.fullName) : null;
-};
-
-/**
  * Gets metadata for the currently clicked node if any
  */
 export const getClickedNodeMetaData = createSelector(
@@ -84,7 +65,6 @@ export const getClickedNodeMetaData = createSelector(
         .sort(sortAlpha),
       pipeline: pipeline.name[pipeline.active],
       parameters,
-      // runCommand: getRunCommand(node),
       runCommand: nodeRunCommand[node.id],
       code: nodeCodes[node.id],
       filepath: nodeFilepaths[node.id],

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -32,6 +32,7 @@ export const createInitialPipelineState = () => ({
     filepath: {},
     plot: {},
     datasetType: {},
+    runCommand: {},
     modularPipelines: {},
   },
   nodeType: {
@@ -147,7 +148,9 @@ const addNode = (state) => (node) => {
   state.node.filepath[id] = node.filepath;
   state.node.plot[id] = node.plot;
   state.node.datasetType[id] = node.dataset_type;
+  state.node.runCommand[id] = node.runCommand;
   state.node.modularPipelines[id] = node.modular_pipelines || [];
+  console.log(node);
 };
 
 /**

--- a/src/store/normalize-data.js
+++ b/src/store/normalize-data.js
@@ -150,7 +150,6 @@ const addNode = (state) => (node) => {
   state.node.datasetType[id] = node.dataset_type;
   state.node.runCommand[id] = node.runCommand;
   state.node.modularPipelines[id] = node.modular_pipelines || [];
-  console.log(node);
 };
 
 /**


### PR DESCRIPTION
## Description

Fixes https://github.com/quantumblacklabs/kedro-viz/issues/492

This PR moves the run command suggestion logic to the backend and now will show:
* `kedro run --to-nodes="<node name>"` for a task node if node name exists. If it doesn’t exist, there will be a help text asking user to add a `name` property to the node definition (see screenshot).

* `kedro run --to-outputs="<dataset name>"` for a data node if the data node is not a free input since free inputs are not output of any node.

<img width="931" alt="Screenshot 2021-07-06 at 17 17 25" src="https://user-images.githubusercontent.com/2032984/124634251-0a00c400-de7e-11eb-9261-d8c1234c921c.png">


## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
