### PR TITLE
[KED-2731] Update deprecated highlight.js call

### DIFF
--- a/src/components/metadata/metadata-code.js
+++ b/src/components/metadata/metadata-code.js
@@ -24,7 +24,7 @@ export const MetaDataCode = ({
   const highlighted = useMemo(() => {
     const detected = hljs.highlightAuto(value);
     const language = detected.language || detected.second_best.language;
-    return language ? hljs.highlight(language, value).value : value;
+    return language ? hljs.highlight(value, { language }).value : value;
   }, [value]);
 
   return (


### PR DESCRIPTION
## Description

Updates deprecated highlight.js call to the new API

## Development notes

The deprecation warning was given as:

```
Deprecated as of 10.7.0. Please use highlight(code, options) instead.
https://github.com/highlightjs/highlight.js/issues/2277
```

## QA notes

No change in behaviour.

Test that code panel works as before.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
