### PR TITLE
Fix node IDs in test data after Kedro updates its __str__ logic for node

### DIFF
--- a/package/tests/example_pipelines.json
+++ b/package/tests/example_pipelines.json
@@ -1,45 +1,45 @@
 {
   "nodes": [
     {
-      "id": "56118ad8",
+      "id": "fdba147b",
       "name": "Process Data",
       "full_name": "process_data",
       "tags": ["split"],
-      "pipelines": ["__default__", "data_processing"],
-      "modular_pipelines": ["uk", "uk.data_processing"],
+      "pipelines": ["data_processing", "__default__"],
       "type": "task",
-      "parameters": { "train_test_split": 0.1 }
-    },
-    {
-      "id": "13399a82",
-      "name": "Raw Data",
-      "full_name": "uk.data_processing.raw_data",
-      "tags": ["split"],
-      "pipelines": ["__default__", "data_processing"],
       "modular_pipelines": ["uk", "uk.data_processing"],
-      "type": "data",
-      "layer": "raw",
-      "dataset_type": "kedro.extras.datasets.pandas.csv_dataset.CSVDataSet"
+      "parameters": { "train_test_split": 0.1 }
     },
     {
       "id": "c506f374",
       "name": "Params: Train Test Split",
       "full_name": "params:train_test_split",
       "tags": ["split"],
-      "pipelines": ["__default__", "data_processing"],
-      "modular_pipelines": [],
+      "pipelines": ["data_processing", "__default__"],
       "type": "parameters",
+      "modular_pipelines": [],
       "layer": null,
       "dataset_type": null
+    },
+    {
+      "id": "13399a82",
+      "name": "Raw Data",
+      "full_name": "uk.data_processing.raw_data",
+      "tags": ["split"],
+      "pipelines": ["data_processing", "__default__"],
+      "type": "data",
+      "modular_pipelines": ["uk", "uk.data_processing"],
+      "layer": "raw",
+      "dataset_type": "kedro.extras.datasets.pandas.csv_dataset.CSVDataSet"
     },
     {
       "id": "0ecea0de",
       "name": "Model Inputs",
       "full_name": "model_inputs",
-      "tags": ["train", "split"],
-      "pipelines": ["__default__", "data_science", "data_processing"],
-      "modular_pipelines": [],
+      "tags": ["split", "train"],
+      "pipelines": ["data_processing", "__default__", "data_science"],
       "type": "data",
+      "modular_pipelines": [],
       "layer": "model_inputs",
       "dataset_type": "kedro.extras.datasets.pandas.csv_dataset.CSVDataSet"
     },
@@ -49,8 +49,8 @@
       "full_name": "train_model",
       "tags": ["train"],
       "pipelines": ["__default__", "data_science"],
-      "modular_pipelines": ["uk", "uk.data_science"],
       "type": "task",
+      "modular_pipelines": ["uk", "uk.data_science"],
       "parameters": { "train_test_split": 0.1, "num_epochs": 1000 }
     },
     {
@@ -59,8 +59,8 @@
       "full_name": "parameters",
       "tags": ["train"],
       "pipelines": ["__default__", "data_science"],
-      "modular_pipelines": [],
       "type": "parameters",
+      "modular_pipelines": [],
       "layer": null,
       "dataset_type": null
     },
@@ -70,8 +70,8 @@
       "full_name": "uk.data_science.model",
       "tags": ["train"],
       "pipelines": ["__default__", "data_science"],
-      "modular_pipelines": ["uk", "uk.data_science"],
       "type": "data",
+      "modular_pipelines": ["uk", "uk.data_science"],
       "layer": null,
       "dataset_type": "kedro.io.memory_data_set.MemoryDataSet"
     },
@@ -80,7 +80,18 @@
       "name": "Data Processing",
       "full_name": "uk.data_processing",
       "tags": [],
-      "pipelines": ["__default__", "data_processing"],
+      "pipelines": ["data_processing", "__default__"],
+      "type": "modularPipeline",
+      "modular_pipelines": null,
+      "layer": null,
+      "dataset_type": null
+    },
+    {
+      "id": "uk",
+      "name": "Uk",
+      "full_name": "uk",
+      "tags": [],
+      "pipelines": ["data_processing", "__default__", "data_science"],
       "type": "modularPipeline",
       "modular_pipelines": null,
       "layer": null,
@@ -96,42 +107,31 @@
       "modular_pipelines": null,
       "layer": null,
       "dataset_type": null
-    },
-    {
-      "id": "uk",
-      "name": "Uk",
-      "full_name": "uk",
-      "tags": [],
-      "pipelines": ["__default__", "data_processing", "data_science"],
-      "type": "modularPipeline",
-      "modular_pipelines": null,
-      "layer": null,
-      "dataset_type": null
     }
   ],
   "edges": [
     { "source": "f1f1425b", "target": "7b140b3f" },
-    { "source": "0ecea0de", "target": "7b140b3f" },
-    { "source": "56118ad8", "target": "0ecea0de" },
-    { "source": "c506f374", "target": "56118ad8" },
-    { "source": "13399a82", "target": "56118ad8" },
-    { "source": "7b140b3f", "target": "d5a8b994" },
-    { "source": "13399a82", "target": "uk.data_processing" },
-    { "source": "uk.data_processing", "target": "0ecea0de" },
-    { "source": "c506f374", "target": "uk.data_processing" },
-    { "source": "f1f1425b", "target": "uk" },
-    { "source": "13399a82", "target": "uk" },
-    { "source": "f1f1425b", "target": "uk.data_science" },
-    { "source": "c506f374", "target": "uk" },
-    { "source": "uk.data_science", "target": "d5a8b994" },
     { "source": "0ecea0de", "target": "uk.data_science" },
-    { "source": "uk", "target": "d5a8b994" }
+    { "source": "c506f374", "target": "uk" },
+    { "source": "7b140b3f", "target": "d5a8b994" },
+    { "source": "c506f374", "target": "uk.data_processing" },
+    { "source": "13399a82", "target": "fdba147b" },
+    { "source": "uk.data_science", "target": "d5a8b994" },
+    { "source": "f1f1425b", "target": "uk" },
+    { "source": "0ecea0de", "target": "7b140b3f" },
+    { "source": "uk", "target": "d5a8b994" },
+    { "source": "f1f1425b", "target": "uk.data_science" },
+    { "source": "fdba147b", "target": "0ecea0de" },
+    { "source": "uk.data_processing", "target": "0ecea0de" },
+    { "source": "c506f374", "target": "fdba147b" },
+    { "source": "13399a82", "target": "uk" },
+    { "source": "13399a82", "target": "uk.data_processing" }
   ],
+  "layers": ["raw", "model_inputs"],
   "tags": [
     { "id": "split", "name": "Split" },
     { "id": "train", "name": "Train" }
   ],
-  "layers": ["raw", "model_inputs"],
   "pipelines": [
     { "id": "__default__", "name": "Default" },
     { "id": "data_science", "name": "Data Science" },
@@ -139,46 +139,46 @@
   ],
   "modular_pipelines": {
     "__root__": {
-      "children": [
-        { "id": "0ecea0de", "type": "data" },
-        { "id": "f1f1425b", "type": "parameters" },
-        { "id": "c506f374", "type": "parameters" },
-        { "id": "uk", "type": "modularPipeline" }
-      ],
       "id": "__root__",
-      "inputs": [],
       "name": "Root",
-      "outputs": []
+      "inputs": [],
+      "outputs": [],
+      "children": [
+        { "id": "f1f1425b", "type": "parameters" },
+        { "id": "uk", "type": "modularPipeline" },
+        { "id": "c506f374", "type": "parameters" },
+        { "id": "0ecea0de", "type": "data" }
+      ]
+    },
+    "uk.data_processing": {
+      "id": "uk.data_processing",
+      "name": "Data Processing",
+      "inputs": ["13399a82", "c506f374"],
+      "outputs": ["0ecea0de"],
+      "children": [
+        { "id": "13399a82", "type": "data" },
+        { "id": "fdba147b", "type": "task" }
+      ]
     },
     "uk": {
+      "id": "uk",
+      "name": "Uk",
+      "inputs": ["13399a82", "c506f374", "f1f1425b"],
+      "outputs": ["d5a8b994"],
       "children": [
         { "id": "uk.data_science", "type": "modularPipeline" },
         { "id": "uk.data_processing", "type": "modularPipeline" }
-      ],
-      "id": "uk",
-      "inputs": ["c506f374", "f1f1425b", "13399a82"],
-      "name": "Uk",
-      "outputs": ["d5a8b994"]
-    },
-    "uk.data_processing": {
-      "children": [
-        { "id": "13399a82", "type": "data" },
-        { "id": "56118ad8", "type": "task" }
-      ],
-      "id": "uk.data_processing",
-      "inputs": ["c506f374", "13399a82"],
-      "name": "Data Processing",
-      "outputs": ["0ecea0de"]
+      ]
     },
     "uk.data_science": {
+      "id": "uk.data_science",
+      "name": "Data Science",
+      "inputs": ["0ecea0de", "f1f1425b"],
+      "outputs": ["d5a8b994"],
       "children": [
         { "id": "d5a8b994", "type": "data" },
         { "id": "7b140b3f", "type": "task" }
-      ],
-      "id": "uk.data_science",
-      "inputs": ["0ecea0de", "f1f1425b"],
-      "name": "Data Science",
-      "outputs": ["d5a8b994"]
+      ]
     }
   },
   "selected_pipeline": "__default__"

--- a/package/tests/test_api/test_apps.py
+++ b/package/tests/test_api/test_apps.py
@@ -71,11 +71,11 @@ def assert_example_data(response_data):
     """Assert graph response for the `example_pipelines` and `example_catalog` fixtures."""
     expected_edges = [
         {"source": "7b140b3f", "target": "d5a8b994"},
-        {"source": "56118ad8", "target": "0ecea0de"},
-        {"source": "13399a82", "target": "56118ad8"},
+        {"source": "fdba147b", "target": "0ecea0de"},
+        {"source": "13399a82", "target": "fdba147b"},
         {"source": "f1f1425b", "target": "7b140b3f"},
         {"source": "0ecea0de", "target": "7b140b3f"},
-        {"source": "c506f374", "target": "56118ad8"},
+        {"source": "c506f374", "target": "fdba147b"},
         {"source": "13399a82", "target": "uk.data_processing"},
         {"source": "uk.data_processing", "target": "0ecea0de"},
         {"source": "c506f374", "target": "uk.data_processing"},
@@ -93,7 +93,7 @@ def assert_example_data(response_data):
     # compare nodes
     expected_nodes = [
         {
-            "id": "56118ad8",
+            "id": "fdba147b",
             "name": "Process Data",
             "full_name": "process_data",
             "tags": ["split"],
@@ -230,7 +230,7 @@ def assert_example_data(response_data):
         "uk.data_processing": {
             "children": [
                 {"id": "13399a82", "type": "data"},
-                {"id": "56118ad8", "type": "task"},
+                {"id": "fdba147b", "type": "task"},
             ],
             "id": "uk.data_processing",
             "inputs": ["c506f374", "13399a82"],
@@ -270,9 +270,9 @@ def assert_example_transcoded_data(response_data):
     and `example_transcoded_catalog` fixtures."""
     expected_edges = [
         {"source": "f1f1425b", "target": "2302ea78"},
-        {"source": "dbad7c24", "target": "0ecea0de"},
-        {"source": "c506f374", "target": "dbad7c24"},
-        {"source": "7c58d8e6", "target": "dbad7c24"},
+        {"source": "20c83b96", "target": "0ecea0de"},
+        {"source": "c506f374", "target": "20c83b96"},
+        {"source": "7c58d8e6", "target": "20c83b96"},
         {"source": "2302ea78", "target": "1d06a0d7"},
         {"source": "0ecea0de", "target": "2302ea78"},
     ]
@@ -282,7 +282,7 @@ def assert_example_transcoded_data(response_data):
     # compare nodes
     expected_nodes = [
         {
-            "id": "dbad7c24",
+            "id": "20c83b96",
             "name": "Process Data",
             "full_name": "process_data",
             "tags": ["split"],
@@ -424,7 +424,6 @@ class TestMainEndpoint:
 
     def test_endpoint_main(self, client):
         response = client.get("/api/main")
-        assert response.status_code == 200
         assert_example_data(response.json())
 
     def test_endpoint_main_no_session_store(self, example_api_no_session_store):
@@ -462,7 +461,7 @@ class TestNodeMetadataEndpoint:
         assert response.status_code == 404
 
     def test_task_node_metadata(self, client):
-        response = client.get("/api/nodes/56118ad8")
+        response = client.get("/api/nodes/fdba147b")
         metadata = response.json()
         assert (
             metadata["code"].lstrip()
@@ -501,7 +500,7 @@ class TestNodeMetadataEndpoint:
 
     def test_no_metadata(self, client):
         with mock.patch.object(TaskNode, "has_metadata", return_value=False):
-            response = client.get("/api/nodes/56118ad8")
+            response = client.get("/api/nodes/fdba147b")
         assert response.json() == {}
 
 


### PR DESCRIPTION
## Description

* Latest Kedro's master update the __str__ logic for nodes. Related PR: https://github.com/quantumblacklabs/kedro/commit/4fa0e68fa7f4954535eff7518c39a2dc7a02ca87
* This changes the IDs calculation for Kedro Viz nodes. This PRs update those IDs in-line with latest Kedro changes.

## Development notes

<!-- What have you changed? Consider adding a screenshot or GIF. -->

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
