### PR TITLE
[KED-2868] Fix auto-reload for metrics plot and tree

### DIFF
--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -122,7 +122,7 @@ def viz(host, port, browser, load_file, save_file, pipeline, env, autoreload):
                 target=run_server,
                 kwargs=run_server_kwargs,
                 watcher_cls=RegExpWatcher,
-                watcher_kwargs=dict(re_files=r"^.*(\.yml|\.yaml|\.py)$"),
+                watcher_kwargs=dict(re_files=r"^.*(\.yml|\.yaml|\.py|\.json)$"),
             )
 
         else:

--- a/package/tests/test_launchers/test_cli.py
+++ b/package/tests/test_launchers/test_cli.py
@@ -109,5 +109,5 @@ def test_kedro_viz_command_with_autoreload(mocker):
             "project_path": mock_project_path,
         },
         watcher_cls=RegExpWatcher,
-        watcher_kwargs={"re_files": "^.*(\\.yml|\\.yaml|\\.py)$"},
+        watcher_kwargs={"re_files": "^.*(\\.yml|\\.yaml|\\.py|\\.json)$"},
     )


### PR DESCRIPTION
## Description

When we do 'kedro run' and the project gets updated with the latest metrics. Kedro viz auto-reload did not catch these updates and refresh automatically. 

## Development notes
 
For now, we have added .json to the watchlist so if any changes are made in any json file (including metrics data) on the user project then it will refresh kedro-viz. 
Note - there is a possibility that this might get annoying if the user updates their json a lot; if that happens then this solution will need to be revised. 

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
