### PR TITLE
KED-2944: integrate the real API with experiment tracking frontend

### DIFF
--- a/src/apollo/config.js
+++ b/src/apollo/config.js
@@ -2,7 +2,7 @@ import fetch from 'cross-fetch';
 import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
 
 const link = createHttpLink({
-  // our graphql endpoint, normally here: http://localhost:4142/graphql
+  // our graphql endpoint, normally here: http://localhost:4141/graphql
   uri: 'http://localhost:4141/graphql',
   fetch,
 });

--- a/src/apollo/config.js
+++ b/src/apollo/config.js
@@ -3,7 +3,7 @@ import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
 
 const link = createHttpLink({
   // our graphql endpoint, normally here: http://localhost:4142/graphql
-  uri: 'http://localhost:4000/graphql',
+  uri: 'http://localhost:4141/graphql',
   fetch,
 });
 

--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -30,8 +30,8 @@ export const GET_RUN_METADATA = gql`
 
 /** query for collapsable run details component */
 export const GET_RUN_TRACKING_DATA = gql`
-  query getRunTrackingData($runs: [ID]!, $showDiff: Boolean) {
-    runTrackingData(runIds: $runs, showDiff: $showDiff) {
+  query getRunTrackingData($runIds: [ID!]!, $showDiff: Boolean) {
+    runTrackingData(runIds: $runIds, showDiff: $showDiff) {
       datasetName
       datasetType
       data

--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -15,8 +15,8 @@ export const GET_RUNS = gql`
 
 /** query for details metadata component */
 export const GET_RUN_METADATA = gql`
-  query getRunMetadata($runs: [ID]!) {
-    runMetadata(runIDs: $runs) {
+  query getRunMetadata($runIds: [ID!]!) {
+    runMetadata(runIds: $runIds) {
       author
       gitBranch
       gitSha
@@ -30,8 +30,8 @@ export const GET_RUN_METADATA = gql`
 
 /** query for collapsable run details component */
 export const GET_RUN_TRACKING_DATA = gql`
-  query getRunTrackingData($runs: [ID]!, $showDiff: Boolean) {
-    runTrackingData(runIDs: $runs, showDiff: $showDiff) {
+  query getRunTrackingData($runs: [ID!]!) {
+    runTrackingData(runIds: $runs) {
       datasetName
       datasetType
       data

--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -30,8 +30,8 @@ export const GET_RUN_METADATA = gql`
 
 /** query for collapsable run details component */
 export const GET_RUN_TRACKING_DATA = gql`
-  query getRunTrackingData($runs: [ID!]!) {
-    runTrackingData(runIds: $runs) {
+  query getRunTrackingData($runs: [ID]!, $showDiff: Boolean) {
+    runTrackingData(runIds: $runs, showDiff: $showDiff) {
       datasetName
       datasetType
       data

--- a/src/components/experiment-tracking/details/index.js
+++ b/src/components/experiment-tracking/details/index.js
@@ -16,14 +16,14 @@ const Details = ({ selectedRuns, sidebarVisible }) => {
     GET_RUN_METADATA,
     {
       skip: selectedRuns.length === 0,
-      variables: { runs: selectedRuns },
+      variables: { runIds: selectedRuns },
     }
   );
 
   const { data: { runTrackingData } = [], error: trackingError } =
     useApolloQuery(GET_RUN_TRACKING_DATA, {
       skip: selectedRuns.length === 0,
-      variables: { runs: selectedRuns },
+      variables: { runIds: selectedRuns },
     });
 
   if (error || trackingError) {
@@ -37,8 +37,7 @@ const Details = ({ selectedRuns, sidebarVisible }) => {
       <div
         className={classnames('kedro', 'details-mainframe', {
           'details-mainframe--sidebar-visible': sidebarVisible,
-        })}
-      >
+        })}>
         <RunMetadata isSingleRun={isSingleRun} runs={runMetadata} />
         <RunDataset isSingleRun={isSingleRun} trackingData={runTrackingData} />
       </div>

--- a/src/components/experiment-tracking/details/index.js
+++ b/src/components/experiment-tracking/details/index.js
@@ -23,7 +23,7 @@ const Details = ({ selectedRuns, sidebarVisible }) => {
   const { data: { runTrackingData } = [], error: trackingError } =
     useApolloQuery(GET_RUN_TRACKING_DATA, {
       skip: selectedRuns.length === 0,
-      variables: { runIds: selectedRuns },
+      variables: { runIds: selectedRuns, showDiff: false },
     });
 
   if (error || trackingError) {
@@ -37,7 +37,8 @@ const Details = ({ selectedRuns, sidebarVisible }) => {
       <div
         className={classnames('kedro', 'details-mainframe', {
           'details-mainframe--sidebar-visible': sidebarVisible,
-        })}>
+        })}
+      >
         <RunMetadata isSingleRun={isSingleRun} runs={runMetadata} />
         <RunDataset isSingleRun={isSingleRun} trackingData={runTrackingData} />
       </div>

--- a/src/components/experiment-tracking/run-dataset/index.js
+++ b/src/components/experiment-tracking/run-dataset/index.js
@@ -17,16 +17,17 @@ const RunDataset = ({ isSingleRun, trackingData = [] }) => {
       })}
     >
       {trackingData.map((dataset) => {
+        const { data, datasetName } = dataset;
         return (
           <Accordion
             className="details-dataset__accordion"
-            heading={dataset.datasetName}
+            heading={datasetName}
             headingClassName="details-dataset__accordion-header"
             key={dataset.datasetName}
             layout="left"
             size="large"
           >
-            {Object.keys(dataset.data)
+            {Object.keys(data)
               .sort()
               .map((key, rowIndex) => {
                 return buildDatasetDataMarkup(
@@ -94,7 +95,7 @@ function buildDatasetDataMarkup(
             })}
             key={value.runId + index}
           >
-            {value.value}
+            {typeof value === 'object' ? JSON.stringify(value) : value.value}
           </span>
         ))}
       </div>

--- a/src/components/experiment-tracking/run-metadata/index.js
+++ b/src/components/experiment-tracking/run-metadata/index.js
@@ -15,20 +15,20 @@ const RunMetadata = ({ isSingleRun, runs = [] }) => {
     setToggleNotes({ ...toggleNotes, [index]: !toggleNotes[index] });
   };
 
-  return (
+  return runs.length === 0 ? (
+    <div>Loading...</div>
+  ) : (
     <div
       className={classnames('details-metadata', {
         'details-metadata--single': isSingleRun,
-      })}
-    >
+      })}>
       {runs.map((run, i) => {
         return (
           <div
             className={classnames('details-metadata__run', {
               'details-metadata__run--single': isSingleRun,
             })}
-            key={run.gitSha}
-          >
+            key={run.gitSha}>
             <table className="details-metadata__table">
               <tbody>
                 {isSingleRun ? (
@@ -68,15 +68,13 @@ const RunMetadata = ({ isSingleRun, runs = [] }) => {
                   <td>
                     <p
                       className="details-metadata__notes"
-                      style={toggleNotes[i] ? { display: 'block' } : null}
-                    >
+                      style={toggleNotes[i] ? { display: 'block' } : null}>
                       {run.notes}
                     </p>
                     {run.notes.length > 100 ? (
                       <button
                         className="details-metadata__show-more kedro"
-                        onClick={() => onToggleNoteExpand(i)}
-                      >
+                        onClick={() => onToggleNoteExpand(i)}>
                         {toggleNotes[i] ? 'Show less' : 'Show more'}
                       </button>
                     ) : null}

--- a/src/components/experiment-wrapper/index.js
+++ b/src/components/experiment-wrapper/index.js
@@ -97,8 +97,7 @@ const ExperimentWrapper = ({ theme }) => {
           <a
             href="https://github.com/quantumblacklabs/kedro-viz"
             rel="noreferrer"
-            target="_blank"
-          >
+            target="_blank">
             <Button onClick={() => {}} theme={theme}>
               View docs
             </Button>


### PR DESCRIPTION
## Description

This PR is the work to test and integrate the experiment tracking features with real data from the graphql endpoint.

## Development notes

<This is the work mainly to switch the reference of our graphql endpoint to the actual graphql endpoint on port 4141, as well as further minor changes to the queries to reflect the expected variable format for the endpoint. 

## QA notes

This will need to be integrated / tested with a kedro project that has a set of experiment runs generated. 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
