### PR TITLE
[KED-2953] Update RunTrackingData schema to show difference

### DIFF
--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -143,15 +143,6 @@ def format_run_tracking_data(tracking_data: Dict, show_diff: bool) -> JSONObject
 
     if show_diff:
         for key in sorted(set(tracking_keys)):
-            if tracking_keys.count(key) == len(tracking_data):
-                for run_id in tracking_data:
-                    if key in tracking_data[run_id]:
-                        formatted_tracking_data[key].append(
-                            {"runId": run_id, "value": tracking_data[run_id][key]}
-                        )
-
-    else:
-        for key in sorted(set(tracking_keys)):
             for run_id in tracking_data:
                 if key in tracking_data[run_id]:
                     formatted_tracking_data[key].append(
@@ -161,7 +152,15 @@ def format_run_tracking_data(tracking_data: Dict, show_diff: bool) -> JSONObject
                     formatted_tracking_data[key].append(
                         {"runId": run_id, "value": None}
                     )
-
+    else:
+        for key in sorted(set(tracking_keys)):
+            if tracking_keys.count(key) == len(tracking_data):
+                for run_id in tracking_data:
+                    if key in tracking_data[run_id]:
+                        formatted_tracking_data[key].append(
+                            {"runId": run_id, "value": tracking_data[run_id][key]}
+                        )
+ 
     return JSONObject(formatted_tracking_data)
 
 

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -240,7 +240,7 @@ class Query:
 
     @strawberry.field
     def run_tracking_data(
-        self, run_ids: List[ID], show_diff: bool
+        self, run_ids: List[ID], show_diff: Optional[bool] = False
     ) -> List[TrackingDataSet]:
         """Query to get data for specific runs from the session store"""
         return get_run_tracking_data(run_ids, show_diff)

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -160,7 +160,7 @@ def format_run_tracking_data(tracking_data: Dict, show_diff: bool) -> JSONObject
                         formatted_tracking_data[key].append(
                             {"runId": run_id, "value": tracking_data[run_id][key]}
                         )
- 
+
     return JSONObject(formatted_tracking_data)
 
 
@@ -240,7 +240,7 @@ class Query:
 
     @strawberry.field
     def run_tracking_data(
-        self, run_ids: List[ID], show_diff: Optional[bool] = False
+        self, run_ids: List[ID], show_diff: bool = False
     ) -> List[TrackingDataSet]:
         """Query to get data for specific runs from the session store"""
         return get_run_tracking_data(run_ids, show_diff)

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -99,8 +99,8 @@ def format_run_tracking_data(tracking_data: Dict, show_diff: bool = False) -> JS
 
     Args:
         tracking_data: JSON blob of tracking data for selected runs
-        show_diff : if false, it will show runs with only common tracking
-        data else it will show all available tracking data
+        show_diff: If false, show runs with only common tracking
+            data; else show all available tracking data
     Returns:
         Dictionary with formatted tracking data for selected runs
 
@@ -157,8 +157,8 @@ def get_run_tracking_data(run_ids: List[ID], show_diff: bool = False) -> List[Tr
     during that specific `kedro run`.
     Args:
         run_ids:  List of IDs of runs to fetch the tracking data for.
-        show_diff : if false, it will show runs with only common tracking
-        data else it will show all available tracking data
+        show_diff: If false, show runs with only common tracking
+            data; else show all available tracking data
 
     Returns:
         List of TrackingDataSets

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -157,7 +157,8 @@ def get_run_tracking_data(run_ids: List[ID], show_diff: bool) -> List[TrackingDa
     during that specific `kedro run`.
     Args:
         run_ids:  List of IDs of runs to fetch the tracking data for.
-        show_diff : user specified boolean for comparison view
+        show_diff : if false, it will show runs with only common tracking
+        data else it will show all available tracking data
 
     Returns:
         List of TrackingDataSets

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -99,7 +99,8 @@ def format_run_tracking_data(tracking_data: Dict, show_diff: bool) -> JSONObject
 
     Args:
         tracking_data: JSON blob of tracking data for selected runs
-        show_diff : user specified boolean for comparison view
+        show_diff : if false, it will show runs with only common tracking
+        data else it will show all available tracking data
     Returns:
         Dictionary with formatted tracking data for selected runs
 

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -154,12 +154,12 @@ def format_run_tracking_data(tracking_data: Dict, show_diff: bool) -> JSONObject
                     )
     else:
         for key in sorted(set(tracking_keys)):
+            # check if key is common across all runs that are compared
             if tracking_keys.count(key) == len(tracking_data):
                 for run_id, run_tracking_data in tracking_data.items():
-                    if key in run_tracking_data:
-                        formatted_tracking_data[key].append(
-                            {"runId": run_id, "value": run_tracking_data[key]}
-                        )
+                    formatted_tracking_data[key].append(
+                        {"runId": run_id, "value": run_tracking_data[key]}
+                    )
 
     return JSONObject(formatted_tracking_data)
 

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -94,7 +94,7 @@ def get_all_runs() -> List[Run]:
     return runs
 
 
-def format_run_tracking_data(tracking_data: Dict, show_diff: bool) -> JSONObject:
+def format_run_tracking_data(tracking_data: Dict, show_diff: bool = False) -> JSONObject:
     """Convert tracking data in the front-end format.
 
     Args:
@@ -150,7 +150,7 @@ def format_run_tracking_data(tracking_data: Dict, show_diff: bool) -> JSONObject
     return JSONObject(formatted_tracking_data)
 
 
-def get_run_tracking_data(run_ids: List[ID], show_diff: bool) -> List[TrackingDataSet]:
+def get_run_tracking_data(run_ids: List[ID], show_diff: bool = False) -> List[TrackingDataSet]:
     # pylint: disable=protected-access,import-outside-toplevel
     """Get all tracking data for a list of runs. Tracking data contains the data from the
     tracking MetricsDataSet and JSONDataSet instances that have been logged

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -143,10 +143,10 @@ def format_run_tracking_data(tracking_data: Dict, show_diff: bool) -> JSONObject
 
     if show_diff:
         for key in sorted(set(tracking_keys)):
-            for run_id in tracking_data:
-                if key in tracking_data[run_id]:
+            for run_id, run_tracking_data in tracking_data.items():
+                if key in run_tracking_data:
                     formatted_tracking_data[key].append(
-                        {"runId": run_id, "value": tracking_data[run_id][key]}
+                        {"runId": run_id, "value": run_tracking_data[key]}
                     )
                 else:
                     formatted_tracking_data[key].append(
@@ -155,10 +155,10 @@ def format_run_tracking_data(tracking_data: Dict, show_diff: bool) -> JSONObject
     else:
         for key in sorted(set(tracking_keys)):
             if tracking_keys.count(key) == len(tracking_data):
-                for run_id in tracking_data:
-                    if key in tracking_data[run_id]:
+                for run_id, run_tracking_data in tracking_data.items():
+                    if key in run_tracking_data:
                         formatted_tracking_data[key].append(
-                            {"runId": run_id, "value": tracking_data[run_id][key]}
+                            {"runId": run_id, "value": run_tracking_data[key]}
                         )
 
     return JSONObject(formatted_tracking_data)

--- a/package/kedro_viz/api/graphql.py
+++ b/package/kedro_viz/api/graphql.py
@@ -136,30 +136,15 @@ def format_run_tracking_data(tracking_data: Dict, show_diff: bool) -> JSONObject
     """
     formatted_tracking_data = defaultdict(list)
 
-    tracking_keys = []
-    for key in tracking_data.keys():
-        for nested_keys in tracking_data[key].keys():
-            tracking_keys.append(nested_keys)
-
-    if show_diff:
-        for key in sorted(set(tracking_keys)):
-            for run_id, run_tracking_data in tracking_data.items():
-                if key in run_tracking_data:
-                    formatted_tracking_data[key].append(
-                        {"runId": run_id, "value": run_tracking_data[key]}
-                    )
-                else:
-                    formatted_tracking_data[key].append(
-                        {"runId": run_id, "value": None}
-                    )
-    else:
-        for key in sorted(set(tracking_keys)):
-            # check if key is common across all runs that are compared
-            if tracking_keys.count(key) == len(tracking_data):
-                for run_id, run_tracking_data in tracking_data.items():
-                    formatted_tracking_data[key].append(
-                        {"runId": run_id, "value": run_tracking_data[key]}
-                    )
+    for run_id, run_tracking_data in tracking_data.items():
+        for tracking_name, data in run_tracking_data.items():
+            formatted_tracking_data[tracking_name].append(
+                {"runId": run_id, "value": data}
+            )
+    if not show_diff:
+        for tracking_key, run_tracking_data in list(formatted_tracking_data.items()):
+            if len(run_tracking_data) != len(tracking_data):
+                del formatted_tracking_data[tracking_key]
 
     return JSONObject(formatted_tracking_data)
 

--- a/package/tests/test_api/test_graphql.py
+++ b/package/tests/test_api/test_graphql.py
@@ -150,20 +150,22 @@ class TestTrackingData:
                 TrackingDataSet(
                     datasetName="new_metrics",
                     datasetType="kedro.extras.datasets.tracking.metrics_dataset.MetricsDataSet",
-                    data=JSONObject({
-                        "col1": [
-                            {"runId": save_version, "value": 1.0},
-                            {"runId": save_new_version, "value": 3.0},
-                        ],
-                        "col2": [
-                            {"runId": save_version, "value": None},
-                            {"runId": save_new_version, "value": 3.23},
-                        ],
-                        "col3": [
-                            {"runId": save_version, "value": 3.0},
-                            {"runId": save_new_version, "value": None},
-                        ],
-                    }),
+                    data=JSONObject(
+                        {
+                            "col1": [
+                                {"runId": save_version, "value": 1.0},
+                                {"runId": save_new_version, "value": 3.0},
+                            ],
+                            "col2": [
+                                {"runId": save_version, "value": None},
+                                {"runId": save_new_version, "value": 3.23},
+                            ],
+                            "col3": [
+                                {"runId": save_version, "value": 3.0},
+                                {"runId": save_new_version, "value": None},
+                            ],
+                        }
+                    ),
                 )
             ]
 
@@ -173,12 +175,14 @@ class TestTrackingData:
                 TrackingDataSet(
                     datasetName="new_metrics",
                     datasetType="kedro.extras.datasets.tracking.metrics_dataset.MetricsDataSet",
-                    data=JSONObject({
-                        "col1": [
-                            {"runId": save_version, "value": 1.0},
-                            {"runId": save_new_version, "value": 3.0},
-                        ]
-                    }),
+                    data=JSONObject(
+                        {
+                            "col1": [
+                                {"runId": save_version, "value": 1.0},
+                                {"runId": save_new_version, "value": 3.0},
+                            ]
+                        }
+                    ),
                 )
             ]
             shutil.rmtree("test.json", ignore_errors=True)
@@ -299,7 +303,7 @@ class TestGraphQLEndpoints:
                 "/graphql",
                 json={
                     "query": """{runTrackingData
-                    (runIds:["%s"], showDiff:false)
+                    (runIds:["%s"])
                     {datasetName, datasetType, data}}"""
                     % save_version
                 },

--- a/package/tests/test_api/test_graphql.py
+++ b/package/tests/test_api/test_graphql.py
@@ -1,5 +1,4 @@
 import shutil
-import time
 from unittest import mock
 from unittest.mock import PropertyMock, call, patch
 
@@ -72,9 +71,6 @@ def example_multiple_run_tracking_catalog(save_version, save_new_version):
         version=Version(None, save_version),
     )
     new_metrics_dataset.save({"col1": 1, "col3": 3})
-
-    time.sleep(1)
-
     new_metrics_dataset = MetricsDataSet(
         filepath="test.json",
         version=Version(None, save_new_version),

--- a/package/tests/test_api/test_graphql.py
+++ b/package/tests/test_api/test_graphql.py
@@ -157,12 +157,10 @@ class TestTrackingData:
                                 {"runId": save_new_version, "value": 3.0},
                             ],
                             "col2": [
-                                {"runId": save_version, "value": None},
                                 {"runId": save_new_version, "value": 3.23},
                             ],
                             "col3": [
                                 {"runId": save_version, "value": 3.0},
-                                {"runId": save_new_version, "value": None},
                             ],
                         }
                     ),

--- a/package/tests/test_api/test_graphql.py
+++ b/package/tests/test_api/test_graphql.py
@@ -150,7 +150,7 @@ class TestTrackingData:
                 TrackingDataSet(
                     datasetName="new_metrics",
                     datasetType="kedro.extras.datasets.tracking.metrics_dataset.MetricsDataSet",
-                    data={
+                    data=JSONObject({
                         "col1": [
                             {"runId": save_version, "value": 1.0},
                             {"runId": save_new_version, "value": 3.0},
@@ -163,7 +163,7 @@ class TestTrackingData:
                             {"runId": save_version, "value": 3.0},
                             {"runId": save_new_version, "value": None},
                         ],
-                    },
+                    }),
                 )
             ]
 
@@ -173,12 +173,12 @@ class TestTrackingData:
                 TrackingDataSet(
                     datasetName="new_metrics",
                     datasetType="kedro.extras.datasets.tracking.metrics_dataset.MetricsDataSet",
-                    data={
+                    data=JSONObject({
                         "col1": [
                             {"runId": save_version, "value": 1.0},
                             {"runId": save_new_version, "value": 3.0},
                         ]
-                    },
+                    }),
                 )
             ]
             shutil.rmtree("test.json", ignore_errors=True)

--- a/package/tests/test_api/test_graphql.py
+++ b/package/tests/test_api/test_graphql.py
@@ -145,7 +145,7 @@ class TestTrackingData:
             data_access_manager.add_catalog(catalog)
 
             assert get_run_tracking_data(
-                [ID(save_version), ID(save_new_version)], False
+                [ID(save_version), ID(save_new_version)], True
             ) == [
                 TrackingDataSet(
                     datasetName="new_metrics",
@@ -168,7 +168,7 @@ class TestTrackingData:
             ]
 
             assert get_run_tracking_data(
-                [ID(save_version), ID(save_new_version)], True
+                [ID(save_version), ID(save_new_version)], False
             ) == [
                 TrackingDataSet(
                     datasetName="new_metrics",


### PR DESCRIPTION
## Description

Jira ticket here - https://jira.quantumblack.com/browse/KED-2953

## Development notes

Earlier, runTrackingData for multiple runs returned only all the available run tracking data. Now for showDiff:true; it returns only runTrackingData that is common for multiple runs and for false, it returns all the available run tracking data
  

The code logic has changed and needs to be reviewed. 

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes

## Legal notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
