### PR TITLE
Add extra -a click command for autoreload

### DIFF
--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -65,7 +65,7 @@ def commands():
 )
 @click.option(
     "--autoreload",
-    "-a"
+    "-a",
     is_flag=True,
     help="Autoreload viz server when a Python or YAML file change in the Kedro project",
 )

--- a/package/kedro_viz/launchers/cli.py
+++ b/package/kedro_viz/launchers/cli.py
@@ -65,6 +65,7 @@ def commands():
 )
 @click.option(
     "--autoreload",
+    "-a"
     is_flag=True,
     help="Autoreload viz server when a Python or YAML file change in the Kedro project",
 )


### PR DESCRIPTION
The `kedro viz --autoreload` function is super useful for developing modular pipelines live and getting the namespace stuff just right.

I've found myself writing `--auto-reload` by accident so many times, I think this shortcut would be appreciated!