### PR TITLE
[KED-2988] Fix for plotly when escape button pressed

### DIFF
--- a/src/components/plotly-modal/index.js
+++ b/src/components/plotly-modal/index.js
@@ -19,39 +19,47 @@ const PlotlyModal = ({ metadata, onToggle, visible }) => {
     return null;
   }
   return (
-    <div className="pipeline-plotly-modal">
-      <div className="pipeline-plot-modal__top">
-        <button
-          className="pipeline-plot-modal__back"
-          onClick={onCollapsePlotClick}
-        >
-          <BackIcon className="pipeline-plot-modal__back-icon"></BackIcon>
-          <span className="pipeline-plot-modal__back-text">Back</span>
-        </button>
-        <div className="pipeline-plot-modal__header">
-          <NodeIcon className="pipeline-plot-modal__icon" icon={nodeTypeIcon} />
-          <span className="pipeline-plot-modal__title">
-            {metadata.node.name}
-          </span>
+    <>
+      {' '}
+      {metadata && (
+        <div className="pipeline-plotly-modal">
+          <div className="pipeline-plot-modal__top">
+            <button
+              className="pipeline-plot-modal__back"
+              onClick={onCollapsePlotClick}
+            >
+              <BackIcon className="pipeline-plot-modal__back-icon"></BackIcon>
+              <span className="pipeline-plot-modal__back-text">Back</span>
+            </button>
+            <div className="pipeline-plot-modal__header">
+              <NodeIcon
+                className="pipeline-plot-modal__icon"
+                icon={nodeTypeIcon}
+              />
+              <span className="pipeline-plot-modal__title">
+                {metadata.node.name}
+              </span>
+            </div>
+          </div>
+          <PlotlyChart
+            data={metadata.plot.data}
+            layout={metadata.plot.layout}
+            view="modal"
+          />
+          <div className="pipeline-plot-modal__bottom">
+            <button
+              className="pipeline-plot-modal__collapse-plot"
+              onClick={onCollapsePlotClick}
+            >
+              <CollapseIcon className="pipeline-plot-modal__collapse-plot-icon"></CollapseIcon>
+              <span className="pipeline-plot-modal__collapse-plot-text">
+                Collapse Plotly Visualization
+              </span>
+            </button>
+          </div>
         </div>
-      </div>
-      <PlotlyChart
-        data={metadata.plot.data}
-        layout={metadata.plot.layout}
-        view="modal"
-      />
-      <div className="pipeline-plot-modal__bottom">
-        <button
-          className="pipeline-plot-modal__collapse-plot"
-          onClick={onCollapsePlotClick}
-        >
-          <CollapseIcon className="pipeline-plot-modal__collapse-plot-icon"></CollapseIcon>
-          <span className="pipeline-plot-modal__collapse-plot-text">
-            Collapse Plotly Visualization
-          </span>
-        </button>
-      </div>
-    </div>
+      )}
+    </>
   );
 };
 

--- a/src/components/plotly-modal/plotly-modal.scss
+++ b/src/components/plotly-modal/plotly-modal.scss
@@ -21,7 +21,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 3;
+  z-index: 5;
   display: flex;
   flex-direction: column;
   align-content: center;


### PR DESCRIPTION
## Description

Jira Ticket - https://jira.quantumblack.com/browse/KED-2988

## Development notes

Besides fixing the bug, I have also raised z-index for plotly modal so it comes on top of the global toolbar. 

## QA notes

<!-- How has the expected behaviour changed? What testing strategies have you used? -->

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
