### PR TITLE
[KED-2973] & [KED-2974] - fix metadata alignment and overlapping text

### DIFF
--- a/src/components/experiment-tracking/run-dataset/run-dataset.scss
+++ b/src/components/experiment-tracking/run-dataset/run-dataset.scss
@@ -61,6 +61,7 @@
   display: block;
   flex-shrink: 0;
   width: 310px;
+  word-wrap: break-word;
 
   &--single {
     width: 50%;

--- a/src/components/experiment-tracking/run-metadata/index.js
+++ b/src/components/experiment-tracking/run-metadata/index.js
@@ -4,6 +4,10 @@ import { toHumanReadableTime } from '../../../utils/date-utils';
 
 import './run-metadata.css';
 
+// checks if value is an empty string, which is the default value returned
+// by the graphql endpoint for empty values
+const checkEmptyValue = (value) => (value !== '' ? value : '-');
+
 const RunMetadata = ({ isSingleRun, runs = [] }) => {
   let initialState = {};
   for (let i = 0; i < runs.length; i++) {
@@ -16,13 +20,12 @@ const RunMetadata = ({ isSingleRun, runs = [] }) => {
     setToggleNotes({ ...toggleNotes, [index]: !toggleNotes[index] });
   };
 
-  return runs.length === 0 ? (
-    <div>Loading...</div>
-  ) : (
+  return (
     <div
       className={classnames('details-metadata', {
         'details-metadata--single': isSingleRun,
-      })}>
+      })}
+    >
       {runs.map((run, i) => {
         const humanReadableTime = toHumanReadableTime(run.timestamp);
 
@@ -31,53 +34,60 @@ const RunMetadata = ({ isSingleRun, runs = [] }) => {
             className={classnames('details-metadata__run', {
               'details-metadata__run--single': isSingleRun,
             })}
-            key={run.gitSha}>
+            key={run.title}
+          >
             <table className="details-metadata__table">
               <tbody>
                 {isSingleRun ? (
                   <tr>
                     <td className="details-metadata__title" colSpan="2">
-                      {run.title}
+                      {checkEmptyValue(run.title)}
                     </td>
                   </tr>
                 ) : (
                   <tr>
                     {i === 0 ? <td></td> : null}
-                    <td className="details-metadata__title">{run.title}</td>
+                    <td className="details-metadata__title">
+                      {checkEmptyValue(run.title)}
+                    </td>
                   </tr>
                 )}
                 <tr>
                   {i === 0 ? <td>Created By</td> : null}
-                  <td>{run.author}</td>
+                  <td>{checkEmptyValue(run.author)}</td>
                 </tr>
                 <tr>
                   {i === 0 ? <td>Creation Date</td> : null}
-                  <td>{`${humanReadableTime} (${run.timestamp})`}</td>
+                  <td>{`${humanReadableTime} (${checkEmptyValue(
+                    run.timestamp
+                  )})`}</td>
                 </tr>
                 <tr>
                   {i === 0 ? <td>Git SHA</td> : null}
-                  <td>{run.gitSha}</td>
+                  <td>{checkEmptyValue(run.gitSha)}</td>
                 </tr>
                 <tr>
                   {i === 0 ? <td>Git Branch</td> : null}
-                  <td>{run.gitBranch}</td>
+                  <td>{checkEmptyValue(run.gitBranch)}</td>
                 </tr>
                 <tr>
                   {i === 0 ? <td>Run Command</td> : null}
-                  <td>{run.runCommand}</td>
+                  <td>{checkEmptyValue(run.runCommand)}</td>
                 </tr>
                 <tr>
                   {i === 0 ? <td>Notes</td> : null}
                   <td>
                     <p
                       className="details-metadata__notes"
-                      style={toggleNotes[i] ? { display: 'block' } : null}>
-                      {run.notes}
+                      style={toggleNotes[i] ? { display: 'block' } : null}
+                    >
+                      {checkEmptyValue(run.notes)}
                     </p>
                     {run.notes.length > 100 ? (
                       <button
                         className="details-metadata__show-more kedro"
-                        onClick={() => onToggleNoteExpand(i)}>
+                        onClick={() => onToggleNoteExpand(i)}
+                      >
                         {toggleNotes[i] ? 'Show less' : 'Show more'}
                       </button>
                     ) : null}

--- a/src/components/experiment-tracking/run-metadata/index.js
+++ b/src/components/experiment-tracking/run-metadata/index.js
@@ -4,9 +4,9 @@ import { toHumanReadableTime } from '../../../utils/date-utils';
 
 import './run-metadata.css';
 
-// checks if value is an empty string, which is the default value returned
-// by the graphql endpoint for empty values
-const checkEmptyValue = (value) => (value !== '' ? value : '-');
+// We are only checking for an empty string as it is the default value
+// returned by the graphql endpoint for empty values ( not null or undefined )
+const sanitiseEmptyValue = (value) => (value !== '' ? value : '-');
 
 const RunMetadata = ({ isSingleRun, runs = [] }) => {
   let initialState = {};
@@ -34,45 +34,45 @@ const RunMetadata = ({ isSingleRun, runs = [] }) => {
             className={classnames('details-metadata__run', {
               'details-metadata__run--single': isSingleRun,
             })}
-            key={run.title}
+            key={run.title + i} // note: this should revert back to use gitSha once the BE returns the actual value
           >
             <table className="details-metadata__table">
               <tbody>
                 {isSingleRun ? (
                   <tr>
                     <td className="details-metadata__title" colSpan="2">
-                      {checkEmptyValue(run.title)}
+                      {sanitiseEmptyValue(run.title)}
                     </td>
                   </tr>
                 ) : (
                   <tr>
                     {i === 0 ? <td></td> : null}
                     <td className="details-metadata__title">
-                      {checkEmptyValue(run.title)}
+                      {sanitiseEmptyValue(run.title)}
                     </td>
                   </tr>
                 )}
                 <tr>
                   {i === 0 ? <td>Created By</td> : null}
-                  <td>{checkEmptyValue(run.author)}</td>
+                  <td>{sanitiseEmptyValue(run.author)}</td>
                 </tr>
                 <tr>
                   {i === 0 ? <td>Creation Date</td> : null}
-                  <td>{`${humanReadableTime} (${checkEmptyValue(
+                  <td>{`${humanReadableTime} (${sanitiseEmptyValue(
                     run.timestamp
                   )})`}</td>
                 </tr>
                 <tr>
                   {i === 0 ? <td>Git SHA</td> : null}
-                  <td>{checkEmptyValue(run.gitSha)}</td>
+                  <td>{sanitiseEmptyValue(run.gitSha)}</td>
                 </tr>
                 <tr>
                   {i === 0 ? <td>Git Branch</td> : null}
-                  <td>{checkEmptyValue(run.gitBranch)}</td>
+                  <td>{sanitiseEmptyValue(run.gitBranch)}</td>
                 </tr>
                 <tr>
                   {i === 0 ? <td>Run Command</td> : null}
-                  <td>{checkEmptyValue(run.runCommand)}</td>
+                  <td>{sanitiseEmptyValue(run.runCommand)}</td>
                 </tr>
                 <tr>
                   {i === 0 ? <td>Notes</td> : null}
@@ -81,7 +81,7 @@ const RunMetadata = ({ isSingleRun, runs = [] }) => {
                       className="details-metadata__notes"
                       style={toggleNotes[i] ? { display: 'block' } : null}
                     >
-                      {checkEmptyValue(run.notes)}
+                      {sanitiseEmptyValue(run.notes)}
                     </p>
                     {run.notes.length > 100 ? (
                       <button

--- a/src/components/experiment-tracking/run-metadata/run-metadata.scss
+++ b/src/components/experiment-tracking/run-metadata/run-metadata.scss
@@ -32,6 +32,7 @@
   font-size: 1.4em;
   padding-bottom: 16px;
   vertical-align: top;
+  word-wrap: break-word; // For breaking potential long text,such as as git branch, title, etc
 
   &:first-of-type {
     width: 230px;

--- a/src/components/experiment-tracking/run-metadata/run-metadata.scss
+++ b/src/components/experiment-tracking/run-metadata/run-metadata.scss
@@ -32,7 +32,7 @@
   font-size: 1.4em;
   padding-bottom: 16px;
   vertical-align: top;
-  word-wrap: break-word; // For breaking potential long text,such as as git branch, title, etc
+  word-wrap: break-word; // For breaking potential long text, such as as git branch, title, etc
 
   &:first-of-type {
     width: 230px;

--- a/src/components/experiment-tracking/run-metadata/run-metadata.test.js
+++ b/src/components/experiment-tracking/run-metadata/run-metadata.test.js
@@ -6,6 +6,21 @@ import { configure, mount, shallow } from 'enzyme';
 
 configure({ adapter: new Adapter() });
 
+const emptyRun = [
+  {
+    id: '',
+    author: '',
+    bookmark: true,
+    timestamp: '2021-09-08T10:55:36.810Z',
+    gitSha: 'ad60192',
+    gitBranch: '',
+    runCommand: '',
+    notes:
+      'But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.',
+    title: '',
+  },
+];
+
 describe('RunMetadata', () => {
   it('renders without crashing', () => {
     const wrapper = shallow(
@@ -26,6 +41,11 @@ describe('RunMetadata', () => {
 
     expect(wrapper.find('.details-metadata').length).toBe(1);
     expect(wrapper.find('.details-metadata__run--single').length).toBe(1);
+  });
+
+  it('shows a "-" for empty values ', () => {
+    const wrapper = mount(<RunMetadata isSingleRun={true} runs={emptyRun} />);
+    expect(wrapper.find('.details-metadata__title').text()).toMatch('-');
   });
 
   it('handles show more/less button click event', () => {

--- a/src/components/experiment-tracking/run-metadata/run-metadata.test.js
+++ b/src/components/experiment-tracking/run-metadata/run-metadata.test.js
@@ -11,12 +11,11 @@ const emptyRun = [
     id: '',
     author: '',
     bookmark: true,
-    timestamp: '2021-09-08T10:55:36.810Z',
-    gitSha: 'ad60192',
+    timestamp: '',
+    gitSha: '',
     gitBranch: '',
     runCommand: '',
-    notes:
-      'But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful.',
+    notes: '',
     title: '',
   },
 ];


### PR DESCRIPTION
## Description

resolves KED-2973 & KED-2974.

This PR is raised to fix the issues with the alignment of rows between runs, as well as the text formatting in the run details table.

## Development notes

While looking into the issue of the row alignment of the table row for the metadata component, I realize that the empty fields within the metadata component are missing a '-' value as per the designs, hence I have added a small util function to check for the run metadata fields and apply the dash for empty values. This in turn will also fix the alignment issue.

I have modified the css to ensure that long text gets wrapped in the tracking dataset fields. 

The comparison view now looks like this:

![image](https://user-images.githubusercontent.com/27775658/143095546-d5e8b17d-f823-4195-845a-f42219758bd6.png)

## QA notes

This can be QAed by running this against your locally generated experiment data. 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
