### PR TITLE
Fix MetricsDataSet test

### DIFF
--- a/package/tests/test_models/test_graph/test_graph_nodes.py
+++ b/package/tests/test_models/test_graph/test_graph_nodes.py
@@ -13,6 +13,7 @@ from kedro.extras.datasets.pandas import CSVDataSet, ParquetDataSet
 from kedro.extras.datasets.spark import SparkDataSet
 from kedro.extras.datasets.tracking.metrics_dataset import MetricsDataSet
 from kedro.io import MemoryDataSet, PartitionedDataSet
+from kedro.io.core import Version
 from kedro.pipeline.node import node
 
 from kedro_viz.models.graph import (
@@ -571,7 +572,7 @@ class TestGraphNodeMetadata:
         # tracking_data_filepath as it fails on windows build.
         # This will be cleaned up in the future.
         filename = "temp.json"
-        dataset = MetricsDataSet(filepath=filename)
+        dataset = MetricsDataSet(filepath=filename, version=Version(None, None))
         data = {"col1": 1, "col2": 0.23, "col3": 0.002}
         dataset.save(data)
         assert DataNodeMetadata.load_latest_tracking_data(dataset) == data


### PR DESCRIPTION
## Description

Following https://github.com/quantumblacklabs/kedro/pull/1016, the test `test_load_latest_tracking_data` was failing. The reason for this is that now when `MetricsDataSet` is constructed with no arguments _without using a catalog_, it is not versioned by default. The solution is to force versioning through the `version` argument. `Version(None, None)` means it will save using the current timestamp.

## On the core side
The code we have to version the dataset is in [`parse_dataset_definition`](
https://github.com/quantumblacklabs/kedro/blob/master/kedro/io/core.py#L410-L415). This only gets called in `AbstractDataSet.from_config` when a data catalog is created. Hence, if we don't have a data catalog and are instead just using `MetricsDataSet` (or another `tracking` dataset) by itself, it _isn't_ versioned by default.

I think I can see an easy fix for this - will add in a bit. Just want to get this fix into kedro-viz ASAP to unblock people.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
