### PR TITLE
KED-2861 Update GraphQL to use Strawberry

### DIFF
--- a/package/features/environment.py
+++ b/package/features/environment.py
@@ -108,6 +108,7 @@ def _setup_context_with_venv(context, venv_dir):
             "wheel",
             "botocore",
             "dynaconf==3.1.5",
+            "click<8.0"
         ],
         env=context.env,
     )

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -26,11 +26,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """`kedro_viz.api.graphql` defines graphql API endpoint."""
-# pylint: disable=missing-function-docstring
-# pylint: disable=unused-argument
-from fastapi import APIRouter
 import strawberry
+
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=too-few-public-methods
+# pylint: disable=no-self-use
+from fastapi import APIRouter
 from strawberry.asgi import GraphQL
+
 
 @strawberry.type
 class HealthCheck:

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -29,20 +29,23 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=unused-argument
 from fastapi import APIRouter
-from graphene import ObjectType, Schema, String
-from starlette.graphql import GraphQLApp
+import strawberry
+from strawberry.asgi import GraphQL
+
+@strawberry.type
+class HealthCheck:
+    name: str
 
 
-class Query(ObjectType):
-    """GraphQL query that returns an empty object on HTTP 200 Response"""
+@strawberry.type
+class Query:
+    @strawberry.field
+    def healthcheck(self) -> HealthCheck:
+        return HealthCheck(name="")
 
-    healthcheck = String()
 
-    @staticmethod
-    def resolve_healthcheck(*args):
-        return {}
-
+schema = strawberry.Schema(query=Query)
 
 router = APIRouter()
 
-router.add_route("/graphql", GraphQLApp(schema=Schema(query=Query)))
+router.add_route("/graphql", GraphQL(schema))

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -38,14 +38,14 @@ from strawberry.asgi import GraphQL
 
 @strawberry.type
 class HealthCheck:
-    name: str
+    status: str
 
 
 @strawberry.type
 class Query:
     @strawberry.field
     def healthcheck(self) -> HealthCheck:
-        return HealthCheck(name="")
+        return HealthCheck(status="OK")
 
 
 schema = strawberry.Schema(query=Query)

--- a/package/mypy.ini
+++ b/package/mypy.ini
@@ -2,6 +2,7 @@
 warn_redundant_casts = True
 warn_unused_ignores = True
 ignore_missing_imports = True
+plugins = strawberry.ext.mypy_plugin
 
 [mypy-kedro_viz.launchers.jupyter]
 ignore_errors = True

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -4,9 +4,8 @@ ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
-uvicorn~=0.13.4
+uvicorn[standard]~=0.13.4
 watchgod~=0.7
 plotly~=4.14.3
 pandas~=1.3.0
-graphene~=2.1.8
-starlette~=0.14.2
+strawberry-graphql~=0.79.0

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -4,7 +4,6 @@ ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
-click==7.0.0
 uvicorn[standard]~=0.13.4
 watchgod~=0.7
 plotly~=4.14.3

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -4,7 +4,8 @@ ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
-uvicorn~=0.13.4
+click==7.0.0
+uvicorn[standard]~=0.13.4
 watchgod~=0.7
 plotly~=4.14.3
 pandas~=1.3.0

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -4,7 +4,7 @@ ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
-uvicorn[standard]~=0.13.4
+uvicorn~=0.13.4
 watchgod~=0.7
 plotly~=4.14.3
 pandas~=1.3.0

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -13,7 +13,7 @@ pytest~=6.2.0
 pytest-cov~=2.11.1
 pytest-mock~=3.6.1
 trufflehog~=2.1.0
-click==7.0.0
+click==7.1.2
 
 # mypy
 types-aiofiles==0.1.3

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -13,7 +13,6 @@ pytest~=6.2.0
 pytest-cov~=2.11.1
 pytest-mock~=3.6.1
 trufflehog~=2.1.0
-click==7.1.2
 
 # mypy
 types-aiofiles==0.1.3

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -13,6 +13,7 @@ pytest~=6.2.0
 pytest-cov~=2.11.1
 pytest-mock~=3.6.1
 trufflehog~=2.1.0
+click==7.0.0
 
 # mypy
 types-aiofiles==0.1.3

--- a/package/tests/test_api/test_apps.py
+++ b/package/tests/test_api/test_apps.py
@@ -78,9 +78,9 @@ def client(example_api):
 
 
 def test_graphql_endpoint():
-    query = "{ healthcheck { name }}"
+    query = "{ healthcheck { status }}"
     result = schema.execute_sync(query)
-    assert result.data["healthcheck"] == {"name": ""}
+    assert result.data["healthcheck"] == {"status": "OK"}
 
 
 def assert_nodes_equal(response_nodes, expected_nodes):

--- a/package/tests/test_api/test_apps.py
+++ b/package/tests/test_api/test_apps.py
@@ -32,13 +32,11 @@ from unittest import mock
 
 import pytest
 from fastapi.testclient import TestClient
-from graphene import Schema
-from graphene.test import Client
 from kedro.io import DataCatalog
 from kedro.pipeline import Pipeline
 
 from kedro_viz.api import apps
-from kedro_viz.api.graphql import Query
+from kedro_viz.api.graphql import schema
 from kedro_viz.data_access.managers import DataAccessManager
 from kedro_viz.models.graph import TaskNode
 from kedro_viz.server import populate_data
@@ -79,16 +77,10 @@ def client(example_api):
     yield TestClient(example_api)
 
 
-@pytest.fixture(scope="module")
-def graphql_client():
-    client = Client(schema=Schema(query=Query))
-    return client
-
-
-def test_graphql_endpoint(graphql_client):
-    query = "{ healthcheck }"
-    result = graphql_client.execute(query)
-    assert result["data"]["healthcheck"] == "{}"
+def test_graphql_endpoint():
+    query = "{ healthcheck { name }}"
+    result = schema.execute_sync(query)
+    assert result.data["healthcheck"] == {"name": ""}
 
 
 def assert_nodes_equal(response_nodes, expected_nodes):


### PR DESCRIPTION
## Description

Graphene was initially used with GraphQL as suggested on FastAPI tutorials. But graphene has been deprecated hence we have switched to using Strawberry

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
