### PR TITLE
Fix dependencies for e2e tests

### DIFF
--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -85,34 +85,6 @@ def install_project_requirements(context):
         assert False
 
 
-# @given('I have executed the kedro command "{command}"')
-# def exec_kedro_target_checked(context, command):
-#     """Execute Kedro command and check the status."""
-#     pin_dynaconf = [context.pip, "install", "dynaconf==3.1.5"]
-#     cmd = [context.kedro] + command.split()
-#
-#     res = run(cmd, env=context.env, cwd=str(context.root_project_dir))
-#
-#     if res.returncode != OK_EXIT_CODE:
-#         print(res.stdout)
-#         print(res.stderr)
-#         assert False
-#
-#     # Wait for subprocess completion since on Windows it takes some time
-#     # to install dependencies in a separate console
-#     if "install" in cmd:
-#         result = run(pin_dynaconf)
-#         max_duration = 5 * 60  # 5 minutes
-#         end_by = time() + max_duration
-#
-#         while time() < end_by:
-#             result = run([context.pip, "show", "pandas"])
-#             if result.returncode == OK_EXIT_CODE:
-#                 # package found
-#                 return
-#             sleep(1.0)
-
-
 @given('I have installed kedro version "{version}"')
 def install_kedro(context, version):
     """Execute Kedro command and check the status."""

--- a/package/features/steps/cli_steps.py
+++ b/package/features/steps/cli_steps.py
@@ -73,32 +73,44 @@ def create_project_with_starter(context, starter):
     assert res.returncode == OK_EXIT_CODE
 
 
-@given('I have executed the kedro command "{command}"')
-def exec_kedro_target_checked(context, command):
-    """Execute Kedro command and check the status."""
-    pin_dynaconf = [context.pip, "install", "dynaconf==3.1.5"]
-    cmd = [context.kedro] + command.split()
-
-    res = run(cmd, env=context.env, cwd=str(context.root_project_dir))
+@given("I have installed the project's requirements")
+def install_project_requirements(context):
+    """Run pip install -U -r src/requirements.txt"""
+    cmd = [context.pip, "install", "-r", str(context.requirements_path)]
+    res = run(cmd, env=context.env)
 
     if res.returncode != OK_EXIT_CODE:
         print(res.stdout)
         print(res.stderr)
         assert False
 
-    # Wait for subprocess completion since on Windows it takes some time
-    # to install dependencies in a separate console
-    if "install" in cmd:
-        result = run(pin_dynaconf)
-        max_duration = 5 * 60  # 5 minutes
-        end_by = time() + max_duration
 
-        while time() < end_by:
-            result = run([context.pip, "show", "pandas"])
-            if result.returncode == OK_EXIT_CODE:
-                # package found
-                return
-            sleep(1.0)
+# @given('I have executed the kedro command "{command}"')
+# def exec_kedro_target_checked(context, command):
+#     """Execute Kedro command and check the status."""
+#     pin_dynaconf = [context.pip, "install", "dynaconf==3.1.5"]
+#     cmd = [context.kedro] + command.split()
+#
+#     res = run(cmd, env=context.env, cwd=str(context.root_project_dir))
+#
+#     if res.returncode != OK_EXIT_CODE:
+#         print(res.stdout)
+#         print(res.stderr)
+#         assert False
+#
+#     # Wait for subprocess completion since on Windows it takes some time
+#     # to install dependencies in a separate console
+#     if "install" in cmd:
+#         result = run(pin_dynaconf)
+#         max_duration = 5 * 60  # 5 minutes
+#         end_by = time() + max_duration
+#
+#         while time() < end_by:
+#             result = run([context.pip, "show", "pandas"])
+#             if result.returncode == OK_EXIT_CODE:
+#                 # package found
+#                 return
+#             sleep(1.0)
 
 
 @given('I have installed kedro version "{version}"')

--- a/package/features/viz.feature
+++ b/package/features/viz.feature
@@ -8,13 +8,13 @@ Feature: Viz plugin in new project
     Scenario: Execute viz with Kedro 0.16.1
         Given I have installed kedro version "0.16.1"
         And I have run a non-interactive kedro new
-        And I have executed the kedro command "install"
+        And I have installed the project's requirements
         When I execute the kedro viz command "viz"
         Then kedro-viz should start successfully
 
     Scenario: Execute viz with latest Kedro
         Given I have installed kedro version "latest"
         And I have run a non-interactive kedro new with pandas-iris starter
-        And I have executed the kedro command "install"
+        And I have installed the project's requirements
         When I execute the kedro viz command "viz"
         Then kedro-viz should start successfully

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -2,6 +2,7 @@ semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
 kedro>=0.16.0
 ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
+typing-extensions==3.10.0.2  # pinned temporarily
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
 uvicorn[standard]~=0.13.4
@@ -9,5 +10,5 @@ watchgod~=0.7
 plotly>=4.0
 pandas>=0.24
 sqlalchemy~=1.2
-strawberry-graphql~=0.79.0
+strawberry-graphql~=0.87.0
 networkx>=1.0

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -2,7 +2,6 @@ semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
 kedro>=0.16.0
 ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
-typing-extensions==3.10.0.2  # pinned temporarily because of conflicts between strawberry-graphql and the rest of the world
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
 uvicorn[standard]~=0.13.4

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -2,7 +2,7 @@ semver~=2.10 # Needs to be at least 2.10.0 to get VersionInfo.match
 kedro>=0.16.0
 ipython>=7.0.0, <8.0
 dataclasses==0.8; python_version == "3.6"
-typing-extensions==3.10.0.2  # pinned temporarily
+typing-extensions==3.10.0.2  # pinned temporarily because of conflicts between strawberry-graphql and the rest of the world
 fastapi>=0.63.0, <0.67.0
 aiofiles==0.6.0
 uvicorn[standard]~=0.13.4


### PR DESCRIPTION
## Description

<!-- Why was this PR created? -->
`typing-extensions` released new version 4.0.0 but `strawberry-graphql` needs `<4.0`. `black` and other kedro project dependencies have only a lower limit, not an upper bound on the version constraint of `typing-extensions`.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->
* 🔒  Temporarily pinned `typing-extensions` to the last version before 4.0 in the requirements of `kedro-viz`.

* 🧹  `kedro install` is deprecated and will be removed in 0.18.0 so while I'm here I also updated some `behave` steps so that it uses `pip install -r src/requirements.txt` instead (which is the recommended workflow now).

* 🍓  I've also bumped `strawberry-graphql`, in the hopes that when they do push the requirements update, it will come as a patch fix in `0.87.3`. If they update it too tightly, i.e. `>=4.0.0`, CI will fail again at which point we know we can remove the temporary pin.


## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->
📢  PSA: if you haven't heard of it before, I can highly recommend `pipdeptree`. I've used it before but forgot about it until this issue had to remind me of its usefulness.

```
pip install pipdeptree
pipdeptree -r -p typing-extensions
```

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes

## Legal notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
