### PR TITLE
Fix routing bugs for experiment tracking

### DIFF
--- a/package/kedro_viz/api/apps.py
+++ b/package/kedro_viz/api/apps.py
@@ -58,6 +58,7 @@ def create_api_app_from_project(
     app_etag = _create_etag()
 
     @app.get("/")
+    @app.get("/runsList")
     async def index():
         heap_app_id = kedro_telemetry.get_heap_app_id(project_path)
         heap_user_identity = kedro_telemetry.get_heap_identity()

--- a/src/apollo/config.js
+++ b/src/apollo/config.js
@@ -3,7 +3,7 @@ import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
 
 const link = createHttpLink({
   // our graphql endpoint, normally here: http://localhost:4141/graphql
-  uri: 'http://localhost:4141/graphql',
+  uri: '/graphql',
   fetch,
 });
 


### PR DESCRIPTION
## Description

Currently there are 2 bugs when launching `kedro viz` (i.e. not through the development server):

* The GraphQL queries from the client go to `http://localhost:4141/graphql`. This will be blocked by the browser's CORS policy if users visit the page through `127.0.0.1:4141`, which is the default address opened by `kedro viz` CLI command. Instead of hard coding the graphql endpoint to either `localhost` or `127.0.0.1`, I changed it to `/graphql` so it uses the current address.
* Currently there are actually 2 levels of routing: server-side routing and client-side routing. In development mode, only client-side routing was used. However, in production, users would encounter server-side routing first. That means previously refreshing the page on `/runsList` when running `kedro viz` will result in a 404. In this PR, I matched server routes to client routes, but we might need a more scalable solution, e.g. doing SPA routing convention with `#` for example.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

I have manually tested this.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
