### PR TITLE
[KED-2954] Format experiment tracking timestamp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6919,6 +6919,11 @@
         }
       }
     },
+    "dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+    },
     "debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "d3-shape": "^2.1.0",
     "d3-transition": "^2.0.0",
     "d3-zoom": "^2.0.0",
+    "dayjs": "^1.10.7",
     "deepmerge": "^4.2.2",
     "fetch-mock": "^9.11.0",
     "graphql": "^15.6.1",

--- a/src/apollo/config.js
+++ b/src/apollo/config.js
@@ -3,7 +3,7 @@ import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
 
 const link = createHttpLink({
   // our graphql endpoint, normally here: http://localhost:4142/graphql
-  uri: 'http://localhost:4000/graphql',
+  uri: 'http://localhost:4141/graphql',
   fetch,
 });
 

--- a/src/apollo/config.js
+++ b/src/apollo/config.js
@@ -3,7 +3,7 @@ import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
 
 const link = createHttpLink({
   // our graphql endpoint, normally here: http://localhost:4142/graphql
-  uri: 'http://localhost:4141/graphql',
+  uri: 'http://localhost:4000/graphql',
   fetch,
 });
 

--- a/src/components/experiment-tracking/run-metadata/index.js
+++ b/src/components/experiment-tracking/run-metadata/index.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import classnames from 'classnames';
+import { toHumanReadableTime } from '../../../utils/date-utils';
 
 import './run-metadata.css';
 
@@ -22,6 +23,8 @@ const RunMetadata = ({ isSingleRun, runs = [] }) => {
       })}
     >
       {runs.map((run, i) => {
+        const humanReadableTime = toHumanReadableTime(run.timestamp);
+
         return (
           <div
             className={classnames('details-metadata__run', {
@@ -49,7 +52,7 @@ const RunMetadata = ({ isSingleRun, runs = [] }) => {
                 </tr>
                 <tr>
                   {i === 0 ? <td>Creation Date</td> : null}
-                  <td>{run.timestamp}</td>
+                  <td>{`${humanReadableTime} (${run.timestamp})`}</td>
                 </tr>
                 <tr>
                   {i === 0 ? <td>Git SHA</td> : null}

--- a/src/components/experiment-tracking/runs-list-card/index.js
+++ b/src/components/experiment-tracking/runs-list-card/index.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import classnames from 'classnames';
+import { toHumanReadableTime } from '../../../utils/date-utils';
 import CheckIcon from '../../icons/check';
 import BookmarkIcon from '../../icons/bookmark';
 
@@ -18,6 +19,7 @@ const RunsListCard = ({
 }) => {
   const { id, timestamp, title = null, bookmark } = data;
   const [active, setActive] = useState(false);
+  const humanReadableTime = toHumanReadableTime(timestamp);
 
   const onClick = (id) => {
     onRunSelection(id);
@@ -45,10 +47,10 @@ const RunsListCard = ({
       )}
       <div>
         <div className="runs-list-card__title">
-          {typeof title === 'string' ? title : timestamp}
+          {typeof title === 'string' ? title : humanReadableTime}
         </div>
         <div className="runs-list-card__id">{id}</div>
-        <div className="runs-list-card__timestamp">{timestamp}</div>
+        <div className="runs-list-card__timestamp">{humanReadableTime}</div>
       </div>
       {bookmark && <BookmarkIcon className={'runs-list-card__bookmark'} />}
     </div>

--- a/src/utils/date-utils.js
+++ b/src/utils/date-utils.js
@@ -1,6 +1,6 @@
-import * as dayjs from 'dayjs';
-import * as relativeTime from 'dayjs/plugin/relativeTime';
-dayjs.extend(relativeTime);
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+const _dayJs = dayjs.extend(relativeTime);
 
 /**
  * Take a timestamp and return a meaningful length of time, e.g. 5 months ago
@@ -8,5 +8,5 @@ dayjs.extend(relativeTime);
  * @returns A human-readable from-now date
  */
 export const toHumanReadableTime = (timestamp) => {
-  return dayjs(timestamp).fromNow();
+  return _dayJs(timestamp).fromNow();
 };

--- a/src/utils/date-utils.js
+++ b/src/utils/date-utils.js
@@ -1,0 +1,12 @@
+import * as dayjs from 'dayjs';
+import * as relativeTime from 'dayjs/plugin/relativeTime';
+dayjs.extend(relativeTime);
+
+/**
+ * Take a timestamp and return a meaningful length of time, e.g. 5 months ago
+ * @param {ISO 8601 string} timestamp The timestamp to be converted
+ * @returns A human-readable from-now date
+ */
+export const toHumanReadableTime = (timestamp) => {
+  return dayjs(timestamp).fromNow();
+};

--- a/src/utils/date-utils.js
+++ b/src/utils/date-utils.js
@@ -4,9 +4,30 @@ const _dayJs = dayjs.extend(relativeTime);
 
 /**
  * Take a timestamp and return a meaningful length of time, e.g. 5 months ago
- * @param {ISO 8601 string} timestamp The timestamp to be converted
+ * Kedro uses this format VERSION_FORMAT = "%Y-%m-%dT%H.%M.%S.%fZ"
+ * So we need to do some string manipulation to get it to this formatted
+ * version: 2021-11-08T18:31:01.171Z
+ * @param {string} timestamp The timestamp to be converted
  * @returns A human-readable from-now date
  */
 export const toHumanReadableTime = (timestamp) => {
-  return _dayJs(timestamp).fromNow();
+  const splitTimestamp = timestamp.split('.');
+  let formattedTimestamp = '';
+
+  let i = 0;
+  const length = splitTimestamp.length;
+
+  while (i < length) {
+    if (i < 2) {
+      formattedTimestamp += `${splitTimestamp[i]}:`;
+    } else if (i === 2) {
+      formattedTimestamp += `${splitTimestamp[i]}.`;
+    } else {
+      formattedTimestamp += `${splitTimestamp[i]}`;
+    }
+
+    i++;
+  }
+
+  return _dayJs(formattedTimestamp).fromNow();
 };


### PR DESCRIPTION
## Description

We'd like to show a human-readable timestamp for experiment tracking runs. This PR implements that.

## Development notes

I've used the `.fromNow()` method of the [Day.js](https://day.js.org/docs/en/display/from-now) library, which is [nice and small](https://bundlephobia.com/package/dayjs@1.10.7) and does exactly what we need.

## QA notes

![image](https://user-images.githubusercontent.com/16869061/141465388-a4e42d62-7eca-480b-b333-08b3932b2aa9.png)


Check out the branch and take a look at the dates.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
