### PR TITLE
[KED-2788] Improve pretty-name algorithm

### DIFF
--- a/package/kedro_viz/models/graph.py
+++ b/package/kedro_viz/models/graph.py
@@ -48,9 +48,9 @@ logger = logging.getLogger(__name__)
 
 
 def _pretty_name(name: str) -> str:
-    name = name.replace("-", " ").replace("_", " ")
-    parts = [n.capitalize() for n in re.split('(\\W)',name)]
-    return "".join(parts)
+    name = name.replace("-", " ").replace("_", " ").replace(":",": ")
+    parts = [n.capitalize() for n in name.split()]
+    return " ".join(parts)
 
 
 def _strip_namespace(name: str) -> str:

--- a/package/kedro_viz/models/graph.py
+++ b/package/kedro_viz/models/graph.py
@@ -49,8 +49,8 @@ logger = logging.getLogger(__name__)
 
 def _pretty_name(name: str) -> str:
     name = name.replace("-", " ").replace("_", " ")
-    parts = [n.capitalize() for n in name.split()]
-    return " ".join(parts)
+    parts = [n.capitalize() for n in re.split('(\\W)',name)]
+    return "".join(parts)
 
 
 def _strip_namespace(name: str) -> str:

--- a/package/tests/example_pipelines.json
+++ b/package/tests/example_pipelines.json
@@ -23,7 +23,7 @@
     },
     {
       "id": "c506f374",
-      "name": "Params:train Test Split",
+      "name": "Params: Train Test Split",
       "full_name": "params:train_test_split",
       "tags": ["split"],
       "pipelines": ["__default__", "data_processing"],

--- a/package/tests/test_api/test_apps.py
+++ b/package/tests/test_api/test_apps.py
@@ -131,7 +131,7 @@ def assert_example_data(response_data):
         },
         {
             "id": "c506f374",
-            "name": "Params:train Test Split",
+            "name": "Params: Train Test Split",
             "full_name": "params:train_test_split",
             "tags": ["split"],
             "pipelines": ["__default__", "data_processing"],
@@ -241,7 +241,7 @@ def assert_example_transcoded_data(response_data):
         },
         {
             "id": "c506f374",
-            "name": "Params:train Test Split",
+            "name": "Params: Train Test Split",
             "full_name": "params:train_test_split",
             "tags": ["split"],
             "pipelines": ["__default__", "data_processing"],
@@ -400,7 +400,7 @@ class TestNodeMetadataEndpoint:
             == "def process_data(raw_data, train_test_split):\n        ...\n"
         )
         assert metadata["parameters"] == {"train_test_split": 0.1}
-        assert metadata["inputs"] == ["Raw Data", "Params:train Test Split"]
+        assert metadata["inputs"] == ["Raw Data", "Params: Train Test Split"]
         assert metadata["outputs"] == ["Model Inputs"]
         assert metadata["run_command"] == 'kedro run --to-nodes="process_data"'
         assert str(Path("package/tests/conftest.py")) in metadata["filepath"]


### PR DESCRIPTION
## Description

The pretty naming algorithm does not handle punctuation well and this affects:
Parameters e.g. Params:linear Regression

This ticket fixes that issue. 

## Development notes

The above issue only affects parameters – it doesn't affect transcoded datasets anymore because @ is removed and datasets with modular pipelines have namespace removed with pretty names. 

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
