### PR TITLE
[KED-2802] Unify monospace fonts

### DIFF
--- a/src/components/metadata/metadata-object.js
+++ b/src/components/metadata/metadata-object.js
@@ -17,16 +17,14 @@ const MetaDataObject = ({ className, value, kind, theme, empty }) => (
     ) : (
       <ReactJson
         theme={theme === 'dark' ? darkjsonViewerTheme : lightjsonViewerTheme}
-        style={{
-          fontFamily: "Consolas, Monaco, 'Courier New', Courier, monospace",
-        }}
         name={false}
         indentWidth={1}
         collapsed={1}
         collapseStringsAfterLength={true}
         enableClipboard={true}
         displayDataTypes={false}
-        src={value}></ReactJson>
+        src={value}
+      />
     )}
   </div>
 );

--- a/src/components/metadata/styles/metadata-code.scss
+++ b/src/components/metadata/styles/metadata-code.scss
@@ -92,7 +92,7 @@
   }
 
   * {
-    font-family: Consolas, Monaco, 'Courier New', Courier, monospace;
+    font-family: $font-monospace;
   }
 
   .hljs-keyword {

--- a/src/components/metadata/styles/metadata.scss
+++ b/src/components/metadata/styles/metadata.scss
@@ -144,8 +144,8 @@
   code & {
     padding: 0.4em 0.8em;
     font-weight: normal;
-    font-size: 0.9em;
-    font-family: Consolas, Monaco, 'Courier New', Courier, monospace;
+    font-size: 0.85em;
+    font-family: $font-monospace;
   }
 }
 
@@ -223,6 +223,8 @@ $list-inline-spacing: 0.2em;
   display: flex;
   flex-grow: 1;
   align-items: center;
+  font-family: $font-monospace;
+  font-size: 0.9em;
 
   &--no-visible {
     opacity: 0;
@@ -302,7 +304,8 @@ $list-inline-spacing: 0.2em;
 }
 
 .pipeline-metadata__object {
-  .react-json-view {
-    font-size: 0.85em;
+  .pretty-json-container {
+    font-family: $font-monospace;
+    font-size: 0.87em;
   }
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,3 +1,7 @@
+//-- Fonts --//
+
+$font-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+
 //-- Colours --//
 
 $color-dark: black;


### PR DESCRIPTION
## Description

Changes all monospace font usage to use the same optimised system font stack.

## Development notes

Since the font changed, I also applied a small adjustment to font size to rebalance the font size against the other fonts.

## QA notes

Check the monospace fonts (only in the metadata sidebar currently).

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
