### PR TITLE
added new '-' indicator for empty parameter object

### DIFF
--- a/src/components/metadata/metadata-object.js
+++ b/src/components/metadata/metadata-object.js
@@ -10,10 +10,11 @@ import {
 /**
  * Shows a metadata object
  */
-const MetaDataObject = ({ className, value, kind, theme }) => (
-  <>
-    <div
-      className={modifiers('pipeline-metadata__object', { kind }, className)}>
+const MetaDataObject = ({ className, value, kind, theme, empty }) => (
+  <div className={modifiers('pipeline-metadata__object', { kind }, className)}>
+    {Object.keys(value).length === 0 ? (
+      empty
+    ) : (
       <ReactJson
         theme={theme === 'dark' ? darkjsonViewerTheme : lightjsonViewerTheme}
         style={{
@@ -26,8 +27,8 @@ const MetaDataObject = ({ className, value, kind, theme }) => (
         enableClipboard={true}
         displayDataTypes={false}
         src={value}></ReactJson>
-    </div>
-  </>
+    )}
+  </div>
 );
 
 export default MetaDataObject;

--- a/src/components/metadata/metadata-row.js
+++ b/src/components/metadata/metadata-row.js
@@ -46,8 +46,13 @@ const MetaDataRow = ({
               theme={theme}
             />
           )}
-          {showObject && Object.keys(value).length > 0 && (
-            <MetaDataObject value={value} kind={kind} theme={theme} />
+          {showObject && (
+            <MetaDataObject
+              value={value}
+              kind={kind}
+              theme={theme}
+              empty={empty}
+            />
           )}
           {children}
         </dd>

--- a/src/components/metadata/metadata.test.js
+++ b/src/components/metadata/metadata.test.js
@@ -93,7 +93,7 @@ describe('MetaData', () => {
       const wrapper = mount({ nodeId: salmonTaskNodeId });
       const row = rowByLabel(wrapper, 'Parameters:');
       //this is output of react-json-view with no value
-      expect(textOf(rowObject(row)).length).toEqual(0);
+      expect(textOf(rowObject(row))).toEqual(['-']);
     });
 
     it('shows the node parameters when there are parameters', () => {
@@ -336,8 +336,7 @@ describe('MetaData', () => {
       it('does not display the node parameter when it is an empty object', () => {
         const wrapper = mount({ nodeId: rabbitParamsNodeId });
         const row = rowByLabel(wrapper, 'Parameters:');
-        //the metadata-object component would not load when parameters is an empty object
-        expect(textOf(rowObject(row)).length).toEqual(0);
+        expect(textOf(rowObject(row))).toEqual(['-']);
       });
 
       it('shows the node tags', () => {
@@ -377,12 +376,6 @@ describe('MetaData', () => {
       const wrapper = mount({ nodeId: bullPlotNodeID });
       const row = rowByLabel(wrapper, 'File Path:');
       expect(textOf(rowValue(row))).toEqual(['-']);
-    });
-
-    it('shows the node parameters', () => {
-      const wrapper = mount({ nodeId: bullPlotNodeID });
-      const row = rowByLabel(wrapper, 'Parameters:');
-      expect(textOf(rowValue(row))).toEqual([]);
     });
 
     it('shows the node tags', () => {


### PR DESCRIPTION
## Description

This is to enable empty parameter object to show an empty state  with a dash ('-') similar to the empty / null state of other fields on the metadata panel

## Development notes

I have added an empty object handler check for metadata object, as well as updated the related tests.

I haven't previously added the empty indicator when adding the empty object check given it provides a small visual jump from the dash indicator to the json object viewer once the data loads, however on testing it multiple times I do find that 'visual jump' minimal and is not disruptive. The benefits of aligning the empty parameter values with other presentation of the null value on the metadata panel outweighs the visual jump. 

I have also spotted an irrelevant test for dataset nodes for parameters ( currently dataset nodes does not display parameters so testing for an empty object is not a relevant test; see previous test suite for dataset nodes in the same test for reference).

## QA notes

on clicking task nodes without parameter values, it should now display a dash value ( '-'.) 

## Checklist

- [ x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ x] Added tests to cover my changes

## Legal notice

- [x ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
