### PR TITLE
Fix parameter metadata loading jump on metadata panel

### DIFF
--- a/src/components/metadata/metadata-row.js
+++ b/src/components/metadata/metadata-row.js
@@ -46,7 +46,7 @@ const MetaDataRow = ({
               theme={theme}
             />
           )}
-          {showObject && (
+          {showObject && Object.keys(value).length > 0 && (
             <MetaDataObject value={value} kind={kind} theme={theme} />
           )}
           {children}

--- a/src/components/metadata/metadata.test.js
+++ b/src/components/metadata/metadata.test.js
@@ -89,11 +89,11 @@ describe('MetaData', () => {
       expect(textOf(rowValue(row))).toEqual(['task']);
     });
 
-    it('shows the node parameters when there are no parameters', () => {
+    it('does not display the node parameter row when there are no parameters', () => {
       const wrapper = mount({ nodeId: salmonTaskNodeId });
       const row = rowByLabel(wrapper, 'Parameters:');
       //this is output of react-json-view with no value
-      expect(textOf(rowObject(row))).toEqual(['{}0 items']);
+      expect(textOf(rowObject(row)).length).toEqual(0);
     });
 
     it('shows the node parameters when there are parameters', () => {
@@ -333,11 +333,11 @@ describe('MetaData', () => {
         expect(textOf(rowValue(row))).toEqual(['-']);
       });
 
-      it('shows the node parameters', () => {
+      it('does not display the node parameter when it is an empty object', () => {
         const wrapper = mount({ nodeId: rabbitParamsNodeId });
         const row = rowByLabel(wrapper, 'Parameters:');
-        //this is output of react-json-view with no value
-        expect(textOf(rowObject(row))).toEqual(['{}0 items']);
+        //the metadata-object component would not load when parameters is an empty object
+        expect(textOf(rowObject(row)).length).toEqual(0);
       });
 
       it('shows the node tags', () => {


### PR DESCRIPTION
## Description

This is a quick fix for the visual jump for the react-json-view that happens before the node metadata is parsed and loaded - see below:

![JSON object visual jump](https://user-images.githubusercontent.com/27775658/125325912-66aa2600-e339-11eb-9b44-d2e6af53cd08.gif)

## Development notes

This is fixed by only displaying the metadata-object when it is not an empty object. 

I've added a quick check to ensure that the `metadata-object` is only loaded when the it is not an empty object ( which is the default value in its state initialization), and updated relevant tests. 

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

the json viewer will only load when the object is not an empty object. Please note that there is still a tiny visual jump as the metadata-object remounts on parsing new data on the initial load of the parameter metadata, but at least it would be slightly less confusing / disruptive than when jumping between 0 items and the full object on parsing the item. 

![parameter](https://user-images.githubusercontent.com/27775658/125327829-7e82a980-e33b-11eb-8bfd-be5e77e31f70.gif)


## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
