### PR TITLE
Fix object check when displaying metadata panel

### DIFF
--- a/src/components/metadata/metadata-row.js
+++ b/src/components/metadata/metadata-row.js
@@ -21,7 +21,7 @@ const MetaDataRow = ({
   children,
 }) => {
   const showList = Array.isArray(value);
-  const showObject = typeof value === 'object' && !showList;
+  const showObject = typeof value === 'object' && value !== null && !showList;
   return (
     visible && (
       <>

--- a/src/utils/data/animals.mock.json
+++ b/src/utils/data/animals.mock.json
@@ -85,7 +85,8 @@
       "modular_pipelines": [],
       "pipelines": ["de", "__default__"],
       "tags": ["large", "medium", "small"],
-      "type": "data"
+      "type": "data",
+      "dataset_type": null
     },
     {
       "full_name": "dog",


### PR DESCRIPTION
## Description

Currently the object check will pass a `null` value as object because `typeof null === "object"`, so it will try to render the `null` value as an object.

This fix will make sure `null` doesn't pass the object check and will get display as an empty primitive, i.e. `-`, as before. 

## Development notes

I think we should extract the type checking out into utility functions so we can unit tests but not doing it to avoid blowing the scope of change for the release.

That, or we use lodash utility functions which are well tested.

## QA notes

I amended the mock data to add a realistic condition where the backend would return `null` for `dataset_type`. Without this fix, the test will break.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
