### PR TITLE
Make sure kedro-viz doesn't hard depend on kedro-telemetry

### DIFF
--- a/package/kedro_viz/integrations/kedro/telemetry.py
+++ b/package/kedro_viz/integrations/kedro/telemetry.py
@@ -28,19 +28,24 @@
 """`kedro_viz.integrations.kedro.telemetry` helps integrate Kedro Viz with Kedro-Telemetry
 """
 import hashlib
-import logging
 import socket
 from pathlib import Path
 from typing import Optional
 
 import yaml
-from kedro_telemetry.plugin import _get_heap_app_id, _is_valid_syntax
 
-logger = logging.getLogger(__name__)
+try:
+    from kedro_telemetry.plugin import _get_heap_app_id, _is_valid_syntax
+
+    _IS_TELEMETRY_INSTALLED = True
+except ImportError:  # pragma: no cover
+    _IS_TELEMETRY_INSTALLED = False
 
 
 def get_heap_app_id(project_path: Path) -> Optional[str]:
     """Return the Heap App ID used for Kedro telemetry if user has given consent."""
+    if not _IS_TELEMETRY_INSTALLED:  # pragma: no cover
+        return None
     telemetry_file_path = project_path / ".telemetry"
     if not telemetry_file_path.exists():
         return None
@@ -53,6 +58,8 @@ def get_heap_app_id(project_path: Path) -> Optional[str]:
 
 def get_heap_identity() -> Optional[str]:  # pragma: no cover
     """Return the user ID in heap identical to the id used by kedro-telemetry plugin."""
+    if not _IS_TELEMETRY_INSTALLED:
+        return None
     try:
         return hashlib.sha512(bytes(socket.gethostname(), encoding="utf8")).hexdigest()
     except socket.timeout:

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,6 +1,5 @@
 semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
 kedro>=0.16.0
-kedro-telemetry>=0.1.0
 ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
 fastapi>=0.63.0, <1.0

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 kedro[pandas.CSVDataSet]>=0.16.0  # we use CSVDataSet in tests
+kedro-telemetry>=0.1.1  # for testing telemetry integration
 bandit~=1.6.2
 behave>=1.2.6, <2.0
 black==21.5b1


### PR DESCRIPTION
## Description

We don't want to make kedro-telemetry a hard dependency of kedro-viz since telemetry requires `kedro>=0.17.3` while viz is compatiable with `kedro>=0.16.0`. Also we can't force users to use `kedro-telemetry`.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

I have tested this with:

* Kedro-Viz works with `kedro-telemetry` and `kedro>0.17.3` if it is installed
* Kedro-Viz works if `kedro-telemetry` is not installed for `kedro>=0.16.0`

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
