### PR TITLE
Pin dynaconf before Kedro is released

### DIFF
--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -107,6 +107,7 @@ def _setup_context_with_venv(context, venv_dir):
             "cookiecutter>=1.7.2",
             "wheel",
             "botocore",
+            "dynaconf==3.1.5",
         ],
         env=context.env,
     )

--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -107,7 +107,6 @@ def _setup_context_with_venv(context, venv_dir):
             "cookiecutter>=1.7.2",
             "wheel",
             "botocore",
-            "dynaconf==3.1.5",
         ],
         env=context.env,
     )

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -116,6 +116,7 @@ def exec_kedro_target_checked(context, command):
     # Wait for subprocess completion since on Windows it takes some time
     # to install dependencies in a separate console
     if "install" in cmd:
+        result = run([context.pip, "install", "dynaconf==3.1.5"])
         max_duration = 5 * 60  # 5 minutes
         end_by = time() + max_duration
 

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -105,7 +105,6 @@ def create_project_with_starter(context, starter):
 def exec_kedro_target_checked(context, command):
     """Execute Kedro command and check the status."""
     pin_dynaconf = [context.pip, "install", "dynaconf==3.1.5"]
-    result = run(pin_dynaconf)
     cmd = [context.kedro] + command.split()
 
     res = run(cmd, env=context.env, cwd=str(context.root_project_dir))

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -130,7 +130,7 @@ def exec_kedro_target_checked(context, command):
 @given('I have installed kedro version "{version}"')
 def install_kedro(context, version):
     """Execute Kedro command and check the status."""
-    pin_dynaconf = [context.pip, "install", "dynaconf==3.1.5"]
+    pin_dynaconf = [context.pip, "install", "'dynaconf==3.1.4'"]
     if version == "latest":
         cmd = [context.pip, "install", "-U", "kedro"]
     else:
@@ -142,7 +142,7 @@ def install_kedro(context, version):
         print(res.stderr)
         assert False
 
-    # pin dynaconf to avoid backward breaking chang ein 3.1.7
+    # pin dynaconf to avoid backward breaking change in 3.1.5
     run(pin_dynaconf, env=context.env)
 
 

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -130,6 +130,7 @@ def exec_kedro_target_checked(context, command):
 @given('I have installed kedro version "{version}"')
 def install_kedro(context, version):
     """Execute Kedro command and check the status."""
+    pin_dynaconf = [context.pip, "install", "dynaconf==3.1.5"]
     if version == "latest":
         cmd = [context.pip, "install", "-U", "kedro"]
     else:
@@ -140,6 +141,9 @@ def install_kedro(context, version):
         print(res.stdout)
         print(res.stderr)
         assert False
+
+    # pin dynaconf to avoid backward breaking chang ein 3.1.7
+    run(pin_dynaconf, env=context.env)
 
 
 @when('I execute the kedro viz command "{command}"')

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -104,6 +104,8 @@ def create_project_with_starter(context, starter):
 @given('I have executed the kedro command "{command}"')
 def exec_kedro_target_checked(context, command):
     """Execute Kedro command and check the status."""
+    pin_dynaconf = [context.pip, "install", "dynaconf==3.1.5"]
+    result = run(pin_dynaconf)
     cmd = [context.kedro] + command.split()
 
     res = run(cmd, env=context.env, cwd=str(context.root_project_dir))
@@ -116,7 +118,7 @@ def exec_kedro_target_checked(context, command):
     # Wait for subprocess completion since on Windows it takes some time
     # to install dependencies in a separate console
     if "install" in cmd:
-        result = run([context.pip, "install", "dynaconf==3.1.5"])
+        result = run(pin_dynaconf)
         max_duration = 5 * 60  # 5 minutes
         end_by = time() + max_duration
 

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -130,7 +130,6 @@ def exec_kedro_target_checked(context, command):
 @given('I have installed kedro version "{version}"')
 def install_kedro(context, version):
     """Execute Kedro command and check the status."""
-    pin_dynaconf = [context.pip, "install", "'dynaconf==3.1.4'"]
     if version == "latest":
         cmd = [context.pip, "install", "-U", "kedro"]
     else:
@@ -141,9 +140,6 @@ def install_kedro(context, version):
         print(res.stdout)
         print(res.stderr)
         assert False
-
-    # pin dynaconf to avoid backward breaking change in 3.1.5
-    run(pin_dynaconf, env=context.env)
 
 
 @when('I execute the kedro viz command "{command}"')

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -2,7 +2,6 @@ semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
 kedro>=0.16.0
 ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
-dynaconf==3.1.5 # 3.1.6 breaks backward compat with Kedro
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
 uvicorn~=0.13.4

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -2,6 +2,7 @@ semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
 kedro>=0.16.0
 ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
+dynaconf<3.1.6 # 3.1.7 breaks backward compat with Kedro
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
 uvicorn~=0.13.4

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -2,7 +2,7 @@ semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
 kedro>=0.16.0
 ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
-dynaconf<3.1.5 # 3.1.5 breaks backward compat with Kedro
+dynaconf<3.1.6 # 3.1.6 breaks backward compat with Kedro
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
 uvicorn~=0.13.4

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -2,7 +2,7 @@ semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
 kedro>=0.16.0
 ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
-dynaconf<3.1.6 # 3.1.7 breaks backward compat with Kedro
+dynaconf<3.1.5 # 3.1.5 breaks backward compat with Kedro
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
 uvicorn~=0.13.4

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -2,7 +2,7 @@ semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
 kedro>=0.16.0
 ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
-dynaconf<3.1.6 # 3.1.6 breaks backward compat with Kedro
+dynaconf==3.1.5 # 3.1.6 breaks backward compat with Kedro
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
 uvicorn~=0.13.4

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -2,6 +2,7 @@ semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
 kedro>=0.16.0
 ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
+dynaconf==3.1.5 # 3.1.6 breaks backward compat with Kedro
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
 uvicorn~=0.13.4


### PR DESCRIPTION
## Description

Latest dynaconf (a dependency of Kedro) has released a new version and is currently breaking Kedro. So we have to pin it here to unblock CI.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
