### PR TITLE
Add --autoreload to relaunch viz server on file change

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,11 @@ Please follow the established format:
 - Use present tense (e.g. 'Add new feature')
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
+
+## Major features and improvements
+
+- Add `--autoreload` flag to `kedro viz` to automatically reload Kedro Viz tab when the Kedro project code changes.
+
 # Release 3.13.1
 
 ## Bug fixes and other changes

--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -29,10 +29,12 @@
 This data could either come from a real Kedro project or a file.
 """
 import json
+import time
 from pathlib import Path
 
-from fastapi import FastAPI
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi import FastAPI, HTTPException
+from fastapi.requests import Request
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
 
@@ -44,17 +46,36 @@ from .router import router
 _HTML_DIR = Path(__file__).parent.parent.absolute() / "html"
 
 
+def _create_etag() -> str:
+    """Generate the current timestamp to use as etag."""
+    return str(time.time())
+
+
 def _create_base_api_app() -> FastAPI:
     return FastAPI(
         title="Kedro-Viz API", description="REST API for Kedro Viz", version=__version__
     )
 
 
-def create_api_app_from_project(project_path: Path) -> FastAPI:
-    """Create an API from a real Kedro project by adding the router to the FastAPI app."""
+def create_api_app_from_project(
+    project_path: Path, autoreload: bool = False
+) -> FastAPI:
+    """Create an API from a real Kedro project by adding the router to the FastAPI app.
+
+    Args:
+        project_path: Path to the Kedro project
+        autoreload: Whether the app should autoreload based on content change
+            in the Kedro project
+    Returns:
+        The FastAPI app
+    """
     app = _create_base_api_app()
     app.include_router(router)
     app.mount("/static", StaticFiles(directory=_HTML_DIR / "static"), name="static")
+
+    # everytime the server reloads, a new app with a new timestamp will be created.
+    # this is used as an etag embedded in the frontend for client to use when making requests.
+    app_etag = _create_etag()
 
     @app.get("/")
     async def index():
@@ -62,13 +83,37 @@ def create_api_app_from_project(project_path: Path) -> FastAPI:
         heap_user_identity = kedro_telemetry.get_heap_identity()
         should_add_telemetry = bool(heap_app_id) and bool(heap_user_identity)
         html_content = (_HTML_DIR / "index.html").read_text(encoding="utf-8")
+        injected_head_content = []
+
+        env = Environment(loader=FileSystemLoader(_HTML_DIR))
         if should_add_telemetry:
-            env = Environment(loader=FileSystemLoader(_HTML_DIR))
             telemetry_content = env.get_template("telemetry.html").render(
                 heap_app_id=heap_app_id, heap_user_identity=heap_user_identity
             )
-            html_content = html_content.replace("</head>", telemetry_content)
+            injected_head_content.append(telemetry_content)
+
+        if autoreload:
+            autoreload_content = env.get_template("autoreload.html").render(
+                etag=app_etag
+            )
+            injected_head_content.append(autoreload_content)
+
+        injected_head_content.append("</head>")
+        html_content = html_content.replace("</head>", "\n".join(injected_head_content))
         return HTMLResponse(html_content)
+
+    @app.get("/api/reload")
+    async def reload(request: Request):
+        if "If-None-Match" not in request.headers:
+            raise HTTPException(
+                status_code=400,
+                detail="Request to reload endpoint must have an If-None-Match header",
+            )
+        current_client_etag = request.headers["If-None-Match"]
+        if app_etag == current_client_etag:
+            return Response(status_code=304)
+
+        return Response()
 
     return app
 

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -35,7 +35,7 @@ import click
 from kedro.framework.cli.utils import KedroCliError
 from watchgod import RegExpWatcher, run_process
 
-from kedro_viz.server import run_server
+from kedro_viz.server import DEFAULT_HOST, DEFAULT_PORT, is_localhost, run_server
 
 
 @click.group(name="Kedro-Viz")
@@ -46,12 +46,12 @@ def commands():
 @commands.command(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.option(
     "--host",
-    default="127.0.0.1",
-    help="Host that viz will listen to. Defaults to 127.0.0.1.",
+    default=DEFAULT_HOST,
+    help="Host that viz will listen to. Defaults to localhost.",
 )
 @click.option(
     "--port",
-    default=4141,
+    default=DEFAULT_PORT,
     type=int,
     help="TCP port that viz will listen to. Defaults to 4141.",
 )
@@ -98,43 +98,35 @@ def commands():
 def viz(host, port, browser, load_file, save_file, pipeline, env, autoreload):
     """Visualise a Kedro pipeline using Kedro viz."""
     try:
+        run_server_kwargs = {
+            "host": host,
+            "port": port,
+            "load_file": load_file,
+            "save_file": save_file,
+            "pipeline_name": pipeline,
+            "env": env,
+            "browser": browser,
+            "autoreload": autoreload,
+        }
         if autoreload:
-            is_localhost = host in ("127.0.0.1", "localhost", "0.0.0.0")
-
-            if browser and is_localhost:
+            if browser and is_localhost(host):
                 webbrowser.open_new(f"http://{host}:{port}/")
 
             project_path = Path.cwd()
-            process_kwargs = {
-                "host": host,
-                "port": port,
-                "load_file": load_file,
-                "save_file": save_file,
-                "pipeline_name": pipeline,
-                "env": env,
-                "autoreload": True,
-                "browser": False,
-                "project_path": project_path,
-            }
+            run_server_kwargs["project_path"] = project_path
+            # we don't want to launch a new browser tab on reload
+            run_server_kwargs["browser"] = False
 
             run_process(
                 path=project_path,
                 target=run_server,
-                kwargs=process_kwargs,
+                kwargs=run_server_kwargs,
                 watcher_cls=RegExpWatcher,
                 watcher_kwargs=dict(re_files=r"^.*(\.yml|\.yaml|\.py)$"),
             )
 
         else:
-            run_server(
-                host=host,
-                port=port,
-                load_file=load_file,
-                save_file=save_file,
-                pipeline_name=pipeline,
-                env=env,
-                browser=browser,
-            )
+            run_server(**run_server_kwargs)
     except Exception as ex:  # pragma: no cover
         traceback.print_exc()
         raise KedroCliError(str(ex)) from ex

--- a/package/kedro_viz/server.py
+++ b/package/kedro_viz/server.py
@@ -40,8 +40,14 @@ from kedro_viz.data_access import DataAccessManager, data_access_manager
 from kedro_viz.integrations.kedro import data_loader as kedro_data_loader
 from kedro_viz.services import layers_services
 
-_DEFAULT_HOST = "0.0.0.0"
-_DEFAULT_PORT = 4141
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 4141
+DEV_PORT = 4142
+
+
+def is_localhost(host) -> bool:
+    """Check whether a host is a localhost"""
+    return host in ("127.0.0.1", "localhost", "0.0.0.0")
 
 
 def populate_data(
@@ -63,15 +69,15 @@ def populate_data(
 
 
 def run_server(
-    host: str = _DEFAULT_HOST,
-    port: int = _DEFAULT_PORT,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
     browser: bool = None,
     load_file: str = None,
     save_file: str = None,
     pipeline_name: str = None,
     env: str = None,
-    autoreload: bool = False,
     project_path: str = None,
+    autoreload: bool = False,
 ):
     """Run a uvicorn server with a FastAPI app that either launches API response data from a file
     or from reading data from a real Kedro project.
@@ -107,9 +113,7 @@ def run_server(
     else:
         app = apps.create_api_app_from_file(load_file)
 
-    is_localhost = host in ("127.0.0.1", "localhost", "0.0.0.0")
-
-    if browser and is_localhost:
+    if browser and is_localhost(host):
         webbrowser.open_new(f"http://{host}:{port}/")
     uvicorn.run(app, host=host, port=port)
 
@@ -122,10 +126,10 @@ if __name__ == "__main__":  # pragma: no cover
     parser = argparse.ArgumentParser(description="Launch a development viz server")
     parser.add_argument("project_path", help="Path to a Kedro project")
     parser.add_argument(
-        "--host", help="The host of the development server", default="localhost"
+        "--host", help="The host of the development server", default=DEFAULT_HOST
     )
     parser.add_argument(
-        "--port", help="The port of the development server", default=4142
+        "--port", help="The port of the development server", default=DEFAULT_PORT
     )
     args = parser.parse_args()
 

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -5,3 +5,4 @@ dataclasses==0.8; python_version == "3.6"
 fastapi>=0.63.0, <1.0
 aiofiles==0.6.0
 uvicorn~=0.13.4
+watchgod~=0.7

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -19,6 +19,7 @@ types-aiofiles==0.1.3
 types-cachetools==0.1.6
 types-click==0.1.14
 types-futures==0.1.3
+types-Jinja2==2.11.2
 types-orjson==0.1.0
 types-pkg-resources==0.1.2
 types-protobuf==0.1.10

--- a/package/tests/test_api/test_apps.py
+++ b/package/tests/test_api/test_apps.py
@@ -193,6 +193,7 @@ class TestIndexEndpoint:
         response = client.get("/")
         assert response.status_code == 200
         assert "heap" not in response.text
+        assert "checkReloadStatus" not in response.text
 
     @mock.patch("kedro_viz.integrations.kedro.telemetry.get_heap_app_id")
     @mock.patch("kedro_viz.integrations.kedro.telemetry.get_heap_identity")
@@ -205,6 +206,44 @@ class TestIndexEndpoint:
         assert response.status_code == 200
         assert 'heap.load("my_heap_app")' in response.text
         assert 'heap.identify("my_heap_identity")' in response.text
+
+
+@pytest.fixture
+def example_autoreload_api():
+    yield apps.create_api_app_from_project(mock.MagicMock(), autoreload=True)
+
+
+class TestReloadEndpoint:
+    def test_autoreload_script_added_to_index(self, example_autoreload_api):
+        client = TestClient(example_autoreload_api)
+        response = client.get("/")
+        assert response.status_code == 200
+        assert "checkReloadStatus" in response.text
+
+    def test_reload_endpoint_return_400_when_header_not_set(
+        self, example_autoreload_api
+    ):
+        client = TestClient(example_autoreload_api)
+        response = client.get("/api/reload")
+        assert response.status_code == 400
+
+    @mock.patch("kedro_viz.api.apps._create_etag")
+    def test_reload_endpoint_return_304_when_content_has_not_changed(
+        self, patched_create_etag
+    ):
+        patched_create_etag.return_value = "old etag"
+        api = apps.create_api_app_from_project(mock.MagicMock(), autoreload=True)
+
+        client = TestClient(api)
+
+        # if the client sends an If-None-Match header with the same value as the etag value
+        # on the server, the server should return a 304
+        response = client.get("/api/reload", headers={"If-None-Match": "old etag"})
+        assert response.status_code == 304
+
+        # when the etag has changed, the server will return a 200
+        response = client.get("/api/reload", headers={"If-None-Match": "new etag"})
+        assert response.status_code == 200
 
 
 class TestMainEndpoint:

--- a/package/tests/test_launchers/test_cli.py
+++ b/package/tests/test_launchers/test_cli.py
@@ -27,6 +27,7 @@
 # limitations under the License.
 import pytest
 from click.testing import CliRunner
+from watchgod import RegExpWatcher
 
 from kedro_viz.launchers import cli
 
@@ -42,7 +43,7 @@ from kedro_viz.launchers import cli
                 browser=True,
                 load_file=None,
                 save_file=None,
-                pipeline=None,
+                pipeline_name=None,
                 env=None,
             ),
         ),
@@ -67,7 +68,7 @@ from kedro_viz.launchers import cli
                 browser=False,
                 load_file=None,
                 save_file="save.json",
-                pipeline="data_science",
+                pipeline_name="data_science",
                 env="local",
             ),
         ),
@@ -79,4 +80,32 @@ def test_kedro_viz_command_run_server(command_options, run_server_args, mocker):
     with runner.isolated_filesystem():
         runner.invoke(cli.commands, command_options)
 
-    run_server.assert_called_once_with(*run_server_args.values())
+    run_server.assert_called_once_with(**run_server_args)
+
+
+def test_kedro_viz_command_with_autoreload(mocker):
+    mocker.patch("webbrowser.open_new")
+    mock_project_path = "/tmp/project_path"
+    mocker.patch("pathlib.Path.cwd", return_value=mock_project_path)
+    run_process = mocker.patch("kedro_viz.launchers.cli.run_process")
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        runner.invoke(cli.commands, ["viz", "--autoreload"])
+
+    run_process.assert_called_once_with(
+        path=mock_project_path,
+        target=cli.run_server,
+        kwargs={
+            "host": "127.0.0.1",
+            "port": 4141,
+            "load_file": None,
+            "save_file": None,
+            "pipeline_name": None,
+            "env": None,
+            "autoreload": True,
+            "browser": False,
+            "project_path": mock_project_path,
+        },
+        watcher_cls=RegExpWatcher,
+        watcher_kwargs={"re_files": "^.*(\\.yml|\\.yaml|\\.py)$"},
+    )

--- a/package/tests/test_launchers/test_cli.py
+++ b/package/tests/test_launchers/test_cli.py
@@ -45,6 +45,7 @@ from kedro_viz.launchers import cli
                 save_file=None,
                 pipeline_name=None,
                 env=None,
+                autoreload=False,
             ),
         ),
         (
@@ -70,6 +71,7 @@ from kedro_viz.launchers import cli
                 save_file="save.json",
                 pipeline_name="data_science",
                 env="local",
+                autoreload=False,
             ),
         ),
     ],

--- a/public/autoreload.html
+++ b/public/autoreload.html
@@ -1,0 +1,25 @@
+<script type="text/javascript">
+  // The etag value will be rendered on first page load
+  // by the server to store the timestamp of the last data update.
+  const etag = '{{ etag }}';
+
+  /**
+   * Periodically check the server whether we should reload the page
+   * since the content has been changed.
+   */
+  function checkReloadStatus() {
+    fetch('/api/reload', {
+      method: 'GET',
+      headers: { 'If-None-Match': etag },
+    }).then((response) => {
+      // The server will return `304 NOT MODIFIED` if the content of the Kedro project hasn't changed.
+      // Otherwise, it will return a `200` with an empty body.
+      // We should only reload on 200 and ignore all other status code like 500 as well.
+      if (response.status === 200) {
+        location.reload();
+      }
+    });
+  }
+
+  setInterval(checkReloadStatus, 1000);
+</script>

--- a/public/autoreload.html
+++ b/public/autoreload.html
@@ -21,5 +21,5 @@
     });
   }
 
-  setInterval(checkReloadStatus, 1000);
+  setInterval(checkReloadStatus, 3000);
 </script>


### PR DESCRIPTION
# Description

![reload](https://user-images.githubusercontent.com/2032984/125808541-48518be1-b21d-480f-80c5-625965719636.gif)

## 🌟 What

This PR adds an `--autoreload` flag to autoreload Kedro Viz when the a `Python` or `YAML` file has changed in the corresponding Kedro project. This all happens automatically without any manual action needed by users. 🎩

## 🤔 Why 

Currently when users change the code of their Kedro project, they will have to manually go to the terminal, kill the Kedro Viz process, relaunch it and go back to the browser to find another new tab for Kedro Viz next to an outdated tab. This is a very tedious user experience, especially if we want to make Kedro Viz more of a development tool.

## 💡 How

* On the server, we watch for file changes in the Kedro project with [watchgod](https://github.com/samuelcolvin/watchgod/) and simply relaunch the uvicorn process. Note: watchgod is made by the same author of pydantic and is now the recommended watcher for uvicorn itself, so it's quite future proof. Everytime the uvicorn process gets relaunched, the server gets a new etag, which tells the client to reload.
* On the client, we inject a script that pings the `/api/reload` endpoint every 3 seconds. If the etag has changed, the client simply reloads the tab.

## Development notes

Please don't mind the snyk failure. It's intermittent.

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

