### PR TITLE
KED-2847: overwrite mui selected defaults

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@ Please follow the established format:
 ## Bug fixes and other changes
 
 - Overwrite material UI selected row defaults. (#568)
+
 # Release 3.16.0
 
 ## Major features and improvements

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,14 @@ Please follow the established format:
 - Use present tense (e.g. 'Add new feature')
 - Include the ID number for the related PR (or PRs) in parentheses
 -->
+
+# Release 3.16.1
+
+## Major features and improvements
+
+## Bug fixes and other changes
+
+- Overwrite material UI selected row defaults. (#568)
 # Release 3.16.0
 
 ## Major features and improvements

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -102,6 +102,7 @@ const NodeListRow = memo(
             'pipeline-nodelist__row--selected': selected,
             'pipeline-nodelist__row--disabled': disabled,
             'pipeline-nodelist__row--unchecked': !checked,
+            'pipeline-nodelist__row--overwrite': !selected,
           }
         )}
         title={name}

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -102,7 +102,8 @@ const NodeListRow = memo(
             'pipeline-nodelist__row--selected': selected,
             'pipeline-nodelist__row--disabled': disabled,
             'pipeline-nodelist__row--unchecked': !checked,
-            'pipeline-nodelist__row--overwrite': !selected,
+            'pipeline-nodelist__row--overwrite':
+              active || selected ? false : true,
           }
         )}
         title={name}

--- a/src/components/node-list/node-list-row.js
+++ b/src/components/node-list/node-list-row.js
@@ -117,7 +117,8 @@ const NodeListRow = memo(
                 'pipeline-nodelist__row__type-icon--disabled': disabled,
                 'pipeline-nodelist__row__type-icon--nested': !children,
                 'pipeline-nodelist__row__type-icon--active': active,
-                'pipeline-nodelist__row__type-icon--selected': selected,
+                'pipeline-nodelist__row__type-icon--selected':
+                  selected || isInFocusMode,
               }
             )}
             icon={icon}

--- a/src/components/node-list/node-list-row.test.js
+++ b/src/components/node-list/node-list-row.test.js
@@ -44,6 +44,18 @@ describe('NodeListRow', () => {
       expect(props.onMouseLeave.mock.calls.length).toEqual(1);
     });
 
+    it('applies the overwrite class if not selected', () => {
+      const { props } = setupProps();
+      const activeNodeWrapper = setup.mount(
+        <NodeListRow {...props} selected={false} />
+      );
+      expect(
+        activeNodeWrapper
+          .find('.pipeline-nodelist__row')
+          .hasClass('pipeline-nodelist__row--overwrite')
+      ).toBe(true);
+    });
+
     it('uses active class if active', () => {
       const { props } = setupProps();
       const activeNodeWrapper = setup.mount(

--- a/src/components/node-list/node-list-row.test.js
+++ b/src/components/node-list/node-list-row.test.js
@@ -44,16 +44,52 @@ describe('NodeListRow', () => {
       expect(props.onMouseLeave.mock.calls.length).toEqual(1);
     });
 
-    it('applies the overwrite class if not selected', () => {
+    it('applies the overwrite class if not active', () => {
       const { props } = setupProps();
       const activeNodeWrapper = setup.mount(
-        <NodeListRow {...props} selected={false} />
+        <NodeListRow {...props} active={false} />
       );
       expect(
         activeNodeWrapper
           .find('.pipeline-nodelist__row')
           .hasClass('pipeline-nodelist__row--overwrite')
       ).toBe(true);
+    });
+
+    it('applies the overwrite class if not selected or active', () => {
+      const { props } = setupProps();
+      const activeNodeWrapper = setup.mount(
+        <NodeListRow {...props} selected={false} active={false} />
+      );
+      expect(
+        activeNodeWrapper
+          .find('.pipeline-nodelist__row')
+          .hasClass('pipeline-nodelist__row--overwrite')
+      ).toBe(true);
+    });
+
+    it('does not applies the overwrite class if not selected', () => {
+      const { props } = setupProps();
+      const activeNodeWrapper = setup.mount(
+        <NodeListRow {...props} selected={true} />
+      );
+      expect(
+        activeNodeWrapper
+          .find('.pipeline-nodelist__row')
+          .hasClass('pipeline-nodelist__row--overwrite')
+      ).toBe(false);
+    });
+
+    it('does not applies the overwrite class if active', () => {
+      const { props } = setupProps();
+      const activeNodeWrapper = setup.mount(
+        <NodeListRow {...props} active={true} />
+      );
+      expect(
+        activeNodeWrapper
+          .find('.pipeline-nodelist__row')
+          .hasClass('pipeline-nodelist__row--overwrite')
+      ).toBe(false);
     });
 
     it('uses active class if active', () => {

--- a/src/components/node-list/styles/_row-toggle.scss
+++ b/src/components/node-list/styles/_row-toggle.scss
@@ -120,7 +120,7 @@ $element-icon-opacity-2: 1;
 
   &.pipeline-row__toggle-icon--focus-checked {
     > * {
-      opacity: $element-icon-opacity-2;
+      opacity: $element-icon-opacity-1;
     }
   }
 }

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -15,6 +15,26 @@
   transform: translate(0, 0);
   cursor: default;
 
+  .Mui-selected & {
+    .kui-theme--dark & {
+      background-color: #{$color-bg-dark-2};
+
+      &--active,
+      &--visible:hover {
+        background-color: var(--color-nodelist-row-active);
+      }
+
+      &--selected,
+      &--visible#{&}--selected {
+        background-color: var(--color-nodelist-row-selected);
+      }
+    }
+
+    .kui-theme--light & {
+      background-color: #{$color-bg-light-3};
+    }
+  }
+
   &--kind-filter {
     padding: 0 $row-offset-right 0 $row-offset-left;
   }

--- a/src/components/node-list/styles/_row.scss
+++ b/src/components/node-list/styles/_row.scss
@@ -15,23 +15,23 @@
   transform: translate(0, 0);
   cursor: default;
 
-  .Mui-selected & {
-    .kui-theme--dark & {
-      background-color: #{$color-bg-dark-2};
-
-      &--active,
-      &--visible:hover {
-        background-color: var(--color-nodelist-row-active);
+  // overwrite material-ui selected row background color settings
+  &--overwrite {
+    .Mui-selected & {
+      .kui-theme--dark & {
+        background-color: #{$color-bg-dark-2};
       }
 
-      &--selected,
-      &--visible#{&}--selected {
-        background-color: var(--color-nodelist-row-selected);
+      .kui-theme--light & {
+        background-color: #{$color-bg-light-3};
       }
     }
+  }
 
-    .kui-theme--light & {
-      background-color: #{$color-bg-light-3};
+  // overwrite with highlighted background for row on hover
+  &--overwrite:hover {
+    .Mui-selected & {
+      background-color: var(--color-nodelist-row-active);
     }
   }
 

--- a/src/components/node-list/styles/node-list.scss
+++ b/src/components/node-list/styles/node-list.scss
@@ -80,3 +80,10 @@
     }
   }
 }
+
+.MuiTreeItem-label {
+  .kui-theme--dark &,
+  .kui-theme--light & {
+    padding-left: 0;
+  }
+}

--- a/src/components/node-list/styles/node-list.scss
+++ b/src/components/node-list/styles/node-list.scss
@@ -81,6 +81,8 @@
   }
 }
 
+// material-ui applies a padding on the left by default -
+// this is to eliminate the unneccessary padding
 .MuiTreeItem-label {
   .kui-theme--dark &,
   .kui-theme--light & {


### PR DESCRIPTION
## Description

Material-UI by default will apply a new background color to depict a highlighted state for a selected item - this PR is a  fix to overwrite the highlighted background caused by the default material UI settings for the tree nav sidebar, while maintaining the existing different cases of interaction on the row ( hover + selected + active). This also includes an update to some minor CSS changes for the sidebar interaction.

## Development notes

I have made the relevant CSS changes to overwrite the default material-UI styles, as well as change the default opacity for the sidebar icon interaction. I have added to ensure the overwrite class gets applied when the row is not selected. 

I have also added a new entry in our release notes for this fix. 

## QA notes

The changes for this PR can be tested here: http://kedro-viz-fe.s3-website.eu-west-2.amazonaws.com/fix/overwrite-Mui-selected-defaults/?data=demo

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
