### PR TITLE
[KED-2808] - BUG FIX -  Display of JSON tracking data on metadata panel

### DIFF
--- a/package/kedro_viz/models/graph.py
+++ b/package/kedro_viz/models/graph.py
@@ -647,7 +647,7 @@ class DataNodeMetadata(GraphNodeMetadata):
             except ValueError:
                 logger.warning(
                     """Expected timestamp of format YYYY-MM-DDTHH:MM:SS.ffffff.
-                    Skip when loading metrics."""
+                    Skip when loading tracking data."""
                 )
                 continue
             else:

--- a/package/tests/test_models/test_graph/test_graph_nodes.py
+++ b/package/tests/test_models/test_graph/test_graph_nodes.py
@@ -449,38 +449,38 @@ class TestGraphNodeMetadata:
         assert not hasattr(metrics_node_metadata, "plot")
 
     @patch("kedro_viz.models.graph.DataNodeMetadata.load_latest_tracking_data")
-    def test_metrics_data_node_metadata_latest_metrics_not_exist(
+    def test_data_node_metadata_latest_tracking_data_not_exist(
         self,
-        patched_latest_metrics,
+        patched_latest_tracking_data,
     ):
-        patched_latest_metrics.return_value = None
-        metrics_data_node = MagicMock()
-        metrics_data_node.is_plot_node.return_value = False
-        metrics_data_node.is_metric_node.return_value = True
-        metrics_node_metadata = DataNodeMetadata(data_node=metrics_data_node)
-        assert not hasattr(metrics_node_metadata, "metrics")
-        assert not hasattr(metrics_node_metadata, "plot")
+        patched_latest_tracking_data.return_value = None
+        tracking_data_node = MagicMock()
+        tracking_data_node.is_plot_node.return_value = False
+        tracking_data_node.is_metric_node.return_value = True
+        tracking_data_node_metadata = DataNodeMetadata(data_node=tracking_data_node)
+        assert not hasattr(tracking_data_node_metadata, "metrics")
+        assert not hasattr(tracking_data_node_metadata, "plot")
 
     @patch("kedro_viz.models.graph.DataNodeMetadata.load_latest_tracking_data")
     @patch("kedro_viz.models.graph.DataNodeMetadata.load_versioned_tracking_data")
-    def test_metrics_data_node_metadata_versioned_dataset_not_exist(
+    def test_tracking_data_node_metadata_versioned_dataset_not_exist(
         self,
         patched_data_loader,
-        patched_latest_metrics,
+        patched_latest_tracking_data,
     ):
         mock_metrics_data = {
             "recommendations": 0.0009277445547700936,
             "recommended_controls": 0.001159680693462617,
             "projected_optimization": 0.0013916168321551402,
         }
-        patched_latest_metrics.return_value = mock_metrics_data
+        patched_latest_tracking_data.return_value = mock_metrics_data
         patched_data_loader.return_value = {}
-        metrics_data_node = MagicMock()
-        metrics_data_node.is_plot_node.return_value = False
-        metrics_data_node.is_metric_node.return_value = True
-        metrics_node_metadata = DataNodeMetadata(data_node=metrics_data_node)
-        assert metrics_node_metadata.tracking_data == mock_metrics_data
-        assert not hasattr(metrics_node_metadata, "plot")
+        tracking_data_node = MagicMock()
+        tracking_data_node.is_plot_node.return_value = False
+        tracking_data_node.is_metric_node.return_value = True
+        tracking_data_node_metadata = DataNodeMetadata(data_node=tracking_data_node)
+        assert tracking_data_node_metadata.tracking_data == mock_metrics_data
+        assert not hasattr(tracking_data_node_metadata, "plot")
 
     def test_data_node_metadata_create_metrics_plot(self):
         test_versioned_data = {
@@ -498,7 +498,7 @@ class TestGraphNodeMetadata:
         assert "layout" in test_plot
 
     @pytest.fixture
-    def metrics_filepath(self, tmp_path):
+    def tracking_data_filepath(self, tmp_path):
         dir_name = ["2021-09-10T09.02.44.245Z", "2021-09-10T09.03.23.733Z"]
         filename = "metrics.json"
         json_content = [
@@ -521,7 +521,7 @@ class TestGraphNodeMetadata:
         return source_dir
 
     @pytest.fixture
-    def metrics_filepath_reload(self, tmp_path):
+    def tracking_data_filepath_reload(self, tmp_path):
         dir_name = ["2021-09-10T09.03.55.245Z", "2021-09-10T09.03.56.733Z"]
         filename = "metrics.json"
         json_content = [
@@ -544,7 +544,7 @@ class TestGraphNodeMetadata:
         return source_dir
 
     @pytest.fixture
-    def metrics_filepath_invalid_timestamp(self, tmp_path):
+    def tracking_data_filepath_invalid_timestamp(self, tmp_path):
         dir_name = ["2021", "2021"]
         filename = "metrics.json"
         json_content = [
@@ -566,9 +566,10 @@ class TestGraphNodeMetadata:
             filepath.write_text(json.dumps(json_content[index]))
         return source_dir
 
-    def test_load_latest_metrics(self):
-        # Note - filepath is assigned temp.json as temp solution instead of metrics_filepath
-        # as it fails on windows build. This will be cleaned up in the future.
+    def test_load_latest_tracking_data(self):
+        # Note - filepath is assigned temp.json as temp solution instead of
+        # tracking_data_filepath as it fails on windows build.
+        # This will be cleaned up in the future.
         filename = "temp.json"
         dataset = MetricsDataSet(filepath=filename)
         data = {"col1": 1, "col2": 0.23, "col3": 0.002}
@@ -581,13 +582,13 @@ class TestGraphNodeMetadata:
         assert DataNodeMetadata.load_latest_tracking_data(dataset) == new_data
         shutil.rmtree(filename)
 
-    def test_load_latest_metrics_fail(self, mocker, metrics_filepath):
-        dataset = MetricsDataSet(filepath=f"{metrics_filepath}")
+    def test_load_latest_tracking_data_fail(self, mocker, tracking_data_filepath):
+        dataset = MetricsDataSet(filepath=f"{tracking_data_filepath}")
         mocker.patch.object(dataset, "_exists_function", return_value=False)
         assert DataNodeMetadata.load_latest_tracking_data(dataset) is None
 
-    def test_load_metrics_versioned_data(self, metrics_filepath):
-        mock_metrics_json = {
+    def test_load_metrics_versioned_data(self, tracking_data_filepath):
+        mock_tracking_data_json = {
             datetime.datetime(2021, 9, 10, 9, 2, 44, 245000): {
                 "recommendations": 0.3866563620506992,
                 "recommended_controls": 0.48332045256337397,
@@ -600,12 +601,12 @@ class TestGraphNodeMetadata:
             },
         }
         assert (
-            DataNodeMetadata.load_versioned_tracking_data(metrics_filepath)
-            == mock_metrics_json
+            DataNodeMetadata.load_versioned_tracking_data(tracking_data_filepath)
+            == mock_tracking_data_json
         )
 
-    def test_load_metrics_versioned_data_set_limit(self, metrics_filepath):
-        mock_metrics_json = {
+    def test_load_tracking_data_versioned_data_set_limit(self, tracking_data_filepath):
+        mock_tracking_data_json = {
             datetime.datetime(2021, 9, 10, 9, 3, 23, 733000): {
                 "recommendations": 0.200383330721228,
                 "recommended_controls": 0.250479163401535,
@@ -614,22 +615,22 @@ class TestGraphNodeMetadata:
         }
         limit = 1
         assert (
-            DataNodeMetadata.load_versioned_tracking_data(metrics_filepath, limit)
-            == mock_metrics_json
+            DataNodeMetadata.load_versioned_tracking_data(tracking_data_filepath, limit)
+            == mock_tracking_data_json
         )
 
     @patch("logging.Logger.warning")
-    def test_load_metrics_versioned_data_invalid_timestamp(
-        self, patched_warning, metrics_filepath_invalid_timestamp
+    def test_load_tracking_data_versioned_data_invalid_timestamp(
+        self, patched_warning, tracking_data_filepath_invalid_timestamp
     ):
         DataNodeMetadata.load_versioned_tracking_data(
-            metrics_filepath_invalid_timestamp
+            tracking_data_filepath_invalid_timestamp
         )
         patched_warning.assert_has_calls(
             [
                 call(
                     """Expected timestamp of format YYYY-MM-DDTHH:MM:SS.ffffff.
-                    Skip when loading metrics."""
+                    Skip when loading tracking data."""
                 )
             ]
         )

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -61,7 +61,9 @@ export const getClickedNodeMetaData = createSelector(
     //rounding of tracking data
     nodeTrackingData[node.id] &&
       Object.entries(nodeTrackingData[node.id]).forEach(([key, value]) => {
-        nodeTrackingData[node.id][key] = Math.round(value * 100) / 100;
+        if (typeof value === 'number') {
+          nodeTrackingData[node.id][key] = Math.round(value * 100) / 100;
+        }
       });
 
     const metadata = {


### PR DESCRIPTION
## Description

Fix the display of JSON tracking data on metadata panel.  All text values were displayed as NAN, and boolean were displayed as 0s 

This was because in front-end we were doing a Math.round on all values instead of just numerical values. This has been fixed. 

![image](https://user-images.githubusercontent.com/37628668/140512160-ccd4207d-cd76-4baf-bdfc-323822dcd53f.png)

I have also renamed some of the test functions from  saying 'metrics' to 'tracking_data'.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
