### PR TITLE
Apply Prettier and add npm format script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lib-test": "npm-run-all -s lib lib-test:setup lib-test:serve",
     "lib-test:setup": "node ./tools/test-lib/setup.js",
     "lib-test:serve": "node ./tools/test-lib/serve.js",
+    "format": "prettier --single-quote --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "lint": "npm-run-all -p lint:js lint:scss",
     "lint:js": "eslint src/ --fix",
     "lint:scss": "stylelint 'src/**/*.scss' --fix",

--- a/src/actions/graph.test.js
+++ b/src/actions/graph.test.js
@@ -1,7 +1,6 @@
 import { createStore } from 'redux';
 import reducer from '../reducers';
 import { mockState } from '../utils/state.mock';
-import { changeFlag } from './index';
 import { calculateGraph, updateGraph } from './graph';
 import { getGraphInput } from '../selectors/layout';
 

--- a/src/actions/node-type.js
+++ b/src/actions/node-type.js
@@ -15,8 +15,6 @@ export const NODE_TYPE_DISABLED_UNSET = 0;
 export function toggleTypeDisabled(typeIDs, disabled) {
   return {
     type: TOGGLE_TYPE_DISABLED,
-    typeIDs: typeof typeIDs === 'string'
-      ? { [typeIDs]: disabled }
-      : typeIDs,
+    typeIDs: typeof typeIDs === 'string' ? { [typeIDs]: disabled } : typeIDs,
   };
 }

--- a/src/components/node-list/index.js
+++ b/src/components/node-list/index.js
@@ -19,7 +19,7 @@ import { toggleTypeDisabled } from '../../actions/node-type';
 import { toggleParametersHovered } from '../../actions';
 import {
   toggleModularPipelineActive,
-  toggleModularPipelineFilter
+  toggleModularPipelineFilter,
 } from '../../actions/modular-pipelines';
 import {
   loadNodeData,

--- a/src/components/node-list/node-list-items.js
+++ b/src/components/node-list/node-list-items.js
@@ -14,8 +14,7 @@ export const isTagType = (type) => type === 'tag';
 export const isModularPipelineType = (type) => type === 'modularPipeline';
 export const isElementType = (type) => type === 'elementType';
 
-export const isGroupType = (type) =>
-  isElementType(type) || isTagType(type);
+export const isGroupType = (type) => isElementType(type) || isTagType(type);
 
 /**
  * Get a list of IDs of the visible nodes from all groups
@@ -181,10 +180,12 @@ export const getFilteredElementTypes = createSelector(
     highlightMatch(
       filterNodeGroups(
         {
-          elementType: Object.entries(sidebarElementTypes).map(([type, name]) => ({
-            id: type,
-            name,
-          })),
+          elementType: Object.entries(sidebarElementTypes).map(
+            ([type, name]) => ({
+              id: type,
+              name,
+            })
+          ),
         },
         searchValue
       ),
@@ -293,32 +294,29 @@ export const getFilteredNodeItems = createSelector(
  * @param {object} items List items by group type
  * @return {array} List of groups
  */
-export const getGroups = createSelector(
-  [(state) => state.items],
-  (items) => {
-    const groups = {};
- 
-    for (const [type, name] of Object.entries(sidebarGroups)) {
-      const itemsOfType = items[type] || [];
-      const allUnchecked = itemsOfType.every((item) => !item.checked);
-      const allChecked = itemsOfType.every((item) => item.checked);
-    
-      groups[type] = {
-        type,
-        name,
-        id: type,
-        kind: 'filter',
-        allUnchecked: itemsOfType.every((item) => !item.checked),
-        allChecked: itemsOfType.every((item) => item.checked),
-        checked: !allUnchecked,
-        visibleIcon: allChecked ? IndicatorIcon : IndicatorPartialIcon,
-        invisibleIcon: IndicatorOffIcon,
-      };
-    }
+export const getGroups = createSelector([(state) => state.items], (items) => {
+  const groups = {};
 
-    return groups;
+  for (const [type, name] of Object.entries(sidebarGroups)) {
+    const itemsOfType = items[type] || [];
+    const allUnchecked = itemsOfType.every((item) => !item.checked);
+    const allChecked = itemsOfType.every((item) => item.checked);
+
+    groups[type] = {
+      type,
+      name,
+      id: type,
+      kind: 'filter',
+      allUnchecked: itemsOfType.every((item) => !item.checked),
+      allChecked: itemsOfType.every((item) => item.checked),
+      checked: !allUnchecked,
+      visibleIcon: allChecked ? IndicatorIcon : IndicatorPartialIcon,
+      invisibleIcon: IndicatorOffIcon,
+    };
   }
-);
+
+  return groups;
+});
 
 /**
  * Returns filtered/highlighted items for nodes, tags and modular pipelines

--- a/src/components/node-list/node-list-items.test.js
+++ b/src/components/node-list/node-list-items.test.js
@@ -61,7 +61,9 @@ describe('node-list-selectors', () => {
   describe('getFilteredElementTypes', () => {
     const elementTypes = Object.keys(sidebarElementTypes);
     const searchValue = 'n';
-    const filteredElementTypes = getFilteredElementTypes({ searchValue }).elementType;
+    const filteredElementTypes = getFilteredElementTypes({
+      searchValue,
+    }).elementType;
 
     const elementType = expect.arrayContaining([
       expect.objectContaining({
@@ -102,7 +104,7 @@ describe('node-list-selectors', () => {
         visible: expect.any(Boolean),
         disabled: expect.any(Boolean),
         checked: expect.any(Boolean),
-        count: expect.any(Number)
+        count: expect.any(Number),
       }),
     ]);
 
@@ -178,7 +180,7 @@ describe('node-list-selectors', () => {
         visible: expect.any(Boolean),
         disabled: expect.any(Boolean),
         checked: expect.any(Boolean),
-        count: expect.any(Number)
+        count: expect.any(Number),
       }),
     ]);
 
@@ -233,7 +235,7 @@ describe('node-list-selectors', () => {
         faded: expect.any(Boolean),
         visible: expect.any(Boolean),
         disabled: expect.any(Boolean),
-        checked: expect.any(Boolean)
+        checked: expect.any(Boolean),
       }),
     ]);
 
@@ -287,7 +289,7 @@ describe('node-list-selectors', () => {
       kind: expect.any(String),
       allUnchecked: expect.any(Boolean),
       allChecked: expect.any(Boolean),
-      checked: expect.any(Boolean)
+      checked: expect.any(Boolean),
     });
 
     it('returns groups for each type in the correct format', () => {

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -26,7 +26,7 @@ const shouldMemo = (prevProps, nextProps) =>
       'selected',
       'label',
       'children',
-      'count'
+      'count',
     ],
     prevProps,
     nextProps
@@ -128,10 +128,14 @@ const NodeListRow = memo(
             )}
             <label
               htmlFor={id}
-              className={classnames('pipeline-row__toggle', `pipeline-row__toggle--kind-${kind}`, {
-                'pipeline-row__toggle--disabled': disabled,
-                'pipeline-row__toggle--selected': selected,
-              })}>
+              className={classnames(
+                'pipeline-row__toggle',
+                `pipeline-row__toggle--kind-${kind}`,
+                {
+                  'pipeline-row__toggle--disabled': disabled,
+                  'pipeline-row__toggle--selected': selected,
+                }
+              )}>
               <input
                 id={id}
                 className="pipeline-nodelist__row__checkbox"

--- a/src/components/node-list/node-list-row.test.js
+++ b/src/components/node-list/node-list-row.test.js
@@ -72,26 +72,18 @@ describe('NodeListRow', () => {
     it('shows count if count prop set', () => {
       const { props } = setupProps();
       const mockCount = 123;
-      const wrapper = setup.mount(
-        <NodeListRow {...props} count={mockCount} />
+      const wrapper = setup.mount(<NodeListRow {...props} count={mockCount} />);
+      expect(wrapper.find('.pipeline-nodelist__row__count').text()).toBe(
+        mockCount.toString()
       );
-      expect(
-        wrapper
-          .find('.pipeline-nodelist__row__count')
-          .text()
-      ).toBe(mockCount.toString());
     });
 
     it('does not show count if count prop not set', () => {
       const { props } = setupProps();
-      const wrapper = setup.mount(
-        <NodeListRow {...props} count={null} />
+      const wrapper = setup.mount(<NodeListRow {...props} count={null} />);
+      expect(wrapper.find('.pipeline-nodelist__row__count').exists()).toBe(
+        false
       );
-      expect(
-        wrapper
-          .find('.pipeline-nodelist__row__count')
-          .exists()
-      ).toBe(false);
     });
   });
 

--- a/src/components/node-list/node-list.test.js
+++ b/src/components/node-list/node-list.test.js
@@ -59,9 +59,9 @@ describe('NodeList', () => {
           const expectedTagResult = tags.filter((tag) =>
             tag.name.includes(searchText)
           );
-          const expectedElementTypeResult = Object.keys(sidebarElementTypes).filter((type) =>
-            type.includes(searchText)
-          );
+          const expectedElementTypeResult = Object.keys(
+            sidebarElementTypes
+          ).filter((type) => type.includes(searchText));
           // obtain the modular pipeline parents
           const expectedModularPipelines = nodesModularPipelines.hasOwnProperty(
             searchText
@@ -108,7 +108,9 @@ describe('NodeList', () => {
         type.includes(searchText)
       );
       expect(nodeList().length).toBe(
-        expectedResult.length + expectedTagResult.length + expectedElementTypeResult.length
+        expectedResult.length +
+          expectedTagResult.length +
+          expectedElementTypeResult.length
       );
       // Clear the list with escape key
       searchWrapper.simulate('keydown', { keyCode: 27 });

--- a/src/config.js
+++ b/src/config.js
@@ -41,14 +41,14 @@ export const flags = {
 // Sidebar groups is an ordered map of { id: label }
 export const sidebarGroups = {
   elementType: 'Element types',
-  tag: 'Tags'
+  tag: 'Tags',
 };
 
 // Sidebar element types is an ordered map of { id: label }
 export const sidebarElementTypes = {
   task: 'Nodes',
   data: 'Datasets',
-  parameters: 'Parameters'
+  parameters: 'Parameters',
 };
 
 export const shortTypeMapping = {

--- a/src/reducers/reducers.test.js
+++ b/src/reducers/reducers.test.js
@@ -23,7 +23,10 @@ import {
   ADD_NODE_METADATA,
 } from '../actions/nodes';
 import { TOGGLE_TAG_ACTIVE, TOGGLE_TAG_FILTER } from '../actions/tags';
-import { TOGGLE_TYPE_DISABLED, NODE_TYPE_DISABLED_UNSET } from '../actions/node-type';
+import {
+  TOGGLE_TYPE_DISABLED,
+  NODE_TYPE_DISABLED_UNSET,
+} from '../actions/node-type';
 import { UPDATE_ACTIVE_PIPELINE } from '../actions/pipelines';
 import {
   TOGGLE_MODULAR_PIPELINE_ACTIVE,
@@ -158,11 +161,11 @@ describe('Reducer', () => {
       const mockDisabledState = {
         data: false,
         parameters: true,
-        task: true
+        task: true,
       };
       const newState = reducer(mockState.animals, {
         type: TOGGLE_TYPE_DISABLED,
-        typeIDs: mockDisabledState
+        typeIDs: mockDisabledState,
       });
       expect(newState.nodeType.disabled).toEqual(mockDisabledState);
     });
@@ -171,16 +174,16 @@ describe('Reducer', () => {
       const mockDisabledState = {
         data: NODE_TYPE_DISABLED_UNSET,
         parameters: false,
-        task: true
+        task: true,
       };
       const newState = reducer(mockState.animals, {
         type: TOGGLE_TYPE_DISABLED,
-        typeIDs: mockDisabledState
+        typeIDs: mockDisabledState,
       });
       expect(newState.nodeType.disabled).toEqual({
         data: true,
         parameters: false,
-        task: true
+        task: true,
       });
     });
 
@@ -188,16 +191,16 @@ describe('Reducer', () => {
       const mockDisabledState = {
         data: true,
         parameters: true,
-        task: true
+        task: true,
       };
       const newState = reducer(mockState.animals, {
         type: TOGGLE_TYPE_DISABLED,
-        typeIDs: mockDisabledState
+        typeIDs: mockDisabledState,
       });
       expect(newState.nodeType.disabled).toEqual({
         data: NODE_TYPE_DISABLED_UNSET,
         parameters: NODE_TYPE_DISABLED_UNSET,
-        task: NODE_TYPE_DISABLED_UNSET
+        task: NODE_TYPE_DISABLED_UNSET,
       });
     });
   });

--- a/src/selectors/tags.js
+++ b/src/selectors/tags.js
@@ -34,17 +34,14 @@ export const getTagCount = createSelector(
 /**
  * Get the total number of nodes for each tag
  */
- export const getTagNodeCounts = createSelector(
-  [getNodeTags],
-  (nodeTags) => {
-    const counts = {};
+export const getTagNodeCounts = createSelector([getNodeTags], (nodeTags) => {
+  const counts = {};
 
-    for (const tagIds of Object.values(nodeTags)) {
-      for (const tagId of tagIds) {
-        counts[tagId] = (counts[tagId] + 1) || 1;
-      }
+  for (const tagIds of Object.values(nodeTags)) {
+    for (const tagId of tagIds) {
+      counts[tagId] = counts[tagId] + 1 || 1;
     }
-
-    return counts;
   }
-);
+
+  return counts;
+});


### PR DESCRIPTION
## Description

This PR only:

- adds an npm script `npm run format` to manually apply the built in Prettier to format all files
- applies this formatting to all files
- fixes an additional lint warning for an unused variable

The automatic Prettier formatting hook does not appear to always work at the moment, so this will need to be addressed later.

## QA notes

No changes made other than the above which were automated.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
